### PR TITLE
Run tests in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,8 +37,11 @@ jobs:
       - name: List installed dependencies
         run: uv tree
       - name: Run checks
+        env:
+          PYTEST_WORKERS: ${{ runner.os == 'macOS' && '2' || 'auto' }}
+          TORCHGEO_USE_BFLOAT16: ${{ runner.os == 'macOS' && 'true' || 'false' }}
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          OMP_NUM_THREADS=1 pytest -n "$PYTEST_WORKERS" --dist loadgroup --cov=torchgeo --cov-report=xml
           python -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v7.0.0
@@ -65,7 +68,7 @@ jobs:
         run: uv tree
       - name: Run checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          OMP_NUM_THREADS=1 pytest -n auto --dist loadgroup --cov=torchgeo --cov-report=xml
           python -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v7.0.0
@@ -93,7 +96,7 @@ jobs:
         run: uv tree
       - name: Run checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          OMP_NUM_THREADS=1 pytest -n auto --dist loadgroup --cov=torchgeo --cov-report=xml
           python -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,8 @@ tests = [
     "pytest>=7.3.2",
     # pytest-cov 4+ required for pytest 7.2+ compatibility
     "pytest-cov>=4",
+    # pytest-xdist 3.0.2+ required for --dist=loadgroup with pytest 9
+    "pytest-xdist>=3.0.2",
     # pytest-socket 0.3.4+ required for wheels
     "pytest-socket>=0.3.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -855,6 +855,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2996,6 +3005,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3790,6 +3812,7 @@ all = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
+    { name = "pytest-xdist" },
     { name = "rioxarray" },
     { name = "ruff" },
     { name = "scipy" },
@@ -3842,6 +3865,7 @@ tests = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -3874,6 +3898,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.3.2" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=4" },
     { name = "pytest-socket", marker = "extra == 'tests'", specifier = ">=0.3.4" },
+    { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.0.2" },
     { name = "rasterio", specifier = ">=1.4.3" },
     { name = "requests", specifier = ">=2.25" },
     { name = "rioxarray", marker = "extra == 'datasets'", specifier = ">=0.14.1" },


### PR DESCRIPTION
## Before

- Each CI job ran pytest serially

## After

- pytest uses xdist with \`--dist loadgroup\`
- Linux and Windows use all available workers, macOS uses two workers
- Memory-intensive model tests (marked \`xdist_group('memory_intensive')\`, see #4016) are scheduled onto the same worker and run in bfloat16 on macOS

### Checklist

- [x] I have read the Contributing docs
- [x] I have read the AI policy
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution