### PR TITLE
docs: update Isaac Corley affiliation

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -6,7 +6,7 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | --------------- | ------------- | --------------- |
 | Adam J. Stewart | @adamjstewart | TUM             |
 | Caleb Robinson  | @calebrob6    | Microsoft       |
-| Isaac Corley    | @isaaccorley  | Wherobots       |
+| Isaac Corley    | @isaaccorley  | Taylor Geospatial |
 | Nils Lehmann    | @nilsleh      | TUM             |
 | Ashwin Nair     | @ashnair1     | Space42         |
 

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -2,13 +2,13 @@
 
 This document lists the Maintainers of the Project. Maintainers may be added once approved by the existing maintainers as described in the [Governance document](./GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's policies, including the [code of conduct](https://github.com/torchgeo/governance/blob/main/CODE-OF-CONDUCT.md), [trademark policy](https://github.com/torchgeo/governance/blob/main/TRADEMARKS.md), and [antitrust policy](https://github.com/torchgeo/governance/blob/main/ANTITRUST.md).
 
-| **NAME**        | **Handle**    | **Affiliation** |
-| --------------- | ------------- | --------------- |
-| Adam J. Stewart | @adamjstewart | TUM             |
-| Caleb Robinson  | @calebrob6    | Microsoft       |
+| **NAME**        | **Handle**    | **Affiliation**   |
+| --------------- | ------------- | ----------------- |
+| Adam J. Stewart | @adamjstewart | TUM               |
+| Caleb Robinson  | @calebrob6    | Microsoft         |
 | Isaac Corley    | @isaaccorley  | Taylor Geospatial |
-| Nils Lehmann    | @nilsleh      | TUM             |
-| Ashwin Nair     | @ashnair1     | Space42         |
+| Nils Lehmann    | @nilsleh      | TUM               |
+| Ashwin Nair     | @ashnair1     | Space42           |
 
 ## How to Join
 


### PR DESCRIPTION
Update Isaac Corley's maintainer affiliation in .github/MAINTAINERS.md from Wherobots to Taylor Geospatial.