### PR TITLE
RtD: linkage requires optional model deps

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
 python:
   install:
     - requirements: requirements/required.txt
+    - requirements: requirements/models.txt
     - requirements: requirements/docs.txt
     - requirements: docs/requirements.txt
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,6 @@ build:
 python:
   install:
     - requirements: requirements/required.txt
-    - requirements: requirements/models.txt
     - requirements: requirements/docs.txt
     - requirements: docs/requirements.txt
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,6 @@ intersphinx_mapping = {
     'torch': ('https://docs.pytorch.org/docs/stable/', None),
     'torchmetrics': ('https://lightning.ai/docs/torchmetrics/stable/', None),
     'torchvision': ('https://docs.pytorch.org/vision/stable/', None),
-    'ultralytics': ('https://docs.ultralytics.com/', None),
 }
 
 # nbsphinx

--- a/torchgeo/models/yolo.py
+++ b/torchgeo/models/yolo.py
@@ -123,8 +123,8 @@ def yolo(weights: YOLO_Weights | None = None, *args: Any, **kwargs: Any) -> nn.M
 
     Args:
         weights: Pre-trained model weights to use.
-        *args: Additional arguments to pass to :class:`ultralytics.YOLO`
-        **kwargs: Additional keyword arguments to pass to :class:`ultralytics.YOLO`
+        *args: Additional arguments to pass to ``ultralytics.YOLO``
+        **kwargs: Additional keyword arguments to pass to ``ultralytics.YOLO``
 
     Returns:
         An ultralytics.YOLO model.


### PR DESCRIPTION
Something changed in an indirect dependency and now the RtD tests are failing with:
```
torchgeo/models/yolo.py:docstring of torchgeo.models.yolo.yolo:2: WARNING: py:class reference target not found: ultralytics.YOLO
```
I'm guessing one of our dependencies dropped a dependency on ultralytics and now it's no longer available in the environment.

This PR is a short-term fix. Long-term fixes include not linking to the ultralytics docs or removing the ultralytics dependency entirely.