### PR TITLE
RasterDataset: rasterio -> (rio)xarray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,8 @@ dependencies = [
     # typing-extensions 4.5+ required for typing_extensions.deprecated
     # can be removed once Python 3.13 is minimum supported version
     "typing-extensions>=4.5",
-    # xarray 0.17+ required by rioxarray
-    "xarray>=0.17",
+    # xarray 0.18+ required for xarray.open_dataset(engine='rasterio')
+    "xarray>=0.18",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,8 @@ dependencies = [
     # typing-extensions 4.5+ required for typing_extensions.deprecated
     # can be removed once Python 3.13 is minimum supported version
     "typing-extensions>=4.5",
-    # xarray 0.18+ required for xarray.open_dataset(engine='rasterio')
-    "xarray>=0.18",
+    # xarray 2022.3+ required by rioxarray
+    "xarray>=2022.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ dependencies = [
     # rasterio 1.4.0-1.4.2 lack support for merging WarpedVRT objects
     # https://github.com/rasterio/rasterio/issues/3196
     "rasterio>=1.3.3,!=1.4.0,!=1.4.1,!=1.4.2",
+    # rioxarray 0.11.2+ required for wheels
+    "rioxarray>=0.11.2",
     # segmentation-models-pytorch 0.5+ required for new UnetDecoder API
     "segmentation-models-pytorch>=0.5",
     # shapely 2+ required for shapely.Geometry
@@ -80,6 +82,8 @@ dependencies = [
     # typing-extensions 4.5+ required for typing_extensions.deprecated
     # can be removed once Python 3.13 is minimum supported version
     "typing-extensions>=4.5",
+    # xarray 0.17+ required by rioxarray
+    "xarray>=0.17",
 ]
 dynamic = ["version"]
 
@@ -103,8 +107,6 @@ datasets = [
     "scipy>=1.9.2",
     # webdataset 0.2.4+ required for PyTorch tuple seed support
     "webdataset>=0.2.4",
-    # xarray 0.12.3+ required for pandas 1.3.3 support
-    "xarray>=0.12.3",
 ]
 docs = [
     # ipywidgets 7+ required by nbsphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,9 @@ dependencies = [
     # pyproj 3.4+ required for Python 3.11 wheels
     "pyproj>=3.4",
     # rasterio 1.3.3+ required for Python 3.11 wheels
-    # rasterio 1.4.0-1.4.2 lack support for merging WarpedVRT objects
-    # https://github.com/rasterio/rasterio/issues/3196
-    "rasterio>=1.3.3,!=1.4.0,!=1.4.1,!=1.4.2",
-    # rioxarray 0.11.2+ required for wheels
-    "rioxarray>=0.11.2",
+    "rasterio>=1.3.3",
+    # rioxarray 0.15.2+ required for RasterioBackend.open_dataset(decode_coords='all')
+    "rioxarray>=0.15.2",
     # segmentation-models-pytorch 0.5+ required for new UnetDecoder API
     "segmentation-models-pytorch>=0.5",
     # shapely 2+ required for shapely.Geometry

--- a/requirements/datasets.txt
+++ b/requirements/datasets.txt
@@ -8,4 +8,3 @@ pycocotools==2.0.10
 scikit-image==0.25.2
 scipy==1.15.2
 webdataset==0.2.111
-xarray==2025.1.2

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -11,6 +11,7 @@ pandas==1.5.0
 pillow==9.2.0
 pyproj==3.4.0
 rasterio==1.3.11
+rioxarray==0.11.2
 segmentation-models-pytorch==0.5.0
 shapely==2.0.0
 timm==1.0.3
@@ -18,6 +19,7 @@ torch==2.0.0
 torchmetrics==1.2.0
 torchvision==0.15.1
 typing-extensions==4.5.0
+xarray==0.17.0
 
 # datasets
 h5py==3.8.0
@@ -29,7 +31,6 @@ pyarrow==15.0.0  # Remove when we upgrade min version of pandas to `pandas[parqu
 scikit-image==0.20.0
 scipy==1.9.2
 webdataset==0.2.4
-xarray==0.12.3
 
 # models
 microsoft-aurora==1.6.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -11,7 +11,7 @@ pandas==1.5.0
 pillow==9.2.0
 pyproj==3.4.0
 rasterio==1.3.11
-rioxarray==0.11.2
+rioxarray==0.15.2
 segmentation-models-pytorch==0.5.0
 shapely==2.0.0
 timm==1.0.3

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -19,7 +19,7 @@ torch==2.0.0
 torchmetrics==1.2.0
 torchvision==0.15.1
 typing-extensions==4.5.0
-xarray==0.18.0
+xarray==2022.3.0
 
 # datasets
 h5py==3.8.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -19,7 +19,7 @@ torch==2.0.0
 torchmetrics==1.2.0
 torchvision==0.15.1
 typing-extensions==4.5.0
-xarray==0.17.0
+xarray==0.18.0
 
 # datasets
 h5py==3.8.0

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -11,6 +11,7 @@ pandas==2.3.2
 pillow==11.3.0
 pyproj==3.7.1
 rasterio==1.4.3
+rioxarray==0.19.0
 segmentation-models-pytorch==0.5.0
 shapely==2.0.7
 timm==1.0.19
@@ -18,3 +19,4 @@ torch==2.8.0
 torchmetrics==1.8.1
 torchvision==0.23.0
 typing-extensions==4.15.0
+xarray==2025.1.2

--- a/tests/datasets/test_dl4gam.py
+++ b/tests/datasets/test_dl4gam.py
@@ -13,9 +13,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import DatasetNotFoundError, DL4GAMAlps, RGBBandsMissingError
 
-pytest.importorskip('xarray', minversion='0.12.3')
-pytest.importorskip('netCDF4', minversion='1.5.8')
-
 
 class TestDL4GAMAlps:
     @pytest.fixture(

--- a/tests/datasets/test_dl4gam.py
+++ b/tests/datasets/test_dl4gam.py
@@ -13,6 +13,8 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import DatasetNotFoundError, DL4GAMAlps, RGBBandsMissingError
 
+pytest.importorskip('netCDF4', minversion='1.5.8')
+
 
 class TestDL4GAMAlps:
     @pytest.fixture(

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -16,7 +16,6 @@ import torch.nn as nn
 from _pytest.fixtures import SubRequest
 from geopandas import GeoDataFrame
 from pyproj import CRS
-from rasterio.enums import Resampling
 from torch.utils.data import ConcatDataset
 
 from torchgeo.datasets import (
@@ -432,22 +431,6 @@ class TestRasterDataset:
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
         assert x['image'].dtype == torch.float32
-
-    @pytest.mark.parametrize('dtype', [torch.float, torch.double])
-    def test_resampling_float_dtype(self, dtype: torch.dtype) -> None:
-        paths = os.path.join('tests', 'data', 'raster', 'uint16')
-        ds = CustomRasterDataset(dtype, paths)
-        x = ds[ds.bounds]
-        assert x['image'].dtype == dtype
-        assert ds.resampling == Resampling.bilinear
-
-    @pytest.mark.parametrize('dtype', [torch.long, torch.bool])
-    def test_resampling_int_dtype(self, dtype: torch.dtype) -> None:
-        paths = os.path.join('tests', 'data', 'raster', 'uint16')
-        ds = CustomRasterDataset(dtype, paths)
-        x = ds[ds.bounds]
-        assert x['image'].dtype == dtype
-        assert ds.resampling == Resampling.nearest
 
     def test_invalid_query(self, sentinel: Sentinel2) -> None:
         with pytest.raises(

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 from _pytest.fixtures import SubRequest
 from geopandas import GeoDataFrame
 from pyproj import CRS
+from rasterio.enums import Resampling
 from torch.utils.data import ConcatDataset
 
 from torchgeo.datasets import (
@@ -431,6 +432,22 @@ class TestRasterDataset:
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
         assert x['image'].dtype == torch.float32
+
+    @pytest.mark.parametrize('dtype', [torch.float, torch.double])
+    def test_resampling_float_dtype(self, dtype: torch.dtype) -> None:
+        paths = os.path.join('tests', 'data', 'raster', 'uint16')
+        ds = CustomRasterDataset(dtype, paths)
+        x = ds[ds.bounds]
+        assert x['image'].dtype == dtype
+        assert ds.resampling == Resampling.bilinear
+
+    @pytest.mark.parametrize('dtype', [torch.long, torch.bool])
+    def test_resampling_int_dtype(self, dtype: torch.dtype) -> None:
+        paths = os.path.join('tests', 'data', 'raster', 'uint16')
+        ds = CustomRasterDataset(dtype, paths)
+        x = ds[ds.bounds]
+        assert x['image'].dtype == dtype
+        assert ds.resampling == Resampling.nearest
 
     def test_invalid_query(self, sentinel: Sentinel2) -> None:
         with pytest.raises(

--- a/torchgeo/datasets/dl4gam.py
+++ b/torchgeo/datasets/dl4gam.py
@@ -76,6 +76,13 @@ class DL4GAMAlps(NonGeoDataset):
 
     * https://doi.org/10.22541/essoar.173557607.70204641/v1
 
+    .. note::
+
+        This dataset requires the following additional library to be installed:
+
+        * `netcdf4 <https://pypi.org/project/netCDF4/>`_
+          or `h5netcdf <https://pypi.org/project/h5netcdf/>`_
+
     .. versionadded:: 0.7
     """
 

--- a/torchgeo/datasets/dl4gam.py
+++ b/torchgeo/datasets/dl4gam.py
@@ -11,18 +11,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import torch
+import xarray as xr
 from matplotlib.figure import Figure
 from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    Path,
-    download_and_extract_archive,
-    download_url,
-    extract_archive,
-    lazy_import,
-)
+from .utils import Path, download_and_extract_archive, download_url, extract_archive
 
 
 class DL4GAMAlps(NonGeoDataset):
@@ -80,14 +75,6 @@ class DL4GAMAlps(NonGeoDataset):
     If you use this dataset in your research, please cite the following paper:
 
     * https://doi.org/10.22541/essoar.173557607.70204641/v1
-
-    .. note::
-
-        This dataset requires the following additional libraries to be installed:
-
-        * `xarray <https://pypi.org/project/xarray/>`_
-        * `netcdf4 <https://pypi.org/project/netCDF4/>`_
-          or `h5netcdf <https://pypi.org/project/h5netcdf/>`_
 
     .. versionadded:: 0.7
     """
@@ -171,10 +158,7 @@ class DL4GAMAlps(NonGeoDataset):
         Raises:
             AssertionError: if any parameters are invalid.
             DatasetNotFoundError: if dataset is not found and *download* is False.
-            DependencyNotFoundError: if xarray is not installed.
         """
-        lazy_import('xarray')
-
         self.root = pathlib.Path(root)
         self.split = split
         self.cv_iter = cv_iter
@@ -240,7 +224,6 @@ class DL4GAMAlps(NonGeoDataset):
                 * the cloud and shadow mask
                 * the additional features (DEM, derived features, etc.) if required
         """
-        xr = lazy_import('xarray')
         nc = xr.open_dataset(
             self.fp_patches[index], decode_coords='all', mask_and_scale=True
         )

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -441,7 +441,6 @@ class RasterDataset(GeoDataset):
                             res = (abs(_res[0]), abs(_res[1]))
                 except (OSError, ValueError):
                     # Skip files that xarray is unable to read
-                    raise
                     continue
                 else:
                     filepaths.append(filepath)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -440,15 +440,15 @@ class RasterDataset(GeoDataset):
             if match is not None:
                 try:
                     with xr.open_dataset(filepath, decode_coords='all') as src:
-                        crs = crs or src.rio.crs or CRS.from_epsg(4326)
+                        crs = crs or src.rio.crs # or CRS.from_epsg(4326)
 
-                        if src.rio.crs is None:
-                            warnings.warn(
-                                f"Unable to decode coordinates of '{filepath}', "
-                                f'defaulting to {crs}. Set `crs` if this is incorrect.',
-                                UserWarning,
-                            )
-                            src = src.rio.write_crs(crs)
+                        # if src.rio.crs is None:
+                        #     warnings.warn(
+                        #         f"Unable to decode coordinates of '{filepath}', "
+                        #         f'defaulting to {crs}. Set `crs` if this is incorrect.',
+                        #         UserWarning,
+                        #     )
+                        #     src = src.rio.write_crs(crs)
 
                         if src.rio.crs != crs:
                             src = src.rio.reproject(crs)
@@ -613,8 +613,8 @@ class RasterDataset(GeoDataset):
         """
         src = xr.open_dataset(filepath, decode_coords='all')
 
-        if src.rio.crs is None:
-            src = src.rio.write_crs(self.crs)
+        # if src.rio.crs is None:
+        #     src = src.rio.write_crs(self.crs)
 
         if src.rio.crs != self.crs:
             src = src.rio.reproject(self.crs, resampling=self.resampling)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -26,7 +26,6 @@ import torch
 import xarray as xr
 from geopandas import GeoDataFrame
 from pyproj import CRS
-from rasterio.enums import Resampling
 from torch import Tensor
 from torch.utils.data import Dataset
 from torchvision.datasets import ImageFolder
@@ -376,23 +375,6 @@ class RasterDataset(GeoDataset):
         else:
             return torch.long
 
-    @property
-    def resampling(self) -> Resampling:
-        """Resampling algorithm used when reading input files.
-
-        Defaults to bilinear for float dtypes and nearest for int dtypes.
-
-        Returns:
-            The resampling method to use.
-
-        .. versionadded:: 0.6
-        """
-        # Based on torch.is_floating_point
-        if self.dtype in [torch.float64, torch.float32, torch.float16, torch.bfloat16]:
-            return Resampling.bilinear
-        else:
-            return Resampling.nearest
-
     def __init__(
         self,
         paths: Path | Iterable[Path] = 'data',
@@ -585,7 +567,7 @@ class RasterDataset(GeoDataset):
         bounds = (x.start, y.start, x.stop, y.stop)
         res = (x.step, y.step)
         dataset = rioxarray.merge.merge_datasets(
-            datasets, bounds=bounds, res=res, method=self.resampling, crs=self.crs
+            datasets, bounds=bounds, res=res, crs=self.crs
         )
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
         tensor = array_to_tensor(dataset.band_data.values)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -466,7 +466,7 @@ class RasterDataset(GeoDataset):
             if self.bands:
                 if self.all_bands:
                     self.band_indexes = [
-                        self.all_bands.index(i) + 1 for i in self.bands
+                        self.all_bands.index(i) for i in self.bands
                     ]
                 else:
                     msg = (

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -441,6 +441,7 @@ class RasterDataset(GeoDataset):
                             res = (abs(_res[0]), abs(_res[1]))
                 except (OSError, ValueError):
                     # Skip files that xarray is unable to read
+                    raise
                     continue
                 else:
                     filepaths.append(filepath)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -596,7 +596,7 @@ class RasterDataset(GeoDataset):
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
         tensor = array_to_tensor(array)
 
-        return tensor.squeeze(0)
+        return tensor
 
     @functools.lru_cache(maxsize=128)
     def _cached_load_warp_file(self, filepath: Path) -> xr.Dataset:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -438,6 +438,7 @@ class RasterDataset(GeoDataset):
                         geometries.append(shapely.box(*src.rio.bounds()))
                         if res is None:
                             res = src.rio.resolution()
+                            res = (abs(res[0]), abs(res[1]))
                 except (OSError, ValueError):
                     # Skip files that xarray is unable to read
                     continue
@@ -570,7 +571,7 @@ class RasterDataset(GeoDataset):
             datasets, bounds=bounds, res=res, crs=self.crs
         )
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
-        tensor = array_to_tensor(dataset.band_data.values)
+        tensor = array_to_tensor(dataset.band_data.values[band_indexes])
         return tensor
 
     @functools.lru_cache(maxsize=128)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -437,8 +437,8 @@ class RasterDataset(GeoDataset):
 
                         geometries.append(shapely.box(*src.rio.bounds()))
                         if res is None:
-                            res = src.rio.resolution()
-                            res = (abs(res[0]), abs(res[1]))
+                            _res = src.rio.resolution()
+                            res = (abs(_res[0]), abs(_res[1]))
                 except (OSError, ValueError):
                     # Skip files that xarray is unable to read
                     continue
@@ -572,7 +572,7 @@ class RasterDataset(GeoDataset):
         )
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
         tensor = array_to_tensor(dataset.band_data.values[band_indexes])
-        return tensor
+        return tensor.squeeze(0)
 
     @functools.lru_cache(maxsize=128)
     def _cached_load_warp_file(self, filepath: Path) -> xr.Dataset:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -465,9 +465,7 @@ class RasterDataset(GeoDataset):
             self.band_indexes = None
             if self.bands:
                 if self.all_bands:
-                    self.band_indexes = [
-                        self.all_bands.index(i) for i in self.bands
-                    ]
+                    self.band_indexes = [self.all_bands.index(i) for i in self.bands]
                 else:
                     msg = (
                         f'{self.__class__.__name__} is missing an `all_bands` '

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -583,15 +583,19 @@ class RasterDataset(GeoDataset):
         x, y, t = self._disambiguate_slice(query)
         bounds = (x.start, y.start, x.stop, y.stop)
         res = (x.step, y.step)
+
         dataset = rioxarray.merge.merge_datasets(
             datasets, bounds=bounds, res=res, nodata=0, crs=self.crs
         )
-        # Use array_to_tensor since merge may return uint16/uint32 arrays.
+
         if band_indexes:
             array = dataset.band_data[band_indexes].values
         else:
             array = dataset.band_data.values
+
+        # Use array_to_tensor since merge may return uint16/uint32 arrays.
         tensor = array_to_tensor(array)
+
         return tensor.squeeze(0)
 
     @functools.lru_cache(maxsize=128)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -584,7 +584,7 @@ class RasterDataset(GeoDataset):
         bounds = (x.start, y.start, x.stop, y.stop)
         res = (x.step, y.step)
         dataset = rioxarray.merge.merge_datasets(
-            datasets, bounds=bounds, res=res, crs=self.crs
+            datasets, bounds=bounds, res=res, nodata=0, crs=self.crs
         )
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
         tensor = array_to_tensor(dataset.band_data.values[band_indexes])

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -587,7 +587,11 @@ class RasterDataset(GeoDataset):
             datasets, bounds=bounds, res=res, nodata=0, crs=self.crs
         )
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
-        tensor = array_to_tensor(dataset.band_data.values[band_indexes])
+        if band_indexes:
+            array = dataset.band_data[band_indexes].values
+        else:
+            array = dataset.band_data.values
+        tensor = array_to_tensor(array)
         return tensor.squeeze(0)
 
     @functools.lru_cache(maxsize=128)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -440,7 +440,7 @@ class RasterDataset(GeoDataset):
             if match is not None:
                 try:
                     with xr.open_dataset(filepath, decode_coords='all') as src:
-                        crs = crs or src.rio.crs # or CRS.from_epsg(4326)
+                        crs = crs or src.rio.crs  # or CRS.from_epsg(4326)
 
                         # if src.rio.crs is None:
                         #     warnings.warn(


### PR DESCRIPTION
This PR converts the `RasterDataset` backend from rasterio to (rio)xarray.

### Motivation

(rio)xarray can load anything that rasterio can, plus NetCDF/HDF5/Zarr and many other file formats with a corresponding xarray backend. We need NetCDF support for ERA5/CMIP6/WeatherBench, and ESA is planning to switch to Zarr in the near future.

Xarray is also extendable. While xarray no longer supports HDF4 files (needed by MODIS), we could [add a new backend](https://docs.xarray.dev/en/stable/internals/how-to-add-new-backend.html) to add support for HDF4.

> [!NOTE]
> NetCDF/HDF5/Zarr files do not always follow standard [metadata conventions](https://cfconventions.org/) and may require additional massaging before they can be used with rioxarray. This PR does not yet do that. I would like to do this in follow-up PRs when adding datasets that actually require it. This will make testing much easier, and the base class can grow organically only as needed.

### Benchmarking

Because @calebrob6 will definitely want to see this 🙂 

| version | raw (random) | raw (grid) | preprocessed (random) | preprocessed (grid) |
| --- | ---: | ---: | ---: | ---: |
| v0.7.1 | 7.398 | 3.411 | 6.167 | 3.018 |
| main | broken | broken | 7.891 | 4.642 |
| #2945 | broken | broken | 37.934 | 34.377 |

Slower than I would like, but it's a start.

Closes #1490 
Closes #1486 
Closes #509