### PR TITLE
ConvLSTM model changes only

### DIFF
--- a/tests/models/test_convlstm.py
+++ b/tests/models/test_convlstm.py
@@ -205,18 +205,3 @@ class TestConvLSTM:
         y_hat_last_step = model(input_tensor, lengths=torch.tensor([t, t]))
 
         torch.testing.assert_close(y_hat, y_hat_last_step)
-
-    def test_convlstm_forward_requires_head(self) -> None:
-        """Test that segmentation forward requires a configured prediction head."""
-        b = 1
-        t = 2
-        c = 3
-        h = 8
-        w = 8
-        input_tensor = torch.rand(b, t, c, h, w)
-        model = ConvLSTM(
-            input_dim=c, hidden_dim=8, kernel_size=3, num_layers=1, batch_first=True
-        )
-
-        with pytest.raises(ValueError, match='Segmentation head is not configured'):
-            model(input_tensor)

--- a/tests/models/test_convlstm.py
+++ b/tests/models/test_convlstm.py
@@ -12,8 +12,8 @@ from torchgeo.models import ConvLSTM
 class TestConvLSTM:
     """Tests for the ConvLSTM model."""
 
-    def test_convlstm_forward(self) -> None:
-        """Test the forward pass of the ConvLSTM model."""
+    def test_convlstm_forward_features(self) -> None:
+        """Test the feature forward pass of the ConvLSTM model."""
         b = 1
         t = 4
         c = 3
@@ -28,7 +28,7 @@ class TestConvLSTM:
             num_layers=1,
             batch_first=True,
         )
-        layer_output_list, last_state_list = model(input_tensor)
+        layer_output_list, last_state_list = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == 1
         assert len(last_state_list) == 1
@@ -53,7 +53,7 @@ class TestConvLSTM:
             batch_first=True,
             return_all_layers=True,
         )
-        layer_output_list, _ = model(input_tensor)
+        layer_output_list, _ = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == num_layers
         assert layer_output_list[0].shape == (b, t, hidden_dims[0], h, w)
@@ -75,7 +75,7 @@ class TestConvLSTM:
             num_layers=1,
             batch_first=True,
         )
-        layer_output_list, last_state_list = model(input_tensor)
+        layer_output_list, last_state_list = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == 1
         assert len(last_state_list) == 1
@@ -97,7 +97,7 @@ class TestConvLSTM:
             num_layers=1,
             batch_first=True,
         )
-        layer_output_list, last_state_list = model(input_tensor)
+        layer_output_list, last_state_list = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == 1
         assert len(last_state_list) == 1
@@ -119,7 +119,7 @@ class TestConvLSTM:
             num_layers=1,
             batch_first=False,
         )
-        layer_output_list, last_state_list = model(input_tensor)
+        layer_output_list, last_state_list = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == 1
         assert len(last_state_list) == 1
@@ -152,9 +152,71 @@ class TestConvLSTM:
             batch_first=True,
             return_all_layers=True,
         )
-        layer_output_list, last_state_list = model(input_tensor)
+        layer_output_list, last_state_list = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == 2
         assert len(last_state_list) == 2
         assert layer_output_list[0].shape == (b, t, 16, h, w)
         assert layer_output_list[1].shape == (b, t, 32, h, w)
+
+    def test_convlstm_forward(self) -> None:
+        """Test segmentation forward pass with prediction head."""
+        b = 2
+        t = 4
+        c = 3
+        h = 16
+        w = 16
+        num_classes = 5
+        input_tensor = torch.rand(b, t, c, h, w)
+
+        model = ConvLSTM(
+            input_dim=c,
+            hidden_dim=16,
+            kernel_size=3,
+            num_layers=1,
+            batch_first=True,
+            num_classes=num_classes,
+            head_kernel_size=1,
+        )
+        y_hat = model(input_tensor, lengths=torch.tensor([4, 2]))
+
+        assert y_hat.shape == (b, num_classes, h, w)
+
+    def test_convlstm_forward_uses_last_timestep_without_lengths(self) -> None:
+        """Test segmentation forward pass defaults to the final timestep."""
+        b = 2
+        t = 4
+        c = 3
+        h = 16
+        w = 16
+        num_classes = 5
+        input_tensor = torch.rand(b, t, c, h, w)
+
+        model = ConvLSTM(
+            input_dim=c,
+            hidden_dim=16,
+            kernel_size=3,
+            num_layers=1,
+            batch_first=True,
+            num_classes=num_classes,
+            head_kernel_size=1,
+        )
+        y_hat = model(input_tensor)
+        y_hat_last_step = model(input_tensor, lengths=torch.tensor([t, t]))
+
+        torch.testing.assert_close(y_hat, y_hat_last_step)
+
+    def test_convlstm_forward_requires_head(self) -> None:
+        """Test that segmentation forward requires a configured prediction head."""
+        b = 1
+        t = 2
+        c = 3
+        h = 8
+        w = 8
+        input_tensor = torch.rand(b, t, c, h, w)
+        model = ConvLSTM(
+            input_dim=c, hidden_dim=8, kernel_size=3, num_layers=1, batch_first=True
+        )
+
+        with pytest.raises(ValueError, match='Segmentation head is not configured'):
+            model(input_tensor)

--- a/tests/models/test_convlstm.py
+++ b/tests/models/test_convlstm.py
@@ -21,13 +21,7 @@ class TestConvLSTM:
         w = 64
         input_tensor = torch.rand(b, t, c, h, w)
 
-        model = ConvLSTM(
-            input_dim=c,
-            hidden_dim=16,
-            kernel_size=(3, 3),
-            num_layers=1,
-            batch_first=True,
-        )
+        model = ConvLSTM(input_dim=c, hidden_dim=16, kernel_size=(3, 3), num_layers=1)
         layer_output_list, last_state_list = model.forward_features(input_tensor)
 
         assert len(layer_output_list) == 1
@@ -50,7 +44,6 @@ class TestConvLSTM:
             hidden_dim=hidden_dims,
             kernel_size=(3, 3),
             num_layers=num_layers,
-            batch_first=True,
             return_all_layers=True,
         )
         layer_output_list, _ = model.forward_features(input_tensor)
@@ -73,7 +66,6 @@ class TestConvLSTM:
             hidden_dim=16,
             kernel_size=3,  # Pass as integer
             num_layers=1,
-            batch_first=True,
         )
         layer_output_list, last_state_list = model.forward_features(input_tensor)
 
@@ -95,29 +87,6 @@ class TestConvLSTM:
             hidden_dim=16,
             kernel_size=[(3, 3)],  # Pass as list of tuples
             num_layers=1,
-            batch_first=True,
-        )
-        layer_output_list, last_state_list = model.forward_features(input_tensor)
-
-        assert len(layer_output_list) == 1
-        assert len(last_state_list) == 1
-        assert layer_output_list[0].shape == (b, t, 16, h, w)
-
-    def test_convlstm_batch_first_false(self) -> None:
-        """Test the forward pass with batch_first=False."""
-        b = 1
-        t = 4
-        c = 3
-        h = 64
-        w = 64
-        input_tensor = torch.rand(t, b, c, h, w)  # Note the different order
-
-        model = ConvLSTM(
-            input_dim=c,
-            hidden_dim=16,
-            kernel_size=(3, 3),
-            num_layers=1,
-            batch_first=False,
         )
         layer_output_list, last_state_list = model.forward_features(input_tensor)
 
@@ -149,7 +118,6 @@ class TestConvLSTM:
             hidden_dim=[16, 32],
             kernel_size=[3, (5, 5)],  # Mix of int and tuple
             num_layers=2,
-            batch_first=True,
             return_all_layers=True,
         )
         layer_output_list, last_state_list = model.forward_features(input_tensor)
@@ -174,7 +142,6 @@ class TestConvLSTM:
             hidden_dim=16,
             kernel_size=3,
             num_layers=1,
-            batch_first=True,
             num_classes=num_classes,
             head_kernel_size=1,
         )
@@ -197,7 +164,6 @@ class TestConvLSTM:
             hidden_dim=16,
             kernel_size=3,
             num_layers=1,
-            batch_first=True,
             num_classes=num_classes,
             head_kernel_size=1,
         )

--- a/torchgeo/models/convlstm.py
+++ b/torchgeo/models/convlstm.py
@@ -111,7 +111,6 @@ class ConvLSTM(nn.Module):
         hidden_dim: int | list[int],
         kernel_size: int | tuple[int, int] | list[int | tuple[int, int]],
         num_layers: int,
-        batch_first: bool = True,
         bias: bool = True,
         return_all_layers: bool = False,
         num_classes: int = 1,
@@ -129,8 +128,6 @@ class ConvLSTM(nn.Module):
                 * a tuple of two integers (for rectangular kernels)
                 * a list of integers or tuples (one for each layer)
             num_layers: Number of LSTM layers stacked on each other.
-            batch_first: If ``True``, then the input and output tensors are
-                provided as (b, t, c, h, w).
             bias: If ``True``, adds a learnable bias to the output.
             return_all_layers: If ``True``, will return the list of computations
                 for all layers.
@@ -159,7 +156,6 @@ class ConvLSTM(nn.Module):
 
         self.input_dim = input_dim
         self.num_layers = num_layers
-        self.batch_first = batch_first
         self.bias = bias
         self.return_all_layers = return_all_layers
         self.num_classes = num_classes
@@ -195,15 +191,12 @@ class ConvLSTM(nn.Module):
         .. versionadded:: 0.10
 
         Args:
-            input_tensor: A 5-D Tensor of shape (t, b, c, h, w) or (b, t, c, h, w).
+            input_tensor: A 5-D Tensor of shape (b, t, c, h, w).
             hidden_state: An optional initial hidden state.
 
         Returns:
             A tuple containing layer_output_list and last_state_list.
         """
-        if not self.batch_first:
-            input_tensor = input_tensor.permute(1, 0, 2, 3, 4)
-
         b, _, _, h, w = input_tensor.size()
 
         if hidden_state is None:
@@ -245,7 +238,7 @@ class ConvLSTM(nn.Module):
         """Forward pass for segmentation with the prediction head.
 
         Args:
-            input_tensor: A 5-D Tensor of shape (t, b, c, h, w) or (b, t, c, h, w).
+            input_tensor: A 5-D Tensor of shape (b, t, c, h, w).
             lengths: Optional sequence lengths (B,) before padding/truncation.
                 Values larger than the available sequence length use the final
                 timestep.

--- a/torchgeo/models/convlstm.py
+++ b/torchgeo/models/convlstm.py
@@ -114,6 +114,8 @@ class ConvLSTM(nn.Module):
         batch_first: bool = True,
         bias: bool = True,
         return_all_layers: bool = False,
+        num_classes: int | None = None,
+        head_kernel_size: int = 1,
     ) -> None:
         """Initializes the ConvLSTM model.
 
@@ -132,6 +134,9 @@ class ConvLSTM(nn.Module):
             bias: If ``True``, adds a learnable bias to the output.
             return_all_layers: If ``True``, will return the list of computations
                 for all layers.
+            num_classes: Optional number of segmentation classes for an attached
+                prediction head.
+            head_kernel_size: Kernel size for the optional segmentation head.
         """
         super().__init__()
 
@@ -157,6 +162,7 @@ class ConvLSTM(nn.Module):
         self.batch_first = batch_first
         self.bias = bias
         self.return_all_layers = return_all_layers
+        self.num_classes = num_classes
 
         cell_list = []
         for i in range(self.num_layers):
@@ -171,13 +177,24 @@ class ConvLSTM(nn.Module):
             )
 
         self.cell_list = nn.ModuleList(cell_list)
+        self.head: nn.Conv2d | None = None
+        if self.num_classes is not None:
+            padding = head_kernel_size // 2
+            self.head = nn.Conv2d(
+                in_channels=self.hidden_dim[-1],
+                out_channels=self.num_classes,
+                kernel_size=head_kernel_size,
+                padding=padding,
+            )
 
-    def forward(
+    def forward_features(
         self,
         input_tensor: torch.Tensor,
         hidden_state: list[tuple[torch.Tensor, torch.Tensor]] | None = None,
     ) -> tuple[list[torch.Tensor], list[tuple[torch.Tensor, torch.Tensor]]]:
-        """Forward pass of the ConvLSTM.
+        """Forward pass of ConvLSTM feature extraction.
+
+        .. versionadded:: 0.10
 
         Args:
             input_tensor: A 5-D Tensor of shape (t, b, c, h, w) or (b, t, c, h, w).
@@ -220,6 +237,48 @@ class ConvLSTM(nn.Module):
             last_state_list = last_state_list[-1:]
 
         return layer_output_list, last_state_list
+
+    def forward(
+        self,
+        input_tensor: torch.Tensor,
+        lengths: torch.Tensor | None = None,
+        hidden_state: list[tuple[torch.Tensor, torch.Tensor]] | None = None,
+    ) -> torch.Tensor:
+        """Forward pass for segmentation with the prediction head.
+
+        Args:
+            input_tensor: A 5-D Tensor of shape (t, b, c, h, w) or (b, t, c, h, w).
+            lengths: Optional sequence lengths (B,) before padding/truncation.
+                Values larger than the available sequence length use the final
+                timestep.
+            hidden_state: An optional initial hidden state.
+
+        Returns:
+            Output tensor of shape (B, num_classes, H, W).
+
+        Raises:
+            ValueError: If the segmentation head is not configured.
+        """
+        if self.head is None:
+            raise ValueError(
+                "Segmentation head is not configured. Set 'num_classes' to use "
+                'ConvLSTM for segmentation.'
+            )
+
+        layer_output_list, _ = self.forward_features(
+            input_tensor, hidden_state=hidden_state
+        )
+        layer_output = layer_output_list[-1]
+
+        if lengths is None:
+            features = layer_output[:, -1]
+        else:
+            idx = lengths.to(device=layer_output.device, dtype=torch.long) - 1
+            idx = idx.clamp(min=0, max=layer_output.size(1) - 1)
+            batch_idx = torch.arange(layer_output.size(0), device=idx.device)
+            features = layer_output[batch_idx, idx]
+
+        return self.head(features)
 
     def _init_hidden(
         self, batch_size: int, image_size: tuple[int, int]

--- a/torchgeo/models/convlstm.py
+++ b/torchgeo/models/convlstm.py
@@ -177,15 +177,13 @@ class ConvLSTM(nn.Module):
             )
 
         self.cell_list = nn.ModuleList(cell_list)
-        self.head: nn.Conv2d | None = None
-        if self.num_classes is not None:
-            padding = head_kernel_size // 2
-            self.head = nn.Conv2d(
-                in_channels=self.hidden_dim[-1],
-                out_channels=self.num_classes,
-                kernel_size=head_kernel_size,
-                padding=padding,
-            )
+        padding = head_kernel_size // 2
+        self.head = nn.Conv2d(
+            in_channels=self.hidden_dim[-1],
+            out_channels=self.num_classes,
+            kernel_size=head_kernel_size,
+            padding=padding,
+        )
 
     def forward_features(
         self,

--- a/torchgeo/models/convlstm.py
+++ b/torchgeo/models/convlstm.py
@@ -114,7 +114,7 @@ class ConvLSTM(nn.Module):
         batch_first: bool = True,
         bias: bool = True,
         return_all_layers: bool = False,
-        num_classes: int | None = None,
+        num_classes: int = 1,
         head_kernel_size: int = 1,
     ) -> None:
         """Initializes the ConvLSTM model.

--- a/torchgeo/models/convlstm.py
+++ b/torchgeo/models/convlstm.py
@@ -256,15 +256,7 @@ class ConvLSTM(nn.Module):
         Returns:
             Output tensor of shape (B, num_classes, H, W).
 
-        Raises:
-            ValueError: If the segmentation head is not configured.
         """
-        if self.head is None:
-            raise ValueError(
-                "Segmentation head is not configured. Set 'num_classes' to use "
-                'ConvLSTM for segmentation.'
-            )
-
         layer_output_list, _ = self.forward_features(
             input_tensor, hidden_state=hidden_state
         )


### PR DESCRIPTION
Support for convlstm in segmentation mode:

- Added a segmentation head `(nn.Conv2d)` controlled by `num_classes` and `head_kernel_size` parameters
- Renamed forward → forward_features for the raw hidden-state output; new forward runs the head and returns `(B, num_classes, H, W)` supports optional lengths for variable-length sequences
- Removed `batch_first` parameter — only `(b, t, c, h, w)` input is supported, consistent with TorchGeo's standard