### PR TITLE
Sample: only support Tensor values

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -516,11 +516,8 @@ class TestCollateFunctionsMatchingKeys:
 class TestCollateFunctionsDifferingKeys:
     @pytest.fixture(scope='class')
     @classmethod
-    def samples(cls) -> list[Sample]:
-        return [
-            {'image': torch.tensor([1, 2, 0])},
-            {'mask': torch.tensor([0, 0, 3]), 'other': 5},
-        ]
+    def samples(self) -> list[Sample]:
+        return [{'image': torch.tensor([1, 2, 0])}, {'mask': torch.tensor([0, 0, 3])}]
 
     def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
         sample = stack_samples(samples)

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -74,7 +74,7 @@ Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
 #: * bbox_xyxy: expected output bounding box in (x1, y1, x2, y2) format
 #: * prediction: predicted output
 #:
-#: Values are usually of type torch.Tensor.
+#: Values are of type torch.Tensor.
 Sample: TypeAlias = dict[str, Tensor]  # noqa: UP040
 
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -75,7 +75,7 @@ Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
 #: * prediction: predicted output
 #:
 #: Values are usually of type torch.Tensor.
-Sample: TypeAlias = dict[str, Any]  # noqa: UP040
+Sample: TypeAlias = dict[str, Tensor]  # noqa: UP040
 
 
 @deprecated('Use torchgeo.datasets.utils.GeoSlice or shapely.Polygon instead')
@@ -670,10 +670,7 @@ def stack_samples(samples: Iterable[Sample]) -> Sample:
     uncollated = _list_dict_to_dict_list(samples)
     collated: Sample = {}
     for key, value in uncollated.items():
-        if isinstance(value[0], Tensor):
-            collated[key] = torch.stack(value)
-        else:
-            collated[key] = value
+        collated[key] = torch.stack(value)
     return collated
 
 
@@ -693,10 +690,7 @@ def concat_samples(samples: Iterable[Sample]) -> Sample:
     uncollated = _list_dict_to_dict_list(samples)
     collated = {}
     for key, value in uncollated.items():
-        if isinstance(value[0], Tensor):
-            collated[key] = torch.cat(value)
-        else:
-            collated[key] = value[0]
+        collated[key] = torch.cat(value)
     return collated
 
 
@@ -716,7 +710,7 @@ def merge_samples(samples: Iterable[Sample]) -> Sample:
     collated = {}
     for sample in samples:
         for key, value in sample.items():
-            if key in collated and isinstance(value, Tensor):
+            if key in collated:
                 # Take the maximum so that nodata values (zeros) get replaced
                 # by data values whenever possible
                 collated[key] = torch.maximum(collated[key], value)
@@ -741,10 +735,7 @@ def unbind_samples(sample: Sample) -> list[Sample]:
     """
     uncollated = {}
     for key, values in sample.items():
-        if isinstance(values, Tensor):
-            uncollated[key] = torch.unbind(values)
-        else:
-            uncollated[key] = values
+        uncollated[key] = torch.unbind(values)
     return _dict_list_to_list_dict(uncollated)
 
 

--- a/torchgeo/tasks/detection.py
+++ b/torchgeo/tasks/detection.py
@@ -22,7 +22,7 @@ from torchvision.models.detection.rpn import AnchorGenerator
 from torchvision.ops import MultiScaleRoIAlign, feature_pyramid_network, misc
 
 from ..datamodules import BaseDataModule
-from ..datasets import RGBBandsMissingError, unbind_samples
+from ..datasets import RGBBandsMissingError
 from ..datasets.utils import Sample
 from .base import BaseTask
 from .utils import GeneralizedRCNNTransformNoOp
@@ -290,7 +290,7 @@ class ObjectDetection(BaseTask):
             batch['prediction_label'] = [b['labels'].cpu() for b in y_hat]
             batch['prediction_score'] = [b['scores'].cpu() for b in y_hat]
             batch['image'] = batch['image'].cpu()
-            sample = unbind_samples(batch)[0]
+            sample = {key: value[0] for key, value in batch.items()}
 
             fig: Figure | None = None
             try:

--- a/torchgeo/tasks/instance_segmentation.py
+++ b/torchgeo/tasks/instance_segmentation.py
@@ -16,7 +16,7 @@ from torchvision.models._api import WeightsEnum
 from torchvision.models.detection import maskrcnn_resnet50_fpn
 
 from ..datamodules import BaseDataModule
-from ..datasets import RGBBandsMissingError, unbind_samples
+from ..datasets import RGBBandsMissingError
 from ..datasets.utils import Sample
 from .base import BaseTask
 from .utils import GeneralizedRCNNTransformNoOp
@@ -137,12 +137,15 @@ class InstanceSegmentation(BaseTask):
             The loss tensor.
         """
         x = batch['image']
