### PR TITLE
Remove default std normalization value in base class

### DIFF
--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -30,7 +30,7 @@ class BaseDataModule(LightningDataModule):
     """
 
     mean = torch.tensor(0)
-    std = torch.tensor(255)
+    std = torch.tensor(1)
 
     def __init__(
         self,


### PR DESCRIPTION
While not technically a bug, I think this is quiet inconvenient, when building custom datamodules inheriting from torchgeo base classes. For my use case, I had trouble understanding why my data was all of the sudden squashed to a tiny range when I had properly normalized it beforehand.

I think the default value here should be 1, i.e nothing happens, and users have to otherwise overwrite it. At the moment it is a base class for RGB data, which is oddly specific, and I think it would be better to keep it more general, especially because it might not be clear to all users, that the normalization "secretly" happens in the on_after_batch_transfer hook.

Closes #1841