### PR TITLE
Contributing: document files to modify when adding new models

### DIFF
--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -172,6 +172,37 @@ A major component of TorchGeo is the large collection of :mod:`torchgeo.datasets
 
 A good way to get started is by looking at some of the existing implementations that are most closely related to the dataset that you are implementing (e.g., if you are implementing a semantic segmentation dataset, looking at the LandCover.ai dataset implementation would be a good starting point).
 
+Models
+------
+
+Pull requests may involve adding new model architectures, new pre-trained model weights, or both.
+
+Model Architectures
+^^^^^^^^^^^^^^^^^^^
+
+The following checklist lists all files that need to be modified to add a new model *architecture*:
+
+* ``torchgeo/models/foo.py``: the actual model code
+* ``torchgeo/models/__init__.py``: the import alias
+* ``torchgeo/models/api.py``: the model loading code
+* ``tests/models/test_foo.py``: the model tests
+* ``tests/models/test_api.py``: the model loading tests
+* ``hubconf.py``: for ``torch.hub`` support
+* ``docs/api/models/foo.rst``: the model documentation
+* ``docs/api/models.rst``: the model table of contents
+
+Model Weights
+^^^^^^^^^^^^^
+
+The following checklist lists all files that need to be modified to add new model *weights*:
+
+* ``torchgeo/models/foo.py``: the actual weight code
+* ``torchgeo/models/__init__.py``: the import alias
+* ``tests/models/test_foo.py``: the weight tests
+* ``docs/api/weights/bar.csv``: the weight documentation
+* ``docs/api/models.rst``: if bar.csv is a new sensor
+
+
 I/O Benchmarking
 ----------------
 


### PR DESCRIPTION
@isaaccorley @piperwolters can you double check this and make sure I didn't miss anything? I didn't include things like pyproject.toml/uv.lock because we don't often add new deps when adding new models.

Pretty sure @calebrob6 was looking for something like this in our contributing docs, we already have one for datasets.