### PR TITLE
Add PR template to gather AI usage disclosure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+
+
+## AI Usage Disclosure
+
+<!-- Check one of the following boxes to help us better review your PR -->
+
+- [ ] 🟢 **No AI usage**: written by humans, for humans
+- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
+- [ ] 🔴 **AI-generated**: AI did everything, review with caution

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-
-
 ## AI Usage Disclosure
 
 <!-- Check one of the following boxes to help us better review your PR -->


### PR DESCRIPTION
While we wait to adopt a formal AI policy at the TorchGeo Organization level, I think one of the less controversial things that most other projects have adopted is AI usage disclosure. This saves maintainers time from guessing whether or not LLMs were used, and helps us prioritize which PRs to review and how to review them.

For example, we may want to consider explicitly banning AI-generated PRs, requiring 2 approving reviews for AI-assisted PRs, etc. We could also consider banning AI for `good-first-issue` or for new contributors. But let's debate these in the next TSC meeting instead of here.

For the sake of my mental health, it is very unlikely that I will be reviewing AI-assisted or AI-generated PRs unless at least one other maintainer has thoroughly reviewed the PR first. Hopefully this will also encourage other maintainers to review; I can't review everything anymore.

P.S. This specific stoplight syntax is coming from Kornia which uses this exact template.