### PR TITLE
[FIX] regex idx retrieval from filename in inria dataset

### DIFF
--- a/torchgeo/datasets/inria.py
+++ b/torchgeo/datasets/inria.py
@@ -115,7 +115,8 @@ class InriaAerialImageLabeling(NonGeoDataset):
             labels = sorted(labels)
 
             for img, lbl in zip(images, labels):
-                if match := pattern.search(img):
+                fname = os.path.basename(img)
+                if match := pattern.search(fname):
                     idx = int(match.group(2))
                     # For validation, use the first 5 images of every location
                     if self.split == 'train' and idx > 5:


### PR DESCRIPTION
Fixes #3533

regex matching a number somewhere in the path to the data dir instead of the number from the filename, which was the intended behaviour for filenames such as austin10.tif matches "10".