### PR TITLE
fix : empty masks ; skip them in instance segmentation 

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1088,6 +1088,11 @@ class VectorDataset(GeoDataset):
                             out_shape=(round(height), round(width)),
                             transform=transform,
                         )
+
+                        if mask.max() == 0:
+                            # Skip empty masks
+                            continue
+
                         mask_list.append(mask)
 
                     labels = np.array(label_list).astype(np.int32)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1076,13 +1076,6 @@ class VectorDataset(GeoDataset):
                         shape = shapely.geometry.shape(s[0])
                         p = convert_poly_coords(shape, transform, inverse=True)
                         p = shapely.clip_by_rect(p, 0, 0, width, height)
-
-                        # Get labels
-                        label_list.append(s[1])
-
-                        # xmin, ymin, xmax, ymax format
-                        box_list.append(p.bounds)
-
                         mask = rasterio.features.rasterize(
                             [(s[0], i + 1)],
                             out_shape=(round(height), round(width)),
@@ -1092,6 +1085,11 @@ class VectorDataset(GeoDataset):
                         if mask.max() == 0:
                             # Skip empty masks
                             continue
+                        # Get labels
+                        label_list.append(s[1])
+
+                        # xmin, ymin, xmax, ymax format
+                        box_list.append(p.bounds)
 
                         mask_list.append(mask)
 


### PR DESCRIPTION
## What does this PR do ? 

- fixes #3332  

## Note : 

Kindly verify the existence of the bug , I encountered it during my experiment and this is what I think is the issue is when geoms are in edge or tiny enough they aren't burnt to raster they get added to the list anyway causing the mismatch , if bug is verified this should fix the issue ! if not feel free to ignore the PR ! 