### PR TITLE
[FIX] change augmentation order to improve performance in selected datamodules

### DIFF
--- a/torchgeo/datamodules/agrifieldnet.py
+++ b/torchgeo/datamodules/agrifieldnet.py
@@ -49,10 +49,10 @@ class AgriFieldNetDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/caffe.py
+++ b/torchgeo/datamodules/caffe.py
@@ -40,17 +40,17 @@ class CaFFeDataModule(NonGeoDataModule):
         self.size = size
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.Resize((size, size)),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.Resize((size, size)),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -47,15 +47,15 @@ class DeepGlobeLandCoverDataModule(NonGeoDataModule):
         self.val_split_pct = val_split_pct
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             same_on_batch=True,
         )
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomCrop(self.patch_size, pad_if_needed=True),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/gid15.py
+++ b/torchgeo/datamodules/gid15.py
@@ -49,14 +49,14 @@ class GID15DataModule(NonGeoDataModule):
         self.val_split_pct = val_split_pct
 
         self.train_aug = self.val_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomCrop(self.patch_size, pad_if_needed=True),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
         self.predict_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             same_on_batch=True,

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -49,23 +49,23 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
         self.patch_size = _to_tuple(patch_size)
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
+            K.RandomCrop(self.patch_size, pad_if_needed=True),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
-            K.RandomCrop(self.patch_size, pad_if_needed=True),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             same_on_batch=True,
         )
         self.predict_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             same_on_batch=True,

--- a/torchgeo/datamodules/l8biome.py
+++ b/torchgeo/datamodules/l8biome.py
@@ -49,10 +49,10 @@ class L8BiomeDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/patternnet.py
+++ b/torchgeo/datamodules/patternnet.py
@@ -47,16 +47,16 @@ class PatternNetDataModule(NonGeoDataModule):
         self.test_split_pct = test_split_pct
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.Resize(size=(256, 256)),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
+            K.Resize(size=(256, 256)),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
-            K.Resize(size=(256, 256)),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -49,15 +49,15 @@ class Potsdam2DDataModule(NonGeoDataModule):
         self.val_split_pct = val_split_pct
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             same_on_batch=True,
         )
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomCrop(self.patch_size, pad_if_needed=True),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/reforestree.py
+++ b/torchgeo/datamodules/reforestree.py
@@ -50,17 +50,17 @@ class ReforesTreeDataModule(NonGeoDataModule):
         self.patch_size = _to_tuple(patch_size)
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(self.mean, self.std),
             K.RandomCrop(self.patch_size, pad_if_needed=True),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
+            K.Normalize(self.mean, self.std),
             data_keys=None,
             keepdim=True,
         )
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -36,12 +36,12 @@ class RESISC45DataModule(NonGeoDataModule):
         super().__init__(RESISC45, batch_size, num_workers, **kwargs)
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomRotation(p=0.5, degrees=90),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
             K.RandomSharpness(p=0.5),
             K.RandomErasing(p=0.1),
+            K.Normalize(mean=self.mean, std=self.std),
             K.ColorJitter(p=0.5, brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1),
             data_keys=None,
             keepdim=True,

--- a/torchgeo/datamodules/sentinel2_cdl.py
+++ b/torchgeo/datamodules/sentinel2_cdl.py
@@ -63,10 +63,10 @@ class Sentinel2CDLDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/sentinel2_eurocrops.py
+++ b/torchgeo/datamodules/sentinel2_eurocrops.py
@@ -64,10 +64,10 @@ class Sentinel2EuroCropsDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/sentinel2_nccm.py
+++ b/torchgeo/datamodules/sentinel2_nccm.py
@@ -63,10 +63,10 @@ class Sentinel2NCCMDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/sentinel2_south_america_soybean.py
+++ b/torchgeo/datamodules/sentinel2_south_america_soybean.py
@@ -62,10 +62,10 @@ class Sentinel2SouthAmericaSoybeanDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/solar_plants_brazil.py
+++ b/torchgeo/datamodules/solar_plants_brazil.py
@@ -59,17 +59,17 @@ class SolarPlantsBrazilDataModule(NonGeoDataModule):
         self.std = STD
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomCrop(self.patch_size, pad_if_needed=True),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(size=self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/southafricacroptype.py
+++ b/torchgeo/datamodules/southafricacroptype.py
@@ -49,10 +49,10 @@ class SouthAfricaCropTypeDataModule(GeoDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={

--- a/torchgeo/datamodules/spacenet.py
+++ b/torchgeo/datamodules/spacenet.py
@@ -122,12 +122,12 @@ class SpaceNet1DataModule(SpaceNetBaseDataModule):
         )
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.PadTo((448, 448)),
             K.RandomRotation(p=0.5, degrees=90),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
             K.RandomSharpness(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             K.ColorJitter(p=0.5, brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1),
             data_keys=None,
             keepdim=True,

--- a/torchgeo/datamodules/ssl4eo_benchmark.py
+++ b/torchgeo/datamodules/ssl4eo_benchmark.py
@@ -40,10 +40,10 @@ class SSL4EOLBenchmarkDataModule(NonGeoDataModule):
         self.patch_size = _to_tuple(patch_size)
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomResizedCrop(_to_tuple(self.patch_size), scale=(0.6, 1.0)),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             extra_args={
@@ -51,14 +51,14 @@ class SSL4EOLBenchmarkDataModule(NonGeoDataModule):
             },
         )
         self.val_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
         self.test_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/treesatai.py
+++ b/torchgeo/datamodules/treesatai.py
@@ -91,9 +91,9 @@ class TreeSatAIDataModule(NonGeoDataModule):
         self.sensors = kwargs.get('sensors', TreeSatAI.all_sensors)
 
         self.train_aug = K.AugmentationSequential(
+            K.Resize(self.patch_size),
             K.RandomVerticalFlip(p=0.5),
             K.RandomHorizontalFlip(p=0.5),
-            K.Resize(self.patch_size),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -31,8 +31,8 @@ class UCMercedDataModule(NonGeoDataModule):
         super().__init__(UCMerced, batch_size, num_workers, **kwargs)
 
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.Resize(size=(256, 256)),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -49,14 +49,14 @@ class Vaihingen2DDataModule(NonGeoDataModule):
         self.val_split_pct = val_split_pct
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomCrop(self.patch_size, pad_if_needed=True),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
         )
         self.aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.CenterCrop(self.patch_size),
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=None,
             keepdim=True,
             same_on_batch=True,

--- a/torchgeo/datamodules/vhr10.py
+++ b/torchgeo/datamodules/vhr10.py
@@ -52,10 +52,10 @@ class VHR10DataModule(NonGeoDataModule):
         self.collate_fn = collate_fn_detection
 
         self.train_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std),
             K.RandomHorizontalFlip(),
-            K.ColorJiggle(0.1, 0.1, 0.1, 0.1, p=0.7),
             K.RandomVerticalFlip(),
+            K.Normalize(mean=self.mean, std=self.std),
+            K.ColorJiggle(0.1, 0.1, 0.1, 0.1, p=0.7),
             data_keys=None,
             keepdim=True,
         )


### PR DESCRIPTION
I guess, that the given augmentations in the inria, potsdam and vaihingen datamodules can be swapped to majorly improve performance. The image size is decreased first to reduce the computational cost of all following augmentations and reduce memory footprint ASAP, which is imporrtant for high-resolution image datasets.