### PR TITLE
Add OpenEarthMap-SAR - DFC2025 baseline U-Net weights

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -175,14 +175,14 @@ NAIP
    :file: weights/naip.csv
 
 
-Sentinel-1
-----------
+Synthetic Aperture Radar (SAR)
+------------------------------
 
 .. csv-table::
    :widths: 45 10 10 10 10
    :header-rows: 1
    :align: center
-   :file: weights/sentinel1.csv
+   :file: weights/sar.csv
 
 
 Sentinel-2

--- a/docs/api/weights/sar.csv
+++ b/docs/api/weights/sar.csv
@@ -2,6 +2,9 @@ Weight,Channels,Source,Citation,License
 ResNet50_Weights.SENTINEL1_GRD_DECUR, 2,`link <https://github.com/zhu-xlab/DeCUR>`__,`link <https://arxiv.org/abs/2309.05300>`__,"Apache-2.0"
 ResNet50_Weights.SENTINEL1_GRD_MOCO, 2,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0"
 ResNet50_Weights.SENTINEL1_GRD_SOFTCON, 2,`link <https://github.com/zhu-xlab/softcon>`__,`link <https://arxiv.org/abs/2405.20462>`__,"CC-BY-4.0"
+Swin_V2_B_Weights.SENTINEL1_MI_SATLAS,2,`link <https://github.com/allenai/satlas>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY
+Swin_V2_B_Weights.SENTINEL1_SI_SATLAS,2,`link <https://github.com/allenai/satlas>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY
+Unet_Weights.UMBRA_GEC_OPENEARTHMAP_SAR, 1,`link <https://github.com/cliffbb/DFC2025-OEM-SAR-Baseline/>`__,`link <https://arxiv.org/abs/2501.10891>`__,"CC-BY-4.0"
 ViTSmall16_Weights.SENTINEL1_GRD_MAE,2,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0"
 ViTSmall16_Weights.SENTINEL1_GRD_FGMAE,2,`link <https://github.com/zhu-xlab/FGMAE>`__,`link <https://arxiv.org/abs/2310.18653>`__,"CC-BY-4.0"
 ViTBase16_Weights.SENTINEL1_GRD_MAE,2,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0"
@@ -12,5 +15,3 @@ ViTHuge14_Weights.SENTINEL1_GRD_MAE,2,`link <https://github.com/zhu-xlab/SSL4EO-
 ViTHuge14_Weights.SENTINEL1_GRD_FGMAE,2,`link <https://github.com/zhu-xlab/FGMAE>`__,`link <https://arxiv.org/abs/2310.18653>`__,"CC-BY-4.0"
 ViTSmall14_DINOv2_Weights.SENTINEL1_GRD_SOFTCON, 2,`link <https://github.com/zhu-xlab/softcon>`__,`link <https://arxiv.org/abs/2405.20462>`__,"CC-BY-4.0"
 ViTBase14_DINOv2_Weights.SENTINEL1_GRD_SOFTCON, 2,`link <https://github.com/zhu-xlab/softcon>`__,`link <https://arxiv.org/abs/2405.20462>`__,"CC-BY-4.0"
-Swin_V2_B_Weights.SENTINEL1_MI_SATLAS,2,`link <https://github.com/allenai/satlas>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY
-Swin_V2_B_Weights.SENTINEL1_SI_SATLAS,2,`link <https://github.com/allenai/satlas>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY

--- a/tests/models/test_unet.py
+++ b/tests/models/test_unet.py
@@ -45,6 +45,10 @@ class TestUnet:
     ) -> None:
         unet(weights=mocked_weights, classes=20)
 
+    def test_unet_extra_model_kwargs(self, mocked_weights: WeightsEnum) -> None:
+        mocked_weights.meta['model_kwargs'] = {'encoder_weights': None}
+        unet(weights=mocked_weights)
+
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
             assert len(weights.meta['bands']) == weights.meta['in_chans']

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -39,8 +39,8 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
     .. versionadded:: 0.8
     """
 
-    SENTINEL1_OPENEARTHMAP_SAR = Weights(
-        url='https://hf.co/torchgeo/sentinel1_unet_effb4_openearthmap_sar/resolve/35837c7be033d485f294ca8878cab265fa5f51ca/sentinel1_unet_effb4_openearthmap_sar-c4871e29.pth',
+    UMBRA_GEC_OPENEARTHMAP_SAR = Weights(
+        url='https://hf.co/torchgeo/umbra_gec_unet_effb4_openearthmap_sar/resolve/738e0216fa5d41d14f535cc28430052683704142/umbra_gec_unet_effb4_openearthmap_sar-f21df2ee.pth',
         transforms=K.AugmentationSequential(
             K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)), data_keys=None
         ),
@@ -61,9 +61,20 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
                 'agriculture land',
                 'building',
             ),
+            'colormap': (
+                '#000000',
+                '#800000',
+                '#00FF24',
+                '#949494',
+                '#FFFFFF',
+                '#226126',
+                '#0045FF',
+                '#4BB549',
+                '#DE1F07',
+            ),
             'publication': 'https://arxiv.org/abs/2501.10891',
             'repo': 'https://github.com/cliffbb/DFC2025-OEM-SAR-Baseline/tree/master',
-            'bands': ['VV'],
+            'bands': ['B1'],
             'model_kwargs': dict(decoder_attention_type='scse'),
             'license': 'CC-BY-4.0',
         },

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -39,6 +39,35 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
     .. versionadded:: 0.8
     """
 
