### PR TITLE
feat: convert skippd to time-series dataset

### DIFF
--- a/tests/datasets/test_skippd.py
+++ b/tests/datasets/test_skippd.py
@@ -57,7 +57,7 @@ class TestSKIPPD:
         if dataset.task == 'nowcast':
             assert x['image'].shape == (3, 64, 64)
         else:
-            assert x['image'].shape == (48, 64, 64)
+            assert x['image'].shape == (16, 3, 64, 64)
 
     def test_len(self, dataset: SKIPPD) -> None:
         assert len(dataset) == 3

--- a/torchgeo/datasets/skippd.py
+++ b/torchgeo/datasets/skippd.py
@@ -163,10 +163,10 @@ class SKIPPD(NonGeoDataset):
         ) as f:
             arr = f[self.split]['images_log'][index]
 
-        # forecast has dimension [16, 64, 64, 3] but reshape to [48, 64, 64]
+        # forecast has dimension [16, 64, 64, 3] but rearrange to [16, 3, 64, 64]
         # https://github.com/yuhao-nie/Stanford-solar-forecasting-dataset/blob/main/models/SUNSET_forecast.ipynb
         if self.task == 'forecast':
-            arr = rearrange(arr, 't h w c-> (t c) h w')
+            arr = rearrange(arr, 't h w c -> t c h w')
         else:
             arr = rearrange(arr, 'h w c -> c h w')
 
@@ -246,7 +246,7 @@ class SKIPPD(NonGeoDataset):
             image, label = sample['image'].permute(1, 2, 0), sample['label'].item()
         else:
             image, label = (
-                sample['image'].permute(1, 2, 0).reshape(64, 64, 3, 16)[:, :, :, -1],
+                sample['image'][-1].permute(1, 2, 0),
                 sample['label'][-1].item(),
             )
 

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -11,6 +11,7 @@ import segmentation_models_pytorch as smp
 import timm
 import torch
 import torch.nn as nn
+from einops import rearrange
 from matplotlib.figure import Figure
 from torch import Tensor
 from torchmetrics import MeanAbsoluteError, MeanSquaredError, MetricCollection
@@ -161,6 +162,8 @@ class RegressionTask(BaseTask):
             The loss tensor.
         """
         x = batch['image']
+        if x.ndim == 5:
+            x = rearrange(x, 'b t c h w -> b (t c) h w')
         batch_size = x.shape[0]
         # TODO: remove .to(...) once we have a real pixelwise regression dataset
         y = batch[self.target_key].to(torch.float)
@@ -185,6 +188,8 @@ class RegressionTask(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch['image']
+        if x.ndim == 5:
+            x = rearrange(x, 'b t c h w -> b (t c) h w')
         batch_size = x.shape[0]
         # TODO: remove .to(...) once we have a real pixelwise regression dataset
         y = batch[self.target_key].to(torch.float)
@@ -205,12 +210,25 @@ class RegressionTask(BaseTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            aug = K.AugmentationSequential(
-                K.Denormalize(datamodule.mean, datamodule.std),
-                data_keys=None,
-                keepdim=True,
-            )
-            batch = aug(batch)
+            
+            if batch['image'].ndim == 5:
+                B, T, C, H, W = batch['image'].shape
+                batch['image'] = rearrange(batch['image'], 'b t c h w -> b (t c) h w')
+
+                aug = K.AugmentationSequential(
+                    K.Denormalize(datamodule.mean, datamodule.std),
+                    data_keys=None,
+                    keepdim=True,
+                )
+                batch = aug(batch)
+                batch['image'] = rearrange(batch['image'], 'b (t c) h w -> b t c h w', t=T, c=C)
+            else:
+                aug = K.AugmentationSequential(
+                    K.Denormalize(datamodule.mean, datamodule.std),
+                    data_keys=None,
+                    keepdim=True,
+                )
+                batch = aug(batch)
             if self.target_key == 'mask':
                 y = y.squeeze(dim=1)
                 y_hat = y_hat.squeeze(dim=1)
@@ -241,6 +259,8 @@ class RegressionTask(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch['image']
+        if x.ndim == 5:
+            x = rearrange(x, 'b t c h w -> b (t c) h w')
         batch_size = x.shape[0]
         # TODO: remove .to(...) once we have a real pixelwise regression dataset
         y = batch[self.target_key].to(torch.float)
@@ -266,6 +286,8 @@ class RegressionTask(BaseTask):
             Output predicted probabilities.
         """
         x = batch['image']
+        if x.ndim == 5:
+            x = rearrange(x, 'b t c h w -> b (t c) h w')
         y_hat: Tensor = self(x)
         return y_hat
 

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -210,7 +210,7 @@ class RegressionTask(BaseTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            
+
             if batch['image'].ndim == 5:
                 _, T, C, _, _ = batch['image'].shape
                 batch['image'] = rearrange(batch['image'], 'b t c h w -> b (t c) h w')
@@ -221,7 +221,9 @@ class RegressionTask(BaseTask):
                     keepdim=True,
                 )
                 batch = aug(batch)
-                batch['image'] = rearrange(batch['image'], 'b (t c) h w -> b t c h w', t=T, c=C)
+                batch['image'] = rearrange(
+                    batch['image'], 'b (t c) h w -> b t c h w', t=T, c=C
+                )
             else:
                 aug = K.AugmentationSequential(
                     K.Denormalize(datamodule.mean, datamodule.std),

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -212,7 +212,7 @@ class RegressionTask(BaseTask):
             datamodule = self.trainer.datamodule
             
             if batch['image'].ndim == 5:
-                B, T, C, H, W = batch['image'].shape
+                _, T, C, _, _ = batch['image'].shape
                 batch['image'] = rearrange(batch['image'], 'b t c h w -> b (t c) h w')
 
                 aug = K.AugmentationSequential(


### PR DESCRIPTION
Updates SKIPPD to properly format 4D tensors for time series. Also includes support in regression datamodule to flatten the items to pass into model blocks appropriately.