-        y = {
-            'boxes': batch['bbox_xyxy'],
-            'labels': batch['label'],
-            'masks': batch['mask'],
-        }
-        loss_dict = self(x.unbind(), unbind_samples(y))
+        y = [
+            {
+                'boxes': batch['bbox_xyxy'][i],
+                'labels': batch['label'][i],
+                'masks': batch['mask'][i],
+            }
+            for i in range(len(x))
+        ]
+        loss_dict = self(x.unbind(), y)
         self.log_dict(loss_dict, batch_size=len(x))
         loss: Tensor = sum(loss_dict.values())
         return loss
@@ -158,16 +161,19 @@ class InstanceSegmentation(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch['image']
-        y = {
-            'boxes': batch['bbox_xyxy'],
-            'labels': batch['label'],
-            'masks': batch['mask'],
-        }
+        y = [
+            {
+                'boxes': batch['bbox_xyxy'][i],
+                'labels': batch['label'][i],
+                'masks': batch['mask'][i],
+            }
+            for i in range(len(x))
+        ]
         y_hat = self(x.unbind())
         for pred in y_hat:
             pred['masks'] = (pred['masks'] > 0.5).squeeze(1).to(torch.uint8)
 
-        metrics = self.val_metrics(y_hat, unbind_samples(y))
+        metrics = self.val_metrics(y_hat, y)
 
         # https://github.com/Lightning-AI/torchmetrics/pull/1832#issuecomment-1623890714
         metrics.pop('val_classes', None)
@@ -196,7 +202,7 @@ class InstanceSegmentation(BaseTask):
             batch['prediction_score'] = [pred['scores'].cpu() for pred in y_hat]
             batch['image'] = batch['image'].cpu()
 
-            sample = unbind_samples(batch)[0]
+            sample = {key: value[0] for key, value in batch.items()}
 
             fig: Figure | None = None
             try:
@@ -220,16 +226,19 @@ class InstanceSegmentation(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch['image']
-        y = {
-            'boxes': batch['bbox_xyxy'],
-            'labels': batch['label'],
-            'masks': batch['mask'],
-        }
+        y = [
+            {
+                'boxes': batch['bbox_xyxy'][i],
+                'labels': batch['label'][i],
+                'masks': batch['mask'][i],
+            }
+            for i in range(len(x))
+        ]
         y_hat = self(x.unbind())
         for pred in y_hat:
             pred['masks'] = (pred['masks'] > 0.5).squeeze(1).to(torch.uint8)
 
-        metrics = self.test_metrics(y_hat, unbind_samples(y))
+        metrics = self.test_metrics(y_hat, y)
 
         # https://github.com/Lightning-AI/torchmetrics/pull/1832#issuecomment-1623890714
         metrics.pop('test_classes', None)


### PR DESCRIPTION
See #985 for motivation. With this, we're finally able to check the type of all Sample dictionaries. Only Tensors are supported, ensuring that PyTorch's default collate_fn and Lightning's default transfer_to_device functions work without changes.

Note that `dict[str, Tensor]` is still very open-ended, allowing for keys with any name, dtype, etc. We should really switch to TypedDict in the future and standardize key names as well.

Depends on #3484, #3483, #3481, #3458, #3788

Closes #3783