+    SENTINEL1_OPENEARTHMAP_SAR = Weights(
+        url='https://hf.co/torchgeo/sentinel1_unet_effb4_openearthmap_sar/resolve/35837c7be033d485f294ca8878cab265fa5f51ca/sentinel1_unet_effb4_openearthmap_sar-c4871e29.pth',
+        transforms=K.AugmentationSequential(
+            K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)), data_keys=None
+        ),
+        meta={
+            'dataset': 'OpenEarthMap-SAR',
+            'in_chans': 1,
+            'num_classes': 9,
+            'model': 'U-Net',
+            'encoder': 'efficientnet-b4',
+            'classes': (
+                'background',
+                'bareland',
+                'rangeland',
+                'developed space',
+                'road',
+                'tree',
+                'water',
+                'agriculture land',
+                'building',
+            ),
+            'publication': 'https://arxiv.org/abs/2501.10891',
+            'repo': 'https://github.com/cliffbb/DFC2025-OEM-SAR-Baseline/tree/master',
+            'bands': ['VV'],
+            'model_kwargs': dict(decoder_attention_type='scse'),
+            'license': 'CC-BY-4.0',
+        },
+    )
     SENTINEL2_2CLASS_FTW = Weights(
         url='https://huggingface.co/torchgeo/ftw/resolve/d2fdab6ea9d9cd38b491292cc9a5c8642533cef5/commercial/2-class/sentinel2_unet_effb3-9c04b7c6.pth',
         transforms=_ftw_transforms,
@@ -168,6 +197,8 @@ def unet(
         kwargs['in_channels'] = weights.meta['in_chans']
         kwargs['encoder_name'] = weights.meta['encoder']
         kwargs['classes'] = weights.meta['num_classes'] if classes is None else classes
+        if 'model_kwargs' in weights.meta:
+            kwargs.update(weights.meta['model_kwargs'])
     else:
         kwargs['classes'] = 1 if classes is None else classes
 

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -73,7 +73,7 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
                 '#DE1F07',
             ),
             'publication': 'https://arxiv.org/abs/2501.10891',
-            'repo': 'https://github.com/cliffbb/DFC2025-OEM-SAR-Baseline/tree/master',
+            'repo': 'https://github.com/cliffbb/DFC2025-OEM-SAR-Baseline',
             'bands': ['B1'],
             'model_kwargs': dict(decoder_attention_type='scse'),
             'license': 'CC-BY-4.0',


### PR DESCRIPTION
Adds the DFC2025 Track 1 Baseline U-Net weights trained by @cliffbb in the [baseline repo](https://github.com/cliffbb/DFC2025-OEM-SAR-Baseline/). The model is a land cover land-use semantic segmentation model trained on the [OpenEarthMap-SAR dataset](https://zenodo.org/records/14622048) which contains high-resolution 1-channel uint8 SAR images from [Umbra Space
](https://registry.opendata.aws/umbra-open-data/) particularly the [Geo-Ellipsoid Corrected (GEC)](https://help.umbra.space/product-guide/umbra-products/umbra-product-specifications/geo-ellipsoid-corrected-gec-geotiff) geotiffs.

The model has an IoU of 0.41 on the private test set leaderboard
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/fc157599-ef9c-4dcf-8f2d-69c4fdbc4b80" />


Before @calebrob6 asks, I've checked that it runs and it's decent but seems to get confused by the noisiness in the SAR imagery. Below is a minimum working example:

```python
import random
import glob

import torch
import torchvision.transforms.v2.functional as F
import rasterio
import matplotlib.pyplot as plt
from matplotlib.colors import to_rgb, ListedColormap
from torchgeo.models import Unet_Weights, unet

h = w = 1024
images = sorted(glob.glob("/data/train/sar_images/*.tif"))
labels = sorted(glob.glob("/data/train/labels/*.tif"))

device = torch.device("cuda")
dtype = torch.float32
weights = Unet_Weights.UMBRA_GEC_OPENEARTHMAP_SAR
classes = weights.meta["classes"]
colormap = ListedColormap([to_rgb(hex) for hex in weights.meta["colormap"]])

transforms = weights.transforms
model = unet(weights)
model.eval()
transforms.eval()
model = model.to(device).to(dtype)
transforms = transforms.to(device).to(dtype)

idx = random.randint(0, len(images) - 1)
path = images[idx]
label = labels[idx]
with rasterio.open(path) as src:
    image = torch.from_numpy(src.read())
    image = F.center_crop(image, (h, w))
    x = image.clone().unsqueeze(dim=0).to(device).to(dtype)
    image = image.repeat(3, 1, 1)

with rasterio.open(label) as src:
    mask = torch.from_numpy(src.read())
    mask = F.center_crop(mask, (h, w))
    mask = mask.squeeze(dim=0).numpy()

x = transforms(dict(image=x))["image"]
preds = model(x).cpu().squeeze().argmax(dim=0)

fig, axs = plt.subplots(1, 3, figsize=(12, 5))
axs[0].imshow(image.permute(1, 2, 0).numpy())
axs[0].axis('off')
axs[1].imshow(mask, vmin=0, vmax=len(classes), cmap=colormap, interpolation='none')
axs[1].axis('off')
axs[2].imshow(preds, vmin=0, vmax=len(classes), cmap=colormap, interpolation='none')
axs[0].set_title('Image')
axs[1].set_title('Mask')
axs[2].set_title('Predictions')
```

<img width="1189" height="422" alt="image" src="https://github.com/user-attachments/assets/0b7af84b-c899-4931-ab8b-3d71605e27eb" />
<img width="1189" height="422" alt="image" src="https://github.com/user-attachments/assets/071a6276-a315-466f-a627-a7239a60a8b9" />
<img width="1189" height="422" alt="image" src="https://github.com/user-attachments/assets/76de8a7e-e0f5-420b-84e1-3d85390f055d" />
<img width="1189" height="422" alt="image" src="https://github.com/user-attachments/assets/fc245c99-13af-4eb1-8001-f8ca4586d293" />
