### PR TITLE
CLI Tutorial: use pre-trained weights

### DIFF
--- a/docs/tutorials/cli.ipynb
+++ b/docs/tutorials/cli.ipynb
@@ -164,6 +164,7 @@
     "  class_path: ClassificationTask\n",
     "  init_args:\n",
     "    model: 'resnet18'\n",
+    "    weights: 'ResNet18_Weights.SENTINEL2_ALL_MOCO'\n",
     "    in_channels: 13\n",
     "    num_classes: 10\n",
     "\n",


### PR DESCRIPTION
We use pre-trained weights in our Lightning tutorial, we should also show how to use them in our CLI tutorial.