### PR TITLE
BigEarthNet: only download required bands

### DIFF
--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -206,6 +206,14 @@ class TestBigEarthNetV2:
             root=tmp_path, bands=dataset.bands, split=dataset.split, download=True
         )
 
+    def test_multiple_band_instances(
+        self, dataset: BigEarthNetV2, tmp_path: Path
+    ) -> None:
+        bands = 's2' if dataset.bands == 's1' else 's1'
+        BigEarthNetV2(
+            root=tmp_path / bands, bands=bands, split=dataset.split, download=True
+        )
+
     def test_not_downloaded(self, tmp_path: Path) -> None:
         """Test error handling when data not present."""
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -862,31 +862,21 @@ class BigEarthNetV2(NonGeoDataset):
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
+        keys = ['s1', 's2'] if self.bands == 'all' else [self.bands]
+        keys += ['maps', 'metadata']
+        if self.bands != 'all':
+            to_remove = 's1' if self.bands == 's2' else 's2'
+            self.metadata_locs.pop(to_remove, None)
+        filenames = []
+        for k in keys:
+            entry = self.metadata_locs[k]['files']
+            filenames += [k for k, _ in entry.items()]
+
         exists = []
-        for key, metadata in self.metadata_locs.items():
-            exists.append(
-                os.path.exists(os.path.join(self.root, self.dir_file_names[key]))
-            )
+        for file in filenames:
+            exists.append(os.path.exists(os.path.join(self.root, file)))
 
-        if all(exists):
-            return
-
-        # check if compressed files already exist
-        exists = []
-        for key, metadata in self.metadata_locs.items():
-            if key == 'metadata':
-                exists.append(
-                    os.path.exists(os.path.join(self.root, self.dir_file_names[key]))
-                )
-            else:
-                for fname in metadata['files']:
-                    fpath = os.path.join(self.root, fname)
-                    exists.append(os.path.exists(fpath))
-
-        if all(exists):
-            return
-
-        if not self.download:
+        if not all(exists) and not self.download:
             raise DatasetNotFoundError(self)
 
         self._download()
@@ -914,14 +904,17 @@ class BigEarthNetV2(NonGeoDataset):
         for key, meta in self.metadata_locs.items():
             if key == 'metadata':
                 continue
-            parts = [os.path.join(self.root, f) for f in meta['files']]
+            parts = [os.path.join(self.root, f) for f in meta['files'].keys()]
             concat_path = os.path.join(self.root, self.dir_file_names[key] + '.tar.gz')
-            with open(concat_path, 'wb') as outfile:
-                for part in parts:
-                    with open(part, 'rb') as g:
-                        while chunk := g.read(chunk_size):
-                            outfile.write(chunk)
-            extract_archive(concat_path, self.root)
+            if not os.path.exists(concat_path):
+                with open(concat_path, 'wb') as outfile:
+                    for part in parts:
+                        with open(part, 'rb') as g:
+                            while chunk := g.read(chunk_size):
+                                outfile.write(chunk)
+            extract_path = concat_path.removesuffix('.tar.gz')
+            if not os.path.exists(extract_path):
+                extract_archive(concat_path, self.root)
 
     def plot(
         self, sample: Sample, show_titles: bool = True, suptitle: str | None = None

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -864,27 +864,27 @@ class BigEarthNetV2(NonGeoDataset):
         """Verify the integrity of the dataset."""
         keys: list[str] = ['s1', 's2'] if self.bands == 'all' else [self.bands]
         keys += ['maps', 'metadata']
-        if self.bands != 'all':
-            to_remove = 's1' if self.bands == 's2' else 's2'
-            self.metadata_locs.pop(to_remove, None)
-        filenames = []
-        for k in keys:
-            entry = self.metadata_locs[k]['files']
-            filenames += [k for k, _ in entry.items()]
-
-        exists = []
-        for file in filenames:
-            exists.append(os.path.exists(os.path.join(self.root, file)))
+        filenames = [
+            filename for key in keys for filename in self.metadata_locs[key]['files']
+        ]
+        exists = [
+            os.path.exists(os.path.join(self.root, filename)) for filename in filenames
+        ]
 
         if not all(exists) and not self.download:
             raise DatasetNotFoundError(self)
 
-        self._download()
-        self._extract()
+        self._download(keys)
+        self._extract(keys)
 
-    def _download(self) -> None:
-        """Download the required tarball parts using the URL template and sha256 sums."""
-        for meta in self.metadata_locs.values():
+    def _download(self, keys: list[str]) -> None:
+        """Download the required tarball parts using the URL template and sha256 sums.
+
+        Args:
+            keys: Metadata entries to download.
+        """
+        for key in keys:
+            meta = self.metadata_locs[key]
             for fname, sha256 in meta['files'].items():
                 target_path = os.path.join(self.root, fname)
                 if not os.path.exists(target_path):
@@ -895,15 +895,19 @@ class BigEarthNetV2(NonGeoDataset):
                         sha256=sha256 if self.checksum else None,
                     )
 
-    def _extract(self) -> None:
+    def _extract(self, keys: list[str]) -> None:
         """Extract the tarball parts.
 
         For each modality (s1, s2, maps), its parts are concatenated together and then extracted.
+
+        Args:
+            keys: Metadata entries to extract.
         """
         chunk_size = 2**15  # same as used in torchvision and ssl4eo
-        for key, meta in self.metadata_locs.items():
+        for key in keys:
             if key == 'metadata':
                 continue
+            meta = self.metadata_locs[key]
             parts = [os.path.join(self.root, f) for f in meta['files']]
             concat_path = os.path.join(self.root, self.dir_file_names[key] + '.tar.gz')
             if not os.path.exists(concat_path):

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -904,7 +904,7 @@ class BigEarthNetV2(NonGeoDataset):
         for key, meta in self.metadata_locs.items():
             if key == 'metadata':
                 continue
-            parts = [os.path.join(self.root, f) for f in meta['files'].keys()]
+            parts = [os.path.join(self.root, f) for f in meta['files']]
             concat_path = os.path.join(self.root, self.dir_file_names[key] + '.tar.gz')
             if not os.path.exists(concat_path):
                 with open(concat_path, 'wb') as outfile:

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -448,7 +448,7 @@ class BigEarthNet(NonGeoDataset):
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
-        keys = ['s1', 's2'] if self.bands == 'all' else [self.bands]
+        keys: list[str] = ['s1', 's2'] if self.bands == 'all' else [self.bands]
         urls = [self.metadata[k]['url'] for k in keys]
         md5s = [self.metadata[k]['md5'] for k in keys]
         filenames = [self.metadata[k]['filename'] for k in keys]

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -448,7 +448,7 @@ class BigEarthNet(NonGeoDataset):
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
-        keys: list[str] = ['s1', 's2'] if self.bands == 'all' else [self.bands]
+        keys = ['s1', 's2'] if self.bands == 'all' else [self.bands]
         urls = [self.metadata[k]['url'] for k in keys]
         md5s = [self.metadata[k]['md5'] for k in keys]
         filenames = [self.metadata[k]['filename'] for k in keys]
@@ -862,7 +862,7 @@ class BigEarthNetV2(NonGeoDataset):
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
-        keys = ['s1', 's2'] if self.bands == 'all' else [self.bands]
+        keys: list[str] = ['s1', 's2'] if self.bands == 'all' else [self.bands]
         keys += ['maps', 'metadata']
         if self.bands != 'all':
             to_remove = 's1' if self.bands == 's2' else 's2'


### PR DESCRIPTION
The current implementation of the `BigEarthNetV2` dataset downloads files to the root directory with the md5 checksum as filename which then causes errors when the `_extract()` method is called. This PR fixes the respective call to `download_url()` ~and also adds a `BigEarthNetV2DataModule`~. Also note that the current implementation of the `BigEarthNetV2` dataset downloads both `s1` and `s2` inputs no matter what was specified in the `bands` argument. This can/should be changed in a future PR.