### PR TITLE
Deps: prevent lightning 2.5.5 from being used in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
           - 'torch'
           - 'torchvision'
     ignore:
+      # lightning 2.5.5 contains known bugs related to checkpoint loading
+      # https://github.com/torchgeo/torchgeo/issues/2995
+      - dependency-name: 'lightning'
+        versions: '>=2.5.5'
       # sphinx 6 is incompatible with pytorch-sphinx-theme
       # https://github.com/pytorch/pytorch_sphinx_theme/issues/175
       - dependency-name: 'sphinx'

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -5,7 +5,7 @@ geopandas==1.0.1
 jsonargparse[signatures]==4.41.0
 kornia==0.8.1
 lightly==1.5.22
-lightning==2.5.5
+lightning==2.5.4
 matplotlib==3.10.1
 numpy==2.2.4
 pandas==2.3.2


### PR DESCRIPTION
Follow-up to #2996 

Although our normal CI tests don't fail with 2.5.5, the tutorial tests fail due to installation of conflicting versions.