### PR TITLE
Related Libraries: DeepForest has a CLI, switched to Kornia

### DIFF
--- a/docs/user/metrics/features.csv
+++ b/docs/user/metrics/features.csv
@@ -2,7 +2,7 @@ Library,ML Backend,I/O Backend,Spatial Backend,Transform Backend,Datasets,Weight
 `TorchGeo`_,PyTorch,"GDAL, h5py, laspy, NetCDF4, OpenCV, pandas, pillow, scipy, xarray","geopandas, R-tree*",Kornia,141,132,✅,❌,✅,❌,🚧
 `OTB`_,"LibSVM, OpenCV, Shark",GDAL,-,-,0,0,✅,✅,✅,❌,❌
 `TerraTorch`_,PyTorch,"GDAL, h5py, pandas, xarray",-,Albumentations,27,13,✅,❌,✅,❌,🚧
-`DeepForest`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy",R-tree,Albumentations,0,4,❌,❌,❌,❌,❌
+`DeepForest`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy",R-tree,"Kornia, Albumentations*",0,4,✅,❌,❌,❌,❌
 `Raster Vision`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy, xarray",STAC,Albumentations,0,6,✅,❌,✅,✅,🚧
 `samgeo`_,PyTorch,"GDAL, OpenCV, pandas, xarray",geopandas,numpy,0,0,❌,✅,✅,❌,❌
 `spopt`_,scikit-learn,pandas,shapely,numpy,0,0,❌,❌,✅,❌,❌


### PR DESCRIPTION
Noticed a couple changes in the DeepForest 2.1 release: https://github.com/weecology/DeepForest/releases/tag/v2.1.0

- [x] DeepForest has a CLI now (and may have had one for a while)
- [x] DeepForest switched from Albumentations (abandoned) to Kornia

Let us know if there are any other things out of date, and welcome to the Kornia gang! https://torchgeo.readthedocs.io/en/stable/user/alternatives.html

@bw4sz @henrykironde @ethanwhite