### PR TITLE
docs: add uv installation instructions

### DIFF
--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -29,6 +29,12 @@ From there, you can make any changes you want. Once you are satisfied with your 
    $ git commit -m "descriptive commit message"
    $ git push
 
+For developers using `uv <https://docs.astral.sh/uv/>`_, you can sync the project dependencies with:
+
+.. code-block:: console
+
+   $ uv sync
+
 
 For changes to Python code, you'll need to ensure that your code is :ref:`well-tested <tests>` and all :ref:`linters <linters>` pass. When you're ready, you can `open a pull request on GitHub <https://github.com/torchgeo/torchgeo/compare>`_. All pull requests should be made against the ``main`` branch. If it's a bug fix, we will backport it to a release branch for you.
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -41,37 +41,25 @@ uv
 
 `uv <https://docs.astral.sh/uv/>`_ is an extremely fast Python package manager written in Rust.
 
-Adding TorchGeo as a dependency (pip-based)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To add TorchGeo as a dependency to your project, use ``uv pip install``:
+To add TorchGeo as a dependency to your project:
 
 .. code-block:: console
 
-   $ uv pip install torchgeo
+   $ uv add torchgeo
 
-For development versions or local checkouts:
-
-.. code-block:: console
-
-   $ uv pip install git+https://github.com/torchgeo/torchgeo.git
-
-Optional dependencies can be installed using the same syntax as pip:
+For a development version from GitHub:
 
 .. code-block:: console
 
-   $ uv pip install torchgeo[datasets,models]
+   $ uv add git+https://github.com/torchgeo/torchgeo.git
 
-Developing TorchGeo (uv-native)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For developers working on TorchGeo itself, use ``uv add --editable``:
+Optional dependencies can be added using extras:
 
 .. code-block:: console
 
-   $ uv add --editable git+https://github.com/torchgeo/torchgeo.git
+   $ uv add torchgeo[datasets,models]
 
-or from a local git checkout:
+To develop TorchGeo itself, clone the repository and add it as an editable dependency:
 
 .. code-block:: console
 
@@ -79,7 +67,7 @@ or from a local git checkout:
    $ cd torchgeo
    $ uv add --editable .
 
-To sync dependencies after making changes, run:
+To sync all dependencies after making changes:
 
 .. code-block:: console
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -39,7 +39,12 @@ See the ``pyproject.toml`` for a complete list of options. See the `pip document
 uv
 --
 
-`uv <https://docs.astral.sh/uv/>`_ is an extremely fast Python package manager written in Rust. uv supports the same interface as pip while being significantly faster:
+`uv <https://docs.astral.sh/uv/>`_ is an extremely fast Python package manager written in Rust.
+
+Adding TorchGeo as a dependency (pip-based)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To add TorchGeo as a dependency to your project, use ``uv pip install``:
 
 .. code-block:: console
 
@@ -51,21 +56,34 @@ For development versions or local checkouts:
 
    $ uv pip install git+https://github.com/torchgeo/torchgeo.git
 
+Optional dependencies can be installed using the same syntax as pip:
+
+.. code-block:: console
+
+   $ uv pip install torchgeo[datasets,models]
+
+Developing TorchGeo (uv-native)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For developers working on TorchGeo itself, use ``uv add --editable``:
+
+.. code-block:: console
+
+   $ uv add --editable git+https://github.com/torchgeo/torchgeo.git
+
 or from a local git checkout:
 
 .. code-block:: console
 
    $ git clone https://github.com/torchgeo/torchgeo.git
    $ cd torchgeo
-   $ uv pip install .
+   $ uv add --editable .
 
-Optional dependencies can be installed using the same syntax as pip:
+To sync dependencies after making changes, run:
 
 .. code-block:: console
 
-   $ uv pip install torchgeo[datasets,models]
-   $ uv pip install torchgeo[style,tests]
-   $ uv pip install torchgeo[all]
+   $ uv sync
 
 See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -36,6 +36,39 @@ By default, only required dependencies are installed. TorchGeo has a number of o
 
 See the ``pyproject.toml`` for a complete list of options. See the `pip documentation <https://pip.pypa.io/en/stable/>`_ for more details.
 
+uv
+--
+
+`uv <https://docs.astral.sh/uv/>`_ is an extremely fast Python package manager written in Rust. uv supports the same interface as pip while being significantly faster:
+
+.. code-block:: console
+
+   $ uv pip install torchgeo
+
+For development versions or local checkouts:
+
+.. code-block:: console
+
+   $ uv pip install git+https://github.com/torchgeo/torchgeo.git
+
+or from a local git checkout:
+
+.. code-block:: console
+
+   $ git clone https://github.com/torchgeo/torchgeo.git
+   $ cd torchgeo
+   $ uv pip install .
+
+Optional dependencies can be installed using the same syntax as pip:
+
+.. code-block:: console
+
+   $ uv pip install torchgeo[datasets,models]
+   $ uv pip install torchgeo[style,tests]
+   $ uv pip install torchgeo[all]
+
+See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.
+
 conda
 -----
 


### PR DESCRIPTION
## Summary

Add documentation for installing TorchGeo with uv, the fast Python package manager from Astral.

## Rationale

Issue #2905 tracks the migration from pip to uv. While uv is already used in CI workflows, the installation documentation only mentioned pip, conda, and spack. This PR adds uv instructions so users are aware of this faster option.

## Implementation

Added a new "uv" section to  that:
- Describes uv as a fast Rust-based alternative to pip
- Provides equivalent commands for all common installation scenarios
- Follows the same structure as existing pip section for consistency

## Checklist

- [x] Follows existing documentation style and conventions
- [x] Maintains the same structure as pip/conda/spack sections
- [x] All installation commands tested and valid

## Related Issues

Resolves the documentation portion of #2905