### PR TITLE
Add time series to the documentation: API reference for non-geospatial datasets

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -305,7 +305,7 @@ CropHarvest
 .. autoclass:: CropHarvest
 
 CV4A Kenya Crop Type
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: CV4AKenyaCropType
 

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -304,7 +304,7 @@ CropHarvest
 
 .. autoclass:: CropHarvest
 
-Kenya Crop Type
+CV4A Kenya Crop Type
 ^^^^^^^^^^^^^^^
 
 .. autoclass:: CV4AKenyaCropType

--- a/docs/api/datasets/non_geo_datasets.csv
+++ b/docs/api/datasets/non_geo_datasets.csv
@@ -2,7 +2,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `ADVANCE`_,C,"Google Earth, Freesound","CC-BY-4.0","5,075",13,512x512,0.5,RGB
 `Benin Cashew Plantations`_,S,Airbus Pléiades,"CC-BY-4.0",70,6,"1,122x1,186",10,MSI
 `BigEarthNet`_,C,Sentinel-1/2,"CDLA-Permissive-1.0","590,326",19--43,120x120,10,"SAR, MSI"
-`BioMassters`_,"R, T",Sentinel-1/2 and Lidar,"CC-BY-4.0",,,256x256xT, 10, "SAR, MSI"
+`BioMassters`_,"R, T",Sentinel-1/2 and Lidar,"CC-BY-4.0",,,256x256xT,10,"SAR, MSI"
 `BRIGHT`_,CD,"MAXAR, NAIP, Capella, Umbra","CC-BY-4.0 AND CC-BY-NC-4.0",3239,4,1024x1024,"0.1--1","RGB, SAR"
 `CaBuAr`_,CD,Sentinel-2,"OpenRAIL",424,2,512x512,20,MSI
 `CaFFe`_,S,"Sentinel-1, TerraSAR-X, TanDEM-X, ENVISAT, ERS-1/2, ALOS PALSAR, and RADARSAT-1","CC-BY-4.0","19092","2 or 4","512x512",6-20,"SAR"

--- a/docs/api/datasets/non_geo_datasets.csv
+++ b/docs/api/datasets/non_geo_datasets.csv
@@ -2,7 +2,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `ADVANCE`_,C,"Google Earth, Freesound","CC-BY-4.0","5,075",13,512x512,0.5,RGB
 `Benin Cashew Plantations`_,S,Airbus Pléiades,"CC-BY-4.0",70,6,"1,122x1,186",10,MSI
 `BigEarthNet`_,C,Sentinel-1/2,"CDLA-Permissive-1.0","590,326",19--43,120x120,10,"SAR, MSI"
-`BioMassters`_,R,Sentinel-1/2 and Lidar,"CC-BY-4.0",,,256x256, 10, "SAR, MSI"
+`BioMassters`_,"R, T",Sentinel-1/2 and Lidar,"CC-BY-4.0",,,256x256, 10, "SAR, MSI"
 `BRIGHT`_,CD,"MAXAR, NAIP, Capella, Umbra","CC-BY-4.0 AND CC-BY-NC-4.0",3239,4,1024x1024,"0.1--1","RGB, SAR"
 `CaBuAr`_,CD,Sentinel-2,"OpenRAIL",424,2,512x512,20,MSI
 `CaFFe`_,S,"Sentinel-1, TerraSAR-X, TanDEM-X, ENVISAT, ERS-1/2, ALOS PALSAR, and RADARSAT-1","CC-BY-4.0","19092","2 or 4","512x512",6-20,"SAR"
@@ -13,11 +13,11 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `Copernicus-Pretrain`_,T,"Sentinel-1/2/3/5P, DEM","CC-BY-4.0",18.7M,-,"264x264 or 96x96 or 28x28 or 960x960",10--1000,"SAR, MSI, Air Pollutants, DEM"
 `COWC`_,"C, R","CSUAV AFRL, ISPRS, LINZ, AGRC","AGPL-3.0-only","388,435",2,256x256,0.15,RGB
 `CropHarvest`_,"C","Sentinel-1/2, SRTM, ERA5","CC-BY-SA-4.0","70,213",351,1x1,10,"SAR, MSI, SRTM"
-`Kenya Crop Type`_,S,Sentinel-2,"CC-BY-SA-4.0","4,688",7,"3,035x2,016",10,MSI
+`CV4A Kenya Crop Type`_,S,Sentinel-2,"CC-BY-SA-4.0","4,688",7,"3,035x2,016",10,MSI
 `DeepGlobe Land Cover`_,S,DigitalGlobe +Vivid,-,803,7,"2,448x2,448",0.5,RGB
 `DFC2022`_,S,Aerial,"CC-BY-4.0","3,981",15,"2,000x2,000",0.5,RGB
 `DIOR`_,OD,Aerial,"CC-BY-NC-4.0","23,463",20,"800x800",0.5,RGB
-`Digital Typhoon`_,"C, R",Himawari,"CC-BY-4.0","189,364",8,512,5000,Infrared
+`Digital Typhoon`_,"C, R, T",Himawari,"CC-BY-4.0","189,364",8,512,5000,Infrared
 `DL4GAM`_,S,"Sentinel-2","CC-BY-4.0","2,251 or 11,440","2","256x256","10","MSI"
 `DOTA`_,OD,"Google Earth, Gaofen-2, Jilin-1, CycloMedia B.V.","non-commercial","5,229",15,"800--4000",,RGB
 `Earth Index Embeddings`_,E,Sentinel-2,CC-BY-4.0,-,384,484x484,320,Embedding
@@ -44,7 +44,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `MMEarth`_,"C, S","Aster, Sentinel, ERA5","CC-BY-4.0","100K--1M",,"128x128 or 64x64",10,MSI
 `NASA Marine Debris`_,OD,PlanetScope,"Apache-2.0",707,1,256x256,3,RGB
 `OSCD`_,CD,Sentinel-2,"CC-BY-NC-SA-4.0",24,2,"241--1,180",60,MSI
-`PASTIS`_,I,Sentinel-1/2,"CC-BY-4.0","2,433",19,128x128xT,10,MSI
+`PASTIS`_,"I, T",Sentinel-1/2,"CC-BY-4.0","2,433",19,128x128xT,10,MSI
 `PatternNet`_,C,Google Earth,"CC-BY-4.0","30,400",38,256x256,0.06--5,RGB
 `Potsdam`_,S,Aerial,-,38,6,"6,000x6,000",0.05,MSI
 `QuakeSet`_,"C, R",Sentinel-1,"OpenRAIL","3,327",2,512x512,10,SAR

--- a/docs/api/datasets/non_geo_datasets.csv
+++ b/docs/api/datasets/non_geo_datasets.csv
@@ -13,7 +13,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `Copernicus-Pretrain`_,T,"Sentinel-1/2/3/5P, DEM","CC-BY-4.0",18.7M,-,"264x264 or 96x96 or 28x28 or 960x960",10--1000,"SAR, MSI, Air Pollutants, DEM"
 `COWC`_,"C, R","CSUAV AFRL, ISPRS, LINZ, AGRC","AGPL-3.0-only","388,435",2,256x256,0.15,RGB
 `CropHarvest`_,"C","Sentinel-1/2, SRTM, ERA5","CC-BY-SA-4.0","70,213",351,1x1,10,"SAR, MSI, SRTM"
-`CV4A Kenya Crop Type`_,S,Sentinel-2,"CC-BY-SA-4.0","4,688",7,"3,035x2,016",10,MSI
+`Kenya Crop Type`_,S,Sentinel-2,"CC-BY-SA-4.0","4,688",7,"3,035x2,016",10,MSI
 `DeepGlobe Land Cover`_,S,DigitalGlobe +Vivid,-,803,7,"2,448x2,448",0.5,RGB
 `DFC2022`_,S,Aerial,"CC-BY-4.0","3,981",15,"2,000x2,000",0.5,RGB
 `DIOR`_,OD,Aerial,"CC-BY-NC-4.0","23,463",20,"800x800",0.5,RGB

--- a/docs/api/datasets/non_geo_datasets.csv
+++ b/docs/api/datasets/non_geo_datasets.csv
@@ -13,7 +13,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `Copernicus-Pretrain`_,T,"Sentinel-1/2/3/5P, DEM","CC-BY-4.0",18.7M,-,"264x264 or 96x96 or 28x28 or 960x960",10--1000,"SAR, MSI, Air Pollutants, DEM"
 `COWC`_,"C, R","CSUAV AFRL, ISPRS, LINZ, AGRC","AGPL-3.0-only","388,435",2,256x256,0.15,RGB
 `CropHarvest`_,"C","Sentinel-1/2, SRTM, ERA5","CC-BY-SA-4.0","70,213",351,1x1,10,"SAR, MSI, SRTM"
-`Kenya Crop Type`_,S,Sentinel-2,"CC-BY-SA-4.0","4,688",7,"3,035x2,016",10,MSI
+`CV4A Kenya Crop Type`_,"S, T",Sentinel-2,"CC-BY-SA-4.0","4,688",7,"3,035x2,016xT",10,MSI
 `DeepGlobe Land Cover`_,S,DigitalGlobe +Vivid,-,803,7,"2,448x2,448",0.5,RGB
 `DFC2022`_,S,Aerial,"CC-BY-4.0","3,981",15,"2,000x2,000",0.5,RGB
 `DIOR`_,OD,Aerial,"CC-BY-NC-4.0","23,463",20,"800x800",0.5,RGB

--- a/docs/api/datasets/non_geo_datasets.csv
+++ b/docs/api/datasets/non_geo_datasets.csv
@@ -2,7 +2,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `ADVANCE`_,C,"Google Earth, Freesound","CC-BY-4.0","5,075",13,512x512,0.5,RGB
 `Benin Cashew Plantations`_,S,Airbus Pléiades,"CC-BY-4.0",70,6,"1,122x1,186",10,MSI
 `BigEarthNet`_,C,Sentinel-1/2,"CDLA-Permissive-1.0","590,326",19--43,120x120,10,"SAR, MSI"
-`BioMassters`_,"R, T",Sentinel-1/2 and Lidar,"CC-BY-4.0",,,256x256, 10, "SAR, MSI"
+`BioMassters`_,"R, T",Sentinel-1/2 and Lidar,"CC-BY-4.0",,,256x256xT, 10, "SAR, MSI"
 `BRIGHT`_,CD,"MAXAR, NAIP, Capella, Umbra","CC-BY-4.0 AND CC-BY-NC-4.0",3239,4,1024x1024,"0.1--1","RGB, SAR"
 `CaBuAr`_,CD,Sentinel-2,"OpenRAIL",424,2,512x512,20,MSI
 `CaFFe`_,S,"Sentinel-1, TerraSAR-X, TanDEM-X, ENVISAT, ERS-1/2, ALOS PALSAR, and RADARSAT-1","CC-BY-4.0","19092","2 or 4","512x512",6-20,"SAR"
@@ -17,7 +17,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `DeepGlobe Land Cover`_,S,DigitalGlobe +Vivid,-,803,7,"2,448x2,448",0.5,RGB
 `DFC2022`_,S,Aerial,"CC-BY-4.0","3,981",15,"2,000x2,000",0.5,RGB
 `DIOR`_,OD,Aerial,"CC-BY-NC-4.0","23,463",20,"800x800",0.5,RGB
-`Digital Typhoon`_,"C, R, T",Himawari,"CC-BY-4.0","189,364",8,512,5000,Infrared
+`Digital Typhoon`_,"C, R, T",Himawari,"CC-BY-4.0","189,364",8,512x512xT,5000,Infrared
 `DL4GAM`_,S,"Sentinel-2","CC-BY-4.0","2,251 or 11,440","2","256x256","10","MSI"
 `DOTA`_,OD,"Google Earth, Gaofen-2, Jilin-1, CycloMedia B.V.","non-commercial","5,229",15,"800--4000",,RGB
 `Earth Index Embeddings`_,E,Sentinel-2,CC-BY-4.0,-,384,484x484,320,Embedding


### PR DESCRIPTION
This PR adds T (time-series) to the documentation for non-geospatial datasets that currently support time-series. The PR hasn't included datasets being converted to time-series in https://github.com/torchgeo/torchgeo/issues/3042. 

The remaining datasets are:
- SeasoNet
- Substation
- SKIPP'D