### PR TITLE
Add descriptions to type aliases

### DIFF
--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -37,11 +37,37 @@ from typing_extensions import deprecated
 
 from .errors import DependencyNotFoundError
 
-# Waiting to upgrade Sphinx before switching to type statement
+#: Slice to index a GeoDataset.
+#:
+#: Can handle several different forms, such as:
+#:
+#: .. code-block:: python
+#:    ds[xmin:xmax:xres, ymin:ymax:yres]
+#:    ds[:, :, tmin:tmax:tres]
+#:    ds[xmin:xmax, ymin:ymax, tmin:tmax]
+#:
+#: All values are optional and will default to the spatiotemporal extent of the dataset.
 GeoSlice: TypeAlias = (  # noqa: UP040
     slice | tuple[slice] | tuple[slice, slice] | tuple[slice, slice, slice]
 )
+
+#: Path-like object.
+#:
+#: Most datasets can handle any kind of path-like object,
+#: and some can support a list of paths.
 Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
+
+#: Sample dictionary returned by a GeoDataset.
+#:
+#: Keys typically follow Kornia constants and include common keys like:
+#:
+#: * image: input image
+#: * mask: expected output semantic segmentation mask
+#: * label: expected output classification or regression label
+#: * bbox_xyxy: expected output bounding box in (x1, y1, x2, y2) format
+#: * prediction: predicted output
+#:
+#: Values are usually of type torch.Tensor.
 Sample: TypeAlias = dict[str, Any]  # noqa: UP040
 
 


### PR DESCRIPTION
I cannot for the life of me figure out how to get Sphinx to actually use these type hints and descriptions correctly, but the descriptions themselves are valuable regardless. Extracts the descriptions out of #3278 and #3450 so we don't lose them. I'll keep hacking on those PRs separately.