### PR TITLE
PyTorch Tutorial: download all split files

### DIFF
--- a/docs/tutorials/pytorch.ipynb
+++ b/docs/tutorials/pytorch.ipynb
@@ -173,9 +173,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_dataset = EuroSAT100(root, split='train')\n",
-    "val_dataset = EuroSAT100(root, split='val')\n",
-    "test_dataset = EuroSAT100(root, split='test')"
+    "train_dataset = EuroSAT100(root, split='train', download=True)\n",
+    "val_dataset = EuroSAT100(root, split='val', download=True)\n",
+    "test_dataset = EuroSAT100(root, split='test', download=True)"
    ]
   },
   {


### PR DESCRIPTION
Bug introduced in 0.7.1

TODO: figure out why CI didn't catch this

Fixes #2895