### PR TITLE
Planet(scope) dataset

### DIFF
--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -76,6 +76,7 @@ from .openbuildings import OpenBuildings
 from .oscd import OSCD
 from .patternnet import PatternNet
 from .potsdam import Potsdam2D
+from .planet import PlanetscopeAnalyticSR
 from .reforestree import ReforesTree
 from .resisc45 import RESISC45
 from .seco import SeasonalContrastS2
@@ -143,6 +144,7 @@ __all__ = (
     "Landsat9",
     "NAIP",
     "OpenBuildings",
+    "PlanetscopeAnalyticSR",
     "Sentinel",
     "Sentinel1",
     "Sentinel2",

--- a/torchgeo/datasets/planet.py
+++ b/torchgeo/datasets/planet.py
@@ -8,7 +8,6 @@ from .utils import percentile_normalization
 class PlanetscopeAnalyticSR(RasterDataset):
 
     filename_glob = "*AnalyticMS_SR*.tif"
-    # filename_regex = r"^.(?P<date>\d{8}_\d{6})_"
     # date_format = "%Y%m%d_%H%M%S"
     is_image = True
     separate_files = False

--- a/torchgeo/datasets/planet.py
+++ b/torchgeo/datasets/planet.py
@@ -1,0 +1,34 @@
+import os
+import matplotlib.pyplot as plt
+import torch
+from .geo import RasterDataset
+from .utils import percentile_normalization
+
+
+class PlanetscopeAnalyticSR(RasterDataset):
+
+    filename_glob = "*AnalyticMS_SR*.tif"
+    # filename_regex = r"^.(?P<date>\d{8}_\d{6})_"
+    # date_format = "%Y%m%d_%H%M%S"
+    is_image = True
+    separate_files = False
+    all_bands = ["B", "G", "R", "NIR"]
+    rgb_bands = ["R", "G", "B"]
+
+    def plot(self, sample):
+        # Find the correct band index order
+        rgb_indices = []
+        for band in self.rgb_bands:
+            rgb_indices.append(self.all_bands.index(band))
+
+            # Reorder and rescale the image
+            image = sample["image"][rgb_indices].permute(1, 2, 0)
+            image = torch.clamp(image / 10000, min=0, max=1).numpy()
+        #         image = np.rollaxis(sample["image"][:3].numpy(), 0, 3)
+        #         image = percentile_normalization(image, axis=(0, 1))
+
+        # Plot the image
+        fig, ax = plt.subplots()
+        ax.imshow(image)
+
+        return fig


### PR DESCRIPTION
I'd like to make a custom raster dataset for Planet's Planetscope near daily 3m imagery analytic product. The dataset I have consists of tif files with 4 band (B, G, R, NIR) surface reflectances clipped to a region of interest. 

For now the images load as expected without specifying a crs when the dataset is instantiated, but if I try specifying the crs to convert to readable lat, lon an error is thrown and I'm not sure what the issue is: 

```
dataset = PlanetscopeAnalyticSR(
    root="data/image_test/",
    crs=CRS.from_epsg(4326),
)

sampler = RandomGeoSampler(dataset, size=256, length=10)
dataloader = DataLoader(dataset, sampler=sampler, collate_fn=stack_samples)

for batch in dataloader:
    sample = unbind_samples(batch)[0]
    dataset.plot(sample)
    plt.axis("off")
    plt.show()
```


```

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[148], line 6
      3 sampler = RandomGeoSampler(dataset, size=256, length=10)
      4 dataloader = DataLoader(dataset, sampler=sampler, collate_fn=stack_samples)
----> 6 for batch in dataloader:
      7     sample = unbind_samples(batch)[0]
      8     dataset.plot(sample)

File ~/miniforge3/envs/planet/lib/python3.10/site-packages/torch/utils/data/dataloader.py:628, in _BaseDataLoaderIter.__next__(self)
    625 if self._sampler_iter is None:
    626     # TODO(https://github.com/pytorch/pytorch/issues/76750)
    627     self._reset()  # type: ignore[call-arg]
--> 628 data = self._next_data()
    629 self._num_yielded += 1
    630 if self._dataset_kind == _DatasetKind.Iterable and \
    631         self._IterableDataset_len_called is not None and \
    632         self._num_yielded > self._IterableDataset_len_called:

File ~/miniforge3/envs/planet/lib/python3.10/site-packages/torch/utils/data/dataloader.py:670, in _SingleProcessDataLoaderIter._next_data(self)
    669 def _next_data(self):
--> 670     index = self._next_index()  # may raise StopIteration
    671     data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
    672     if self._pin_memory:

File ~/miniforge3/envs/planet/lib/python3.10/site-packages/torch/utils/data/dataloader.py:618, in _BaseDataLoaderIter._next_index(self)
    617 def _next_index(self):
--> 618     return next(self._sampler_iter)

File ~/miniforge3/envs/planet/lib/python3.10/site-packages/torch/utils/data/sampler.py:254, in BatchSampler.__iter__(self)
    252 batch = [0] * self.batch_size
    253 idx_in_batch = 0
--> 254 for idx in self.sampler:
    255     batch[idx_in_batch] = idx
    256     idx_in_batch += 1

File ~/miniforge3/envs/planet/lib/python3.10/site-packages/torchgeo/samplers/single.py:140, in RandomGeoSampler.__iter__(self)
    133 """Return the index of a dataset.
    134 
    135 Returns:
    136     (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
    137 """
    138 for _ in range(len(self)):
    139     # Choose a random tile, weighted by area
--> 140     idx = torch.multinomial(self.areas, 1)
    141     hit = self.hits[idx]
    142     bounds = BoundingBox(*hit.bounds)

RuntimeError: cannot sample n_sample > prob_dist.size(-1) samples without replacement
```