### PR TITLE
Remove PyTorch Lightning from Pretrained Weights tutorial

### DIFF
--- a/docs/tutorials/pretrained_weights.ipynb
+++ b/docs/tutorials/pretrained_weights.ipynb
@@ -71,7 +71,9 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
-    "from torchgeo.models import ResNet18_Weights, ResNet50_Weights"
+    "import timm\n",
+    "\n",
+    "from torchgeo.models import ResNet18_Weights, ResNet50_Weights, resnet18"
    ]
   },
   {
@@ -144,8 +146,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using Pretrained Weights for Training\n",
-    "\n",
+    "## Using Pretrained Weights for Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can load the pretrained weights `ResNet18_Weights.SENTINEL2_ALL_MOCO` into a ResNet-18 model like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = resnet18(all_weights)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, TorchGeo simply acts as a wrapper around [timm](https://github.com/huggingface/pytorch-image-models). If you don't want to use this wrapper, you can create a timm model directly and load the pretrained weights from TorchGeo as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "in_chans = all_weights.meta['in_chans']\n",
+    "model = timm.create_model('resnet18', in_chans=in_chans, num_classes=10)\n",
+    "model.load_state_dict(all_weights.get_state_dict(progress=True), strict=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To train our pretrained model on a dataset we will make use of Lightning's [Trainer](https://lightning.ai/docs/pytorch/stable/common/trainer.html). For a more elaborate explanation of how TorchGeo uses Lightning, check out [this next tutorial](https://torchgeo.readthedocs.io/en/stable/tutorials/trainers.html)."
    ]
   }

--- a/docs/tutorials/pretrained_weights.ipynb
+++ b/docs/tutorials/pretrained_weights.ipynb
@@ -119,11 +119,11 @@
    "outputs": [],
    "source": [
     "# ResNet18_Weights.SENTINEL2_ALL_MOCO\n",
-    "print(f\"Weight URL: {all_weights.url}\")\n",
+    "print(f'Weight URL: {all_weights.url}')\n",
     "\n",
-    "print(\"Weight metadata:\")\n",
+    "print('Weight metadata:')\n",
     "for key, value in all_weights.meta.items():\n",
-    "    print(f\" {key}: {value}\")"
+    "    print(f' {key}: {value}')"
    ]
   },
   {
@@ -133,11 +133,11 @@
    "outputs": [],
    "source": [
     "# ResNet50_Weights.SENTINEL2_RGB_MOCO\n",
-    "print(f\"Weight URL: {rgb_weights.url}\")\n",
+    "print(f'Weight URL: {rgb_weights.url}')\n",
     "\n",
-    "print(\"Weight metadata:\")\n",
+    "print('Weight metadata:')\n",
     "for key, value in rgb_weights.meta.items():\n",
-    "    print(f\" {key}: {value}\")"
+    "    print(f' {key}: {value}')"
    ]
   },
   {

--- a/docs/tutorials/pretrained_weights.ipynb
+++ b/docs/tutorials/pretrained_weights.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "_Written by: Nils Lehmann_\n",
     "\n",
-    "In this tutorial, we demonstrate some available pretrained weights in TorchGeo. The implementation follows torchvisions' recently introduced [Multi-Weight API](https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/). We will use the [EuroSAT](https://torchgeo.readthedocs.io/en/stable/api/datasets.html#eurosat) dataset throughout this tutorial. Specifically, a subset containing only 100 images.\n",
+    "In this tutorial, we demonstrate some available pretrained weights in TorchGeo. The implementation follows torchvisions' recently introduced [Multi-Weight API](https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/).\n",
     "\n",
     "It's recommended to run this notebook on Google Colab if you don't have your own GPU. Click the \"Open in Colab\" button above to get started."
    ]
@@ -58,7 +58,7 @@
    "source": [
     "## Imports\n",
     "\n",
-    "Next, we import TorchGeo and any other libraries we need."
+    "Next, we import TorchGeo."
    ]
   },
   {
@@ -71,81 +71,17 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
-    "import os\n",
-    "import tempfile\n",
-    "\n",
-    "import timm\n",
-    "import torch\n",
-    "from lightning.pytorch import Trainer\n",
-    "\n",
-    "from torchgeo.datamodules import EuroSAT100DataModule\n",
-    "from torchgeo.models import ResNet18_Weights\n",
-    "from torchgeo.trainers import ClassificationTask"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "njAH71F3rMOJ"
-   },
-   "source": [
-    "The following variables can be used to control training."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "TVG_Z9MKrMOJ",
-    "nbmake": {
-     "mock": {
-      "batch_size": 1,
-      "fast_dev_run": true,
-      "max_epochs": 1,
-      "num_workers": 0
-     }
-    }
-   },
-   "outputs": [],
-   "source": [
-    "batch_size = 10\n",
-    "num_workers = 2\n",
-    "max_epochs = 10\n",
-    "fast_dev_run = False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "QNnDoIf2rMOK"
-   },
-   "source": [
-    "## Datamodule\n",
-    "\n",
-    "We will utilize TorchGeo's [Lightning](https://lightning.ai/docs/pytorch/stable/) datamodules to organize the dataloader setup."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ia5ktOVerMOL"
-   },
-   "outputs": [],
-   "source": [
-    "root = os.path.join(tempfile.gettempdir(), 'eurosat100')\n",
-    "datamodule = EuroSAT100DataModule(\n",
-    "    root=root, batch_size=batch_size, num_workers=num_workers, download=True\n",
+    "from torchgeo.models import (\n",
+    "    ResNet18_Weights,\n",
+    "    ResNet50_Weights,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ksoszRjZrMOL"
-   },
+   "metadata": {},
    "source": [
-    "## Weights\n",
+    "## Pretrained Weights\n",
     "\n",
     "Pretrained weights for `torchgeo.models` are available and sorted by satellite or sensor type: sensor-agnostic, Landsat, NAIP, Sentinel-1, and Sentinel-2. Refer to the [model documentation](https://torchgeo.readthedocs.io/en/stable/api/models.html#pretrained-weights) for a complete list of weights. Choose from the provided pre-trained weights based on your specific use case.\n",
     "\n",
@@ -158,125 +94,62 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "wJOrRqBGrMOM"
+    "id": "RZ8MPYH1rMON",
+    "outputId": "fa683b8f-da21-4f26-ca3a-46163c9f12bf"
    },
    "outputs": [],
    "source": [
-    "weights = ResNet18_Weights.SENTINEL2_ALL_MOCO"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "EIpnXuXgrMOM"
-   },
-   "source": [
-    "This set of weights is a torchvision `WeightEnum` and holds information such as the download url link or additional meta data. TorchGeo takes care of the downloading and initialization of models with a desired set of weights. "
+    "all_weights = ResNet18_Weights.SENTINEL2_ALL_MOCO\n",
+    "\n",
+    "rgb_weights = ResNet50_Weights.SENTINEL2_RGB_MOCO"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`torchgeo.trainers` provides specialized task classes that simplify training workflows for common geospatial tasks. Depending on your objective, you can select the appropriate trainer class, such as `ClassificationTask` for classification, `SemanticSegmentationTask` for semantic segmentation, or other task-specific trainers. Check the [trainers documentation](https://torchgeo.readthedocs.io/en/stable/api/trainers.html) for more information.\n",
+    "## Weight Metadata\n",
     "\n",
-    "Given that EuroSAT is a classification dataset, we can use a `ClassificationTask` object that holds the model and optimizer as well as the training logic."
+    "This set of weights is a torchvision `WeightEnum` and holds information such as the download url link or additional meta data. TorchGeo takes care of the downloading and initialization of models with a desired set of weights.\n",
+    "\n",
+    "Let's inspect the metadata of the two pretrained weights we have just loaded:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "RZ8MPYH1rMON",
-    "outputId": "fa683b8f-da21-4f26-ca3a-46163c9f12bf"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "task = ClassificationTask(\n",
-    "    model='resnet18',\n",
-    "    loss='ce',\n",
-    "    weights=weights,\n",
-    "    in_channels=13,\n",
-    "    num_classes=10,\n",
-    "    lr=0.001,\n",
-    "    patience=5,\n",
-    ")"
+    "# ResNet18_Weights.SENTINEL2_ALL_MOCO\n",
+    "print(f\"Weight URL: {all_weights.url}\")\n",
+    "\n",
+    "print(\"Weight metadata:\")\n",
+    "for key, value in all_weights.meta.items():\n",
+    "    print(f\" {key}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ResNet50_Weights.SENTINEL2_RGB_MOCO\n",
+    "print(f\"Weight URL: {rgb_weights.url}\")\n",
+    "\n",
+    "print(\"Weight metadata:\")\n",
+    "for key, value in rgb_weights.meta.items():\n",
+    "    print(f\" {key}: {value}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "dWidC6vDrMON"
-   },
+   "metadata": {},
    "source": [
-    "If you do not want to utilize the `ClassificationTask` functionality for your experiments, you can also just create a [timm](https://github.com/huggingface/pytorch-image-models) model with pretrained weights from TorchGeo as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ZaZQ07jorMOO"
-   },
-   "outputs": [],
-   "source": [
-    "in_chans = weights.meta['in_chans']\n",
-    "model = timm.create_model('resnet18', in_chans=in_chans, num_classes=10)\n",
-    "model.load_state_dict(weights.get_state_dict(progress=True), strict=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "vgNswWKOrMOO"
-   },
-   "source": [
-    "## Training\n",
+    "## Using Pretrained Weights for Training\n",
     "\n",
-    "To train our pretrained model on the EuroSAT dataset we will make use of Lightning's [Trainer](https://lightning.ai/docs/pytorch/stable/common/trainer.html). For a more elaborate explanation of how TorchGeo uses Lightning, check out [this tutorial](https://torchgeo.readthedocs.io/en/stable/tutorials/trainers.html)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "0Sf-CBorrMOO"
-   },
-   "outputs": [],
-   "source": [
-    "accelerator = 'gpu' if torch.cuda.is_available() else 'cpu'\n",
-    "default_root_dir = os.path.join(tempfile.gettempdir(), 'experiments')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "veVvF-5LrMOP",
-    "outputId": "698e3e9e-8a53-4897-d40e-13b43470e29e"
-   },
-   "outputs": [],
-   "source": [
-    "trainer = Trainer(\n",
-    "    accelerator=accelerator,\n",
-    "    default_root_dir=default_root_dir,\n",
-    "    fast_dev_run=fast_dev_run,\n",
-    "    log_every_n_steps=1,\n",
-    "    min_epochs=1,\n",
-    "    max_epochs=max_epochs,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "9WQD4cuwrMOP",
-    "outputId": "590f75dd-064b-4bcc-b504-167bf2ad6cfb"
-   },
-   "outputs": [],
-   "source": [
-    "trainer.fit(model=task, datamodule=datamodule)"
+    "To train our pretrained model on a dataset we will make use of Lightning's [Trainer](https://lightning.ai/docs/pytorch/stable/common/trainer.html). For a more elaborate explanation of how TorchGeo uses Lightning, check out [this next tutorial](https://torchgeo.readthedocs.io/en/stable/tutorials/trainers.html)."
    ]
   }
  ],

--- a/docs/tutorials/pretrained_weights.ipynb
+++ b/docs/tutorials/pretrained_weights.ipynb
@@ -71,10 +71,7 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
-    "from torchgeo.models import (\n",
-    "    ResNet18_Weights,\n",
-    "    ResNet50_Weights,\n",
-    ")"
+    "from torchgeo.models import ResNet18_Weights, ResNet50_Weights"
    ]
   },
   {

--- a/docs/tutorials/trainers.ipynb
+++ b/docs/tutorials/trainers.ipynb
@@ -153,12 +153,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d46e930d",
+   "metadata": {},
+   "source": [
+    "`torchgeo.trainers` provides specialized task classes that simplify training workflows for common geospatial tasks. Depending on your objective, you can select the appropriate trainer class, such as `ClassificationTask` for classification, `SemanticSegmentationTask` for semantic segmentation, or other task-specific trainers. Check the [trainers documentation](https://torchgeo.readthedocs.io/en/stable/api/trainers.html) for more information.\n",
+    "\n",
+    "Given that EuroSAT is a classification dataset, we can use a `ClassificationTask` object that holds the model and optimizer as well as the training logic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "056b7b4c",
    "metadata": {
     "id": "056b7b4c"
    },
    "source": [
-    "Next, we create a `ClassificationTask` object that holds the model object, optimizer object, and training logic. We will use a ResNet-18 model that has been pre-trained on Sentinel-2 imagery."
+    "Here, we create a `ClassificationTask` object that holds the model object, optimizer object, and training logic. We will use a ResNet-18 model that has been pre-trained on Sentinel-2 imagery."
    ]
   },
   {


### PR DESCRIPTION
Fixes #2854 

this PR removes the use of PyTorch Lightning from the `pretrained_weights.ipynb` notebook to improve the tutorial's logical order

The changes consist of the following:

* The PyTorch Lightning dataloader and training module have been removed from `pretrained_weights.ipynb`
* Code to inspect the metadata of the pretrained weights has been added to the notebook
* Content regarding the Lightning Trainer has been moved to `trainer.ipynb`

No new tests are needed for this PR