### PR TITLE
Deps: fix rasterio minimum version

### DIFF
--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -10,7 +10,7 @@ numpy==1.23.2
 pandas==1.5.0
 pillow==9.2.0
 pyproj==3.4.0
-rasterio==1.3.11
+rasterio==1.3.3
 segmentation-models-pytorch==0.5.0
 shapely==2.0.0
 timm==1.0.3


### PR DESCRIPTION
Fixes a bug introduced in #2601 

We should be testing the minimum supported version. We need to either update the tested version or update the minimum supported version.