### PR TITLE
Geospatial Tutorial: fix raster/vector file link

### DIFF
--- a/docs/tutorials/geospatial.ipynb
+++ b/docs/tutorials/geospatial.ipynb
@@ -300,7 +300,7 @@
     "Not all geospatial data is raster data. Many files come in vector format, including points, lines, and polygons.\n",
     "\n",
     "<center>\n",
-    "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Bitmap_VS_SVG.svg/2560px-Bitmap_VS_SVG.svg.png\" width=\"500\">\n",
+    "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Bitmap_VS_SVG.svg/3840px-Bitmap_VS_SVG.svg.png\" width=\"500\">\n",
     "</center>\n",
     "\n",
     "Of course, semantic segmentation requires these polygon masks to be converted to raster masks. This process is called rasterization, and can be performed like so:\n",


### PR DESCRIPTION
Not sure why the link changed, seems like a lot of back and forth copyediting wars on Wikimedia: https://commons.wikimedia.org/wiki/File:Bitmap_VS_SVG.svg