### PR TITLE
Separated sample logic from vector dataset getitem

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ nitpick_ignore = [
     ('py:class', 'torchvision.models._api.WeightsEnum'),
     ('py:class', 'torchvision.models.resnet.ResNet'),
     ('py:class', 'torchvision.models.swin_transformer.SwinTransformer'),
+    ('py:class', 'numpy.int32'),
 ]
 
 

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -582,7 +582,7 @@ class TestVectorDataset:
             CustomVectorDataset(dataset.paths, task='invalid-task')  # type: ignore[arg-type]
 
     def test_getitem_invalid_task(self, dataset: CustomVectorDataset) -> None:
-        dataset.task = "invalid-task"
+        dataset.task = 'invalid-task'
         with pytest.raises(ValueError, match='Invalid task:'):
             dataset[dataset.bounds]
 

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -581,6 +581,11 @@ class TestVectorDataset:
         with pytest.raises(ValueError, match='Invalid task:'):
             CustomVectorDataset(dataset.paths, task='invalid-task')  # type: ignore[arg-type]
 
+    def test_getitem_invalid_task(self, dataset: CustomVectorDataset) -> None:
+        dataset.task = "invalid-task"
+        with pytest.raises(ValueError, match='Invalid task:'):
+            dataset[dataset.bounds]
+
     def test_getitem_sem_seg(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'semantic_segmentation'
         x = dataset[dataset.bounds]

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -26,7 +26,8 @@ import rasterio.merge
 import rasterio.warp
 import shapely
 import torch
-from geopandas import GeoDataFrame, GeoSeries
+from geopandas import GeoDataFrame
+from shapely.geometry.base import BaseGeometry
 from pyproj import CRS
 from rasterio.enums import Resampling
 from rasterio.io import DatasetReader
@@ -1030,7 +1031,7 @@ class VectorDataset(GeoDataset):
 
     def _semantic_segmentation_sample(
         self,
-        shapes: list[tuple[GeoSeries, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1046,7 +1047,7 @@ class VectorDataset(GeoDataset):
 
     def _object_detection_sample(
         self,
-        shapes: list[tuple[GeoSeries, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1078,7 +1079,7 @@ class VectorDataset(GeoDataset):
 
     def _instance_segmentation_sample(
         self,
-        shapes: list[tuple[GeoSeries, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1129,7 +1130,7 @@ class VectorDataset(GeoDataset):
 
     def prepare_sample(
         self,
-        shapes: list[tuple[GeoSeries, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1598,8 +1599,8 @@ class UnionDataset(GeoDataset):
 
         dataset2.crs = dataset1.crs
         dataset2.res = dataset1.res
-        
-        self.index = pd.concat([dataset1.index, dataset2.index]) # type: ignore[invalid-assignment]
+
+        self.index = pd.concat([dataset1.index, dataset2.index])  # type: ignore[invalid-assignment]
 
     def __getitem__(self, index: GeoSlice) -> Sample:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1178,6 +1178,9 @@ class VectorDataset(GeoDataset):
 
         Returns:
             Sample of input, target, and/or metadata for those shapes.
+
+        Raises:
+            ValueError: If the *dataset.task* is invalid
         """
         match self.task:
             case 'semantic_segmentation':
@@ -1192,8 +1195,8 @@ class VectorDataset(GeoDataset):
                 return self._instance_segmentation_sample(
                     shapes, width, height, transform
                 )
-
-        return {}
+            
+        raise ValueError(f'Invalid task: {self.task!r}')
 
     def __getitem__(self, index: GeoSlice) -> Sample:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
@@ -1208,7 +1211,7 @@ class VectorDataset(GeoDataset):
             IndexError: If *index* is not found in the dataset.
         """
         x, y, t = self._disambiguate_slice(index)
-        interval = pd.Interval(t.start, t.stop)
+        interval = pd.Interval(t.start, t.stop) 
         df = self.index.iloc[self.index.index.overlaps(interval)]
         df = df.iloc[:: t.step]
         df = df.cx[x.start : x.stop, y.start : y.stop]

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1598,9 +1598,8 @@ class UnionDataset(GeoDataset):
 
         dataset2.crs = dataset1.crs
         dataset2.res = dataset1.res
-
-        # type: ignore[invalid-assignment]
-        self.index = pd.concat([dataset1.index, dataset2.index])
+        
+        self.index = pd.concat([dataset1.index, dataset2.index]) # type: ignore[invalid-assignment]
 
     def __getitem__(self, index: GeoSlice) -> Sample:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1195,7 +1195,7 @@ class VectorDataset(GeoDataset):
                 return self._instance_segmentation_sample(
                     shapes, width, height, transform
                 )
-            
+
         raise ValueError(f'Invalid task: {self.task!r}')
 
     def __getitem__(self, index: GeoSlice) -> Sample:
@@ -1211,7 +1211,7 @@ class VectorDataset(GeoDataset):
             IndexError: If *index* is not found in the dataset.
         """
         x, y, t = self._disambiguate_slice(index)
-        interval = pd.Interval(t.start, t.stop) 
+        interval = pd.Interval(t.start, t.stop)
         df = self.index.iloc[self.index.index.overlaps(interval)]
         df = df.iloc[:: t.step]
         df = df.cx[x.start : x.stop, y.start : y.stop]

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -28,9 +28,9 @@ import shapely
 import torch
 from geopandas import GeoDataFrame
 from pyproj import CRS
+from rasterio import Affine
 from rasterio.enums import Resampling
 from rasterio.io import DatasetReader
-from rasterio import Affine
 from rasterio.vrt import WarpedVRT
 from shapely import Geometry
 from torch import Tensor

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -27,12 +27,12 @@ import rasterio.warp
 import shapely
 import torch
 from geopandas import GeoDataFrame
-from shapely.geometry.base import BaseGeometry
 from pyproj import CRS
 from rasterio.enums import Resampling
 from rasterio.io import DatasetReader
 from rasterio.transform import Affine
 from rasterio.vrt import WarpedVRT
+from shapely.geometry.base import BaseGeometry
 from torch import Tensor
 from torch.utils.data import Dataset
 from torchvision.datasets import ImageFolder
@@ -1036,6 +1036,17 @@ class VectorDataset(GeoDataset):
         height: float,
         transform: Affine,
     ) -> Sample:
+        """Computes the sample dict matching the given shapes.
+
+        Args:
+            shapes: List of shapes and associated labels.
+            width: Width of the patch
+            height: Height of the patch
+            transform: Rasterio transform associated with the patch
+
+        Returns:
+            Sample including rasterized mask for input shapes.
+        """
         if shapes:
             masks = rasterio.features.rasterize(
                 shapes, out_shape=(round(height), round(width)), transform=transform
@@ -1052,6 +1063,17 @@ class VectorDataset(GeoDataset):
         height: float,
         transform: Affine,
     ) -> Sample:
+        """Computes the sample dict matching the given shapes.
+
+        Args:
+            shapes: List of shapes and associated labels.
+            width: Width of the patch
+            height: Height of the patch
+            transform: Rasterio transform associated with the patch
+
+        Returns:
+            Sample including bounding box coordinates and labels for input shapes
+        """
         if shapes:
             label_list = []
             box_list = []
@@ -1084,6 +1106,17 @@ class VectorDataset(GeoDataset):
         height: float,
         transform: Affine,
     ) -> Sample:
+        """Computes the sample dict matching the given shapes.
+
+        Args:
+            shapes: List of shapes and associated labels.
+            width: Width of the patch
+            height: Height of the patch
+            transform: Rasterio transform associated with the patch
+
+        Returns:
+            Sample including rasterized mask, boundind boxes and labels for input shapes.
+        """
         if shapes:
             label_list = []
             box_list = []

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -26,10 +26,11 @@ import rasterio.merge
 import rasterio.warp
 import shapely
 import torch
-from geopandas import GeoDataFrame
+from geopandas import GeoDataFrame, GeoSeries
 from pyproj import CRS
 from rasterio.enums import Resampling
 from rasterio.io import DatasetReader
+from rasterio.transform import Affine
 from rasterio.vrt import WarpedVRT
 from torch import Tensor
 from torch.utils.data import Dataset
@@ -1027,6 +1028,139 @@ class VectorDataset(GeoDataset):
         index = pd.IntervalIndex.from_tuples(datetimes, closed='both', name='datetime')
         self.index = GeoDataFrame(data, index=index, geometry=geometries, crs=crs)
 
+    def _semantic_segmentation_sample(
+        self,
+        shapes: list[tuple[GeoSeries, np.int32]],
+        width: float,
+        height: float,
+        transform: Affine,
+    ) -> Sample:
+        if shapes:
+            masks = rasterio.features.rasterize(
+                shapes, out_shape=(round(height), round(width)), transform=transform
+            )
+        else:
+            masks = np.zeros((round(height), round(width)), dtype=np.uint8)
+
+        return {'mask': array_to_tensor(masks).to(self.dtype)}
+
+    def _object_detection_sample(
+        self,
+        shapes: list[tuple[GeoSeries, np.int32]],
+        width: float,
+        height: float,
+        transform: Affine,
+    ) -> Sample:
+        if shapes:
+            label_list = []
+            box_list = []
+            for s in shapes:
+                shape = shapely.geometry.shape(s[0])
+                p = convert_poly_coords(shape, transform, inverse=True)
+                p = shapely.clip_by_rect(p, 0, 0, width, height)
+
+                # Get labels
+                label_list.append(s[1])
+
+                # xmin, ymin, xmax, ymax format
+                box_list.append(p.bounds)
+
+            labels = np.array(label_list).astype(np.int32)
+            boxes_xyxy = np.array(box_list).astype(np.float32)
+        else:
+            boxes_xyxy = np.empty((0, 4), dtype=np.float32)
+            labels = np.empty((0,), dtype=np.int32)
+
+        return {
+            'bbox_xyxy': torch.from_numpy(boxes_xyxy),
+            'label': torch.from_numpy(labels),
+        }
+
+    def _instance_segmentation_sample(
+        self,
+        shapes: list[tuple[GeoSeries, np.int32]],
+        width: float,
+        height: float,
+        transform: Affine,
+    ) -> Sample:
+        if shapes:
+            label_list = []
+            box_list = []
+            mask_list = []
+            for i, s in enumerate(shapes):
+                shape = shapely.geometry.shape(s[0])
+                p = convert_poly_coords(shape, transform, inverse=True)
+                p = shapely.clip_by_rect(p, 0, 0, width, height)
+
+                # Get labels
+                label_list.append(s[1])
+
+                # xmin, ymin, xmax, ymax format
+                box_list.append(p.bounds)
+
+                mask = rasterio.features.rasterize(
+                    [(s[0], i + 1)],
+                    out_shape=(round(height), round(width)),
+                    transform=transform,
+                )
+                mask_list.append(mask)
+
+            labels = np.array(label_list).astype(np.int32)
+            boxes_xyxy = np.array(box_list).astype(np.float32)
+            masks = np.array(mask_list)
+
+            obj_ids = np.unique(masks)
+
+            # first id is the background, so remove it
+            obj_ids = obj_ids[1:]
+
+            # convert (H, W) mask a set of binary masks
+            masks = (masks == obj_ids[:, None, None]).astype(np.uint8)
+        else:
+            masks = np.zeros((round(height), round(width)), dtype=np.uint8)
+            boxes_xyxy = np.empty((0, 4), dtype=np.float32)
+            labels = np.empty((0,), dtype=np.int32)
+
+        return {
+            'mask': array_to_tensor(masks),
+            'bbox_xyxy': torch.from_numpy(boxes_xyxy),
+            'label': torch.from_numpy(labels),
+        }
+
+    def prepare_sample(
+        self,
+        shapes: list[tuple[GeoSeries, np.int32]],
+        width: float,
+        height: float,
+        transform: Affine,
+    ) -> Sample:
+        """Computes the sample dict matching the given shapes.
+
+        Args:
+            shapes: List of shapes and associated labels.
+            width: Width of the patch
+            height: Height of the patch
+            transform: Rasterio transform associated with the patch
+
+        Returns:
+            Sample of input, target, and/or metadata for those shapes.
+        """
+        match self.task:
+            case 'semantic_segmentation':
+                return self._semantic_segmentation_sample(
+                    shapes, width, height, transform
+                )
+
+            case 'object_detection':
+                return self._object_detection_sample(shapes, width, height, transform)
+
+            case 'instance_segmentation':
+                return self._instance_segmentation_sample(
+                    shapes, width, height, transform
+                )
+
+        return {}
+
     def __getitem__(self, index: GeoSlice) -> Sample:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
@@ -1078,93 +1212,17 @@ class VectorDataset(GeoDataset):
         transform = rasterio.transform.from_bounds(
             x.start, y.start, x.stop, y.stop, width, height
         )
-        if shapes:
-            match self.task:
-                case 'semantic_segmentation':
-                    masks = rasterio.features.rasterize(
-                        shapes,
-                        out_shape=(round(height), round(width)),
-                        transform=transform,
-                    )
 
-                case 'object_detection':
-                    # Get boxes for object detection or instance segmentation
-                    label_list = []
-                    box_list = []
-                    for s in shapes:
-                        shape = shapely.geometry.shape(s[0])
-                        p = convert_poly_coords(shape, transform, inverse=True)
-                        p = shapely.clip_by_rect(p, 0, 0, width, height)
-
-                        # Get labels
-                        label_list.append(s[1])
-
-                        # xmin, ymin, xmax, ymax format
-                        box_list.append(p.bounds)
-
-                    labels = np.array(label_list).astype(np.int32)
-                    boxes_xyxy = np.array(box_list).astype(np.float32)
-
-                case 'instance_segmentation':
-                    # Get boxes for object detection or instance segmentation
-                    label_list = []
-                    box_list = []
-                    mask_list = []
-                    for i, s in enumerate(shapes):
-                        shape = shapely.geometry.shape(s[0])
-                        p = convert_poly_coords(shape, transform, inverse=True)
-                        p = shapely.clip_by_rect(p, 0, 0, width, height)
-
-                        # Get labels
-                        label_list.append(s[1])
-
-                        # xmin, ymin, xmax, ymax format
-                        box_list.append(p.bounds)
-
-                        mask = rasterio.features.rasterize(
-                            [(s[0], i + 1)],
-                            out_shape=(round(height), round(width)),
-                            transform=transform,
-                        )
-                        mask_list.append(mask)
-
-                    labels = np.array(label_list).astype(np.int32)
-                    boxes_xyxy = np.array(box_list).astype(np.float32)
-                    masks = np.array(mask_list)
-
-                    obj_ids = np.unique(masks)
-
-                    # first id is the background, so remove it
-                    obj_ids = obj_ids[1:]
-
-                    # convert (H, W) mask a set of binary masks
-                    masks = (masks == obj_ids[:, None, None]).astype(np.uint8)
-        else:
-            # If no features are found in this key, return an empty mask
-            # with the default fill value and dtype used by rasterize
-            masks = np.zeros((round(height), round(width)), dtype=np.uint8)
-            boxes_xyxy = np.empty((0, 4), dtype=np.float32)
-            labels = np.empty((0,), dtype=np.int32)
+        sample = self.prepare_sample(shapes, width, height, transform)
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample: Sample = {
-            'bounds': self._slice_to_tensor(index),
-            'transform': torch.tensor(transform),
-        }
 
-        # Use array_to_tensor since rasterize may return uint16/uint32 arrays.
-        match self.task:
-            case 'semantic_segmentation':
-                sample['mask'] = array_to_tensor(masks).to(self.dtype)
-
-            case 'object_detection':
-                sample['bbox_xyxy'] = torch.from_numpy(boxes_xyxy)
-                sample['label'] = torch.from_numpy(labels)
-
-            case 'instance_segmentation':
-                sample['mask'] = array_to_tensor(masks)
-                sample['bbox_xyxy'] = torch.from_numpy(boxes_xyxy)
-                sample['label'] = torch.from_numpy(labels)
+        sample.update(
+            {
+                'bounds': self._slice_to_tensor(index),
+                'transform': torch.tensor(transform),
+            }
+        )
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -1541,7 +1599,8 @@ class UnionDataset(GeoDataset):
         dataset2.crs = dataset1.crs
         dataset2.res = dataset1.res
 
-        self.index = pd.concat([dataset1.index, dataset2.index])  # type: ignore[invalid-assignment]
+        # type: ignore[invalid-assignment]
+        self.index = pd.concat([dataset1.index, dataset2.index])
 
     def __getitem__(self, index: GeoSlice) -> Sample:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -30,9 +30,9 @@ from geopandas import GeoDataFrame
 from pyproj import CRS
 from rasterio.enums import Resampling
 from rasterio.io import DatasetReader
-from rasterio.transform import Affine
+from rasterio import Affine
 from rasterio.vrt import WarpedVRT
-from shapely.geometry.base import BaseGeometry
+from shapely import Geometry
 from torch import Tensor
 from torch.utils.data import Dataset
 from torchvision.datasets import ImageFolder
@@ -1031,7 +1031,7 @@ class VectorDataset(GeoDataset):
 
     def _semantic_segmentation_sample(
         self,
-        shapes: list[tuple[BaseGeometry, np.int32]],
+        shapes: list[tuple[Geometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1058,7 +1058,7 @@ class VectorDataset(GeoDataset):
 
     def _object_detection_sample(
         self,
-        shapes: list[tuple[BaseGeometry, np.int32]],
+        shapes: list[tuple[Geometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1101,7 +1101,7 @@ class VectorDataset(GeoDataset):
 
     def _instance_segmentation_sample(
         self,
-        shapes: list[tuple[BaseGeometry, np.int32]],
+        shapes: list[tuple[Geometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1163,7 +1163,7 @@ class VectorDataset(GeoDataset):
 
     def prepare_sample(
         self,
-        shapes: list[tuple[BaseGeometry, np.int32]],
+        shapes: list[tuple[Geometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -32,7 +32,7 @@ from rasterio import Affine
 from rasterio.enums import Resampling
 from rasterio.io import DatasetReader
 from rasterio.vrt import WarpedVRT
-from shapely import Geometry
+from shapely.geometry.base import BaseGeometry
 from torch import Tensor
 from torch.utils.data import Dataset
 from torchvision.datasets import ImageFolder
@@ -1031,7 +1031,7 @@ class VectorDataset(GeoDataset):
 
     def _semantic_segmentation_sample(
         self,
-        shapes: list[tuple[Geometry, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1058,7 +1058,7 @@ class VectorDataset(GeoDataset):
 
     def _object_detection_sample(
         self,
-        shapes: list[tuple[Geometry, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1078,8 +1078,7 @@ class VectorDataset(GeoDataset):
             label_list = []
             box_list = []
             for s in shapes:
-                shape = shapely.geometry.shape(s[0])
-                p = convert_poly_coords(shape, transform, inverse=True)
+                p = convert_poly_coords(s[0], transform, inverse=True)
                 p = shapely.clip_by_rect(p, 0, 0, width, height)
 
                 # Get labels
@@ -1101,7 +1100,7 @@ class VectorDataset(GeoDataset):
 
     def _instance_segmentation_sample(
         self,
-        shapes: list[tuple[Geometry, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1122,8 +1121,7 @@ class VectorDataset(GeoDataset):
             box_list = []
             mask_list = []
             for i, s in enumerate(shapes):
-                shape = shapely.geometry.shape(s[0])
-                p = convert_poly_coords(shape, transform, inverse=True)
+                p = convert_poly_coords(s[0], transform, inverse=True)
                 p = shapely.clip_by_rect(p, 0, 0, width, height)
 
                 # Get labels
@@ -1163,7 +1161,7 @@ class VectorDataset(GeoDataset):
 
     def prepare_sample(
         self,
-        shapes: list[tuple[Geometry, np.int32]],
+        shapes: list[tuple[BaseGeometry, np.int32]],
         width: float,
         height: float,
         transform: Affine,
@@ -1241,7 +1239,12 @@ class VectorDataset(GeoDataset):
                 [self.get_label(row) for _, row in src.iterrows()]
             ).astype(np.int32)
 
-            shapes.extend(list(zip(src.geometry, labels)))
+            shapes.extend(
+                [
+                    (shapely.geometry.shape(geom), label)
+                    for geom, label in zip(src.geometry, labels)
+                ]
+            )
 
         # Rasterize geometries
         width = (x.stop - x.start) / x.step


### PR DESCRIPTION
This PR refactors the vector dataset by decoupling sample creation logic from the __getitem__ method. The goal is to make the sampling process more modular and extensible for other potential vector use cases such as keypoint prediction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Resolved documentation configuration issues to properly handle external library type references.

* **Tests**
  * Added test coverage for error handling when invalid task values are used during dataset indexing.

* **Refactor**
  * Improved dataset sample preparation logic for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->