### PR TITLE
Rename ResNet50 S1 weights in tutorial.

### DIFF
--- a/docs/tutorials/earthquake_detection.ipynb
+++ b/docs/tutorials/earthquake_detection.ipynb
@@ -250,8 +250,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_transform = ResNet50_Weights.SENTINEL1_ALL_MOCO.transforms\n",
-    "rn_model = resnet50(ResNet50_Weights.SENTINEL1_ALL_MOCO).to(DEVICE).eval()"
+    "model_transform = ResNet50_Weights.SENTINEL1_GRD_MOCO.transforms\n",
+    "rn_model = resnet50(ResNet50_Weights.SENTINEL1_GRD_MOCO).to(DEVICE).eval()"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes #2950 by renaming deprecated `SENTINEL1_ALL `to `ENTINEL1_GRD`.