### PR TITLE
add weatherbench2 dataset

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -114,6 +114,11 @@ VectorDataset
 
 .. autoclass:: VectorDataset
 
+XarrayDataset
+^^^^^^^^^^^^^
+
+.. autoclass:: XarrayDataset
+
 NonGeoDataset
 ^^^^^^^^^^^^^
 

--- a/docs/api/datasets/images.csv
+++ b/docs/api/datasets/images.csv
@@ -6,3 +6,4 @@ Dataset,Type,Source,Size (px),Resolution (m),License
 :ref:`OpenAerialMap`,Imagery,Aerial,"256x256 OR 512x512",0.03--50,CC-BY-4.0
 :ref:`PRISMA`,Imagery,PRISMA,512x512,5--30,
 :ref:`Sentinel`,Imagery,Sentinel,"10,000x10,000",10,CC-BY-SA-3.0-IGO
+:ref:`WeatherBench2`,Reanalysis,ECMWF ERA5,"1,440x721x13xT",,CC-BY-4.0

--- a/docs/api/datasets/weatherbench2.rst
+++ b/docs/api/datasets/weatherbench2.rst
@@ -1,0 +1,7 @@
+.. _WeatherBench2:
+
+WeatherBench 2
+==============
+
+.. currentmodule:: torchgeo.datasets
+.. autoclass:: WeatherBench2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,6 +176,7 @@ intersphinx_mapping = {
     'torch': ('https://docs.pytorch.org/docs/stable/', None),
     'torchmetrics': ('https://lightning.ai/docs/torchmetrics/stable/', None),
     'torchvision': ('https://docs.pytorch.org/vision/stable/', None),
+    'xarray': ('https://docs.xarray.dev/en/stable/', None),
 }
 
 # myst-parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ datasets = [
     "webdataset>=0.2.4",
     # xarray 0.17+ required by rioxarray
     "xarray>=0.17",
+    # zarr 2.18+ required for numcodecs 0.13+ compatibility
+    "zarr>=2.18",
 ]
 docs = [
     # ipywidgets 7+ required by nbsphinx

--- a/tests/data/weatherbench/data.py
+++ b/tests/data/weatherbench/data.py
@@ -22,13 +22,21 @@ PERIODS = 4
 LEVELS = (50, 250, 500, 1000)
 
 
-def make_dataset() -> xr.Dataset:
+def make_dataset(
+    start_date: str = '2023-01-01',
+    *,
+    descending_lat: bool = True,
+    descending_lon: bool = False,
+) -> xr.Dataset:
     """Build a synthetic ERA5-like xarray Dataset."""
     rng = np.random.default_rng(0)
-    longitude = np.linspace(0, 359, SIZE).astype(np.float32)
-    # Latitude is descending in WeatherBench2.
-    latitude = np.linspace(90, -90, SIZE).astype(np.float32)
-    time = pd.date_range('2023-01-01', periods=PERIODS, freq='6h')
+    # Latitude is descending in WeatherBench2 by default; flip via flags to
+    # exercise the opposite axis ordering.
+    lon_pair = (359.0, 0.0) if descending_lon else (0.0, 359.0)
+    lat_pair = (90.0, -90.0) if descending_lat else (-90.0, 90.0)
+    longitude = np.linspace(*lon_pair, SIZE).astype(np.float32)
+    latitude = np.linspace(*lat_pair, SIZE).astype(np.float32)
+    time = pd.date_range(start_date, periods=PERIODS, freq='6h')
     level = np.array(LEVELS, dtype=np.int32)
 
     surf_shape = (PERIODS, SIZE, SIZE)
@@ -94,9 +102,17 @@ def make_dataset() -> xr.Dataset:
     return xr.Dataset(data_vars, coords)
 
 
-def main(out: str) -> None:
+def main(
+    out: str,
+    start_date: str = '2023-01-01',
+    *,
+    descending_lat: bool = True,
+    descending_lon: bool = False,
+) -> None:
     """Write the fixture to disk."""
-    make_dataset().to_zarr(out, mode='w')
+    make_dataset(
+        start_date, descending_lat=descending_lat, descending_lon=descending_lon
+    ).to_zarr(out, mode='w')
 
 
 if __name__ == '__main__':

--- a/tests/data/weatherbench2_era5_zarr/data.py
+++ b/tests/data/weatherbench2_era5_zarr/data.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""Generate a tiny WeatherBench2-like ERA5 Zarr fixture for unit tests.
+
+The fixture mirrors the variable layout of the public WeatherBench2 ERA5 store
+(`gs://weatherbench2/datasets/era5/...`) but at a tiny resolution so it is fast
+to read and small enough to commit. We only ship ``data.py`` (not the resulting
+store) because most tests build their own short-lived fixture in ``tmp_path``.
+"""
+
+import argparse
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+SIZE = 8
+PERIODS = 4
+LEVELS = (50, 250, 500, 1000)
+
+
+def make_dataset() -> xr.Dataset:
+    """Build a synthetic ERA5-like xarray Dataset."""
+    rng = np.random.default_rng(0)
+    longitude = np.linspace(0, 359, SIZE).astype(np.float32)
+    # Latitude is descending in WeatherBench2.
+    latitude = np.linspace(90, -90, SIZE).astype(np.float32)
+    time = pd.date_range('2023-01-01', periods=PERIODS, freq='6h')
+    level = np.array(LEVELS, dtype=np.int32)
+
+    surf_shape = (PERIODS, SIZE, SIZE)
+    atmos_shape = (PERIODS, len(level), SIZE, SIZE)
+    static_shape = (SIZE, SIZE)
+
+    data_vars = {
+        '2m_temperature': (
+            ('time', 'latitude', 'longitude'),
+            rng.standard_normal(surf_shape, dtype=np.float32) + 280,
+        ),
+        '10m_u_component_of_wind': (
+            ('time', 'latitude', 'longitude'),
+            rng.standard_normal(surf_shape, dtype=np.float32),
+        ),
+        '10m_v_component_of_wind': (
+            ('time', 'latitude', 'longitude'),
+            rng.standard_normal(surf_shape, dtype=np.float32),
+        ),
+        'mean_sea_level_pressure': (
+            ('time', 'latitude', 'longitude'),
+            rng.standard_normal(surf_shape, dtype=np.float32) * 100 + 101325,
+        ),
+        'temperature': (
+            ('time', 'level', 'latitude', 'longitude'),
+            rng.standard_normal(atmos_shape, dtype=np.float32) + 250,
+        ),
+        'u_component_of_wind': (
+            ('time', 'level', 'latitude', 'longitude'),
+            rng.standard_normal(atmos_shape, dtype=np.float32),
+        ),
+        'v_component_of_wind': (
+            ('time', 'level', 'latitude', 'longitude'),
+            rng.standard_normal(atmos_shape, dtype=np.float32),
+        ),
+        'specific_humidity': (
+            ('time', 'level', 'latitude', 'longitude'),
+            rng.uniform(0, 0.02, atmos_shape).astype(np.float32),
+        ),
+        'geopotential': (
+            ('time', 'level', 'latitude', 'longitude'),
+            rng.standard_normal(atmos_shape, dtype=np.float32) * 100 + 50000,
+        ),
+        'land_sea_mask': (
+            ('latitude', 'longitude'),
+            rng.uniform(0, 1, static_shape).astype(np.float32),
+        ),
+        'soil_type': (
+            ('latitude', 'longitude'),
+            rng.integers(0, 7, static_shape).astype(np.float32),
+        ),
+        'geopotential_at_surface': (
+            ('latitude', 'longitude'),
+            rng.standard_normal(static_shape, dtype=np.float32) * 1000,
+        ),
+    }
+    coords = {
+        'longitude': longitude,
+        'latitude': latitude,
+        'time': time,
+        'level': level,
+    }
+    return xr.Dataset(data_vars, coords)
+
+
+def main(out: str) -> None:
+    """Write the fixture to disk."""
+    make_dataset().to_zarr(out, mode='w')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--out', default='era5.zarr', help='output Zarr path')
+    args = parser.parse_args()
+    main(args.out)

--- a/tests/datasets/test_weatherbench.py
+++ b/tests/datasets/test_weatherbench.py
@@ -1,10 +1,12 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
-import importlib
+import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
 
+import pandas as pd
 import pytest
 import torch
 
@@ -15,18 +17,24 @@ from torchgeo.datasets import DatasetNotFoundError, WeatherBench2
 pytestmark = pytest.mark.enable_socket
 
 
-def _make_store(store: Path) -> Path:
-    """Build a tiny WeatherBench2-like Zarr fixture under *store*."""
+def _load_fixture_module() -> Any:
+    """Load ``tests/data/weatherbench/data.py`` as an importable module."""
     pytest.importorskip('xarray', minversion='0.17')
     pytest.importorskip('zarr', minversion='2.16')
 
-    fixture = Path('tests/data/weatherbench2_era5_zarr/data.py')
+    fixture = Path('tests/data/weatherbench/data.py')
     spec = importlib.util.spec_from_file_location('wb2_data', fixture)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules['wb2_data'] = module
     spec.loader.exec_module(module)
-    module.main(str(store))
+    return module
+
+
+def _make_store(store: Path, **kwargs: Any) -> Path:
+    """Build a tiny WeatherBench2-like Zarr fixture under *store*."""
+    module = _load_fixture_module()
+    module.main(str(store), **kwargs)
     return store
 
 
@@ -74,17 +82,132 @@ class TestWeatherBench2:
         }
 
     def test_directory_path(self, tmp_path: Path) -> None:
-        # Passing the parent directory should also discover the .zarr store.
         _make_store(tmp_path / 'era5.zarr')
         ds = WeatherBench2(tmp_path, data_vars=('2m_temperature',))
         sample = ds[ds.bounds]
         assert isinstance(sample['image'], torch.Tensor)
 
     def test_storage_options_local_zarr(self, store: Path) -> None:
-        # ``storage_options`` is forwarded to ``xarray.open_zarr``; local paths
-        # should ignore an empty mapping.
+        # ``storage_options`` is forwarded to ``xarray.open_zarr`` only for
+        # remote paths; local paths should ignore the mapping entirely.
+        ds = WeatherBench2(store, data_vars=('2m_temperature',), storage_options={})
+        sample = ds[ds.bounds]
+        assert isinstance(sample['image'], torch.Tensor)
+
+    def test_scalar_resolution(self, store: Path) -> None:
+        # Passing ``res`` as a scalar should be normalized to ``(res, res)``
+        # by both :meth:`__init__` and :meth:`_spatial_metadata`.
+        ds = WeatherBench2(store, res=0.5, data_vars=('2m_temperature',))
+        assert ds.res == (0.5, 0.5)
+
+    def test_skips_unreadable_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_store(tmp_path / 'good.zarr')
+        bad = tmp_path / 'bad.zarr'
+        bad.mkdir()
+
+        xr = pytest.importorskip('xarray')
+        real_open_zarr = xr.open_zarr
+
+        def fake_open_zarr(path: Any, **kwargs: Any) -> Any:
+            if 'bad.zarr' in str(path):
+                raise OSError('cannot read store')
+            return real_open_zarr(path, **kwargs)
+
+        monkeypatch.setattr(xr, 'open_zarr', fake_open_zarr)
+
+        ds = WeatherBench2(tmp_path, data_vars=('2m_temperature',))
+        assert len(ds.index) == 1
+        assert ds.index.iloc[0]['filepath'].endswith('good.zarr')
+
+    def test_index_error_outside_time_range(self, store: Path) -> None:
+        ds = WeatherBench2(store, data_vars=('2m_temperature',))
+        x, y, _ = ds.bounds
+        far_future = slice(pd.Timestamp('2050-01-01'), pd.Timestamp('2050-01-02'))
+        with pytest.raises(IndexError, match='not found in dataset'):
+            ds[x, y, far_future]
+
+    def test_transforms_applied(self, store: Path) -> None:
+        sentinel: dict[str, Any] = {'tagged': True}
+
+        def transform(sample: dict[str, Any]) -> dict[str, Any]:
+            return {**sample, **sentinel}
+
+        ds = WeatherBench2(store, data_vars=('2m_temperature',), transforms=transform)
+        sample = ds[ds.bounds]
+        assert sample['tagged'] is True
+
+    def test_unknown_variable_skipped(self, store: Path) -> None:
+        ds = WeatherBench2(store, data_vars=('2m_temperature', 'does_not_exist'))
+        sample = ds[ds.bounds]
+        assert set(sample['variables']) == {'2m_temperature'}
+
+    def test_ascending_latitude(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path / 'era5.zarr', descending_lat=False)
+        ds = WeatherBench2(store, data_vars=('2m_temperature',))
+        sample = ds[ds.bounds]
+        assert sample['lat'][0].item() < sample['lat'][-1].item()
+
+    def test_descending_longitude(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path / 'era5.zarr', descending_lon=True)
+        ds = WeatherBench2(store, data_vars=('2m_temperature',))
+        sample = ds[ds.bounds]
+        assert sample['lon'][0].item() > sample['lon'][-1].item()
+
+    def test_multi_store_concat(self, tmp_path: Path) -> None:
+        _make_store(tmp_path / 'a.zarr', start_date='2023-01-01')
+        _make_store(tmp_path / 'b.zarr', start_date='2023-02-01')
+        ds = WeatherBench2(tmp_path, data_vars=('2m_temperature',))
+        sample = ds[ds.bounds]
+        # Both stores contribute their PERIODS=4 timestamps after concat.
+        assert len(sample['time']) == 8
+
+    def test_paths_as_list(self, tmp_path: Path) -> None:
+        a = _make_store(tmp_path / 'a.zarr', start_date='2023-01-01')
+        b = _make_store(tmp_path / 'b.zarr', start_date='2023-02-01')
+        ds = WeatherBench2([a, b], data_vars=('2m_temperature',))
+        assert len(ds.index) == 2
+
+    def test_open_xarray_default_module(self, store: Path) -> None:
+        with WeatherBench2._open_xarray(str(store)) as opened:
+            assert '2m_temperature' in opened.data_vars
+
+    def test_spatial_metadata_missing_coords(self) -> None:
+        xr = pytest.importorskip('xarray')
+        empty = xr.Dataset()
+        with pytest.raises(ValueError, match='missing longitude'):
+            WeatherBench2._spatial_metadata(empty, None, None)
+
+    def test_spatial_metadata_too_few_coords(self) -> None:
+        xr = pytest.importorskip('xarray')
+        sparse = xr.Dataset(coords={'longitude': [0.0], 'latitude': [0.0]})
+        with pytest.raises(ValueError, match='fewer than 2'):
+            WeatherBench2._spatial_metadata(sparse, None, None)
+
+    def test_remote_uri(self, store: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Stand-in for a public WeatherBench2 store on GCS: the dataset
+        # should treat ``gs://`` as opaque and forward ``storage_options``
+        # to :func:`xarray.open_zarr`.
+        pytest.importorskip('fsspec')
+        pytest.importorskip('gcsfs')
+        xr = pytest.importorskip('xarray')
+
+        real_open_zarr = xr.open_zarr
+        captured: dict[str, Any] = {}
+
+        def fake_open_zarr(path: Any, **kwargs: Any) -> Any:
+            captured.setdefault('paths', []).append(str(path))
+            captured['kwargs'] = kwargs
+            return real_open_zarr(str(store))
+
+        monkeypatch.setattr(xr, 'open_zarr', fake_open_zarr)
+
+        remote = 'gs://fake-bucket/era5.zarr'
         ds = WeatherBench2(
-            store, data_vars=('2m_temperature',), storage_options={}
+            remote, data_vars=('2m_temperature',), storage_options={'token': 'anon'}
         )
+        assert ds.files == [remote]
+        assert captured['kwargs'].get('storage_options') == {'token': 'anon'}
         sample = ds[ds.bounds]
         assert isinstance(sample['image'], torch.Tensor)

--- a/tests/datasets/test_weatherbench.py
+++ b/tests/datasets/test_weatherbench.py
@@ -191,10 +191,20 @@ class TestWeatherBench2:
     def test_remote_uri(self, store: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # Stand-in for a public WeatherBench2 store on GCS: the dataset
         # should treat ``gs://`` as opaque and forward ``storage_options``
-        # to :func:`xarray.open_zarr`.
-        pytest.importorskip('fsspec')
-        pytest.importorskip('gcsfs')
+        # to ``xarray.open_zarr``. Stub out the fsspec/gcsfs guard so the
+        # test runs even when those packages are not installed.
         import xarray as xr
+
+        from torchgeo.datasets import utils, weatherbench
+
+        real_lazy_import = utils.lazy_import
+
+        def stub_lazy_import(name: str) -> Any:
+            if name in {'fsspec', 'gcsfs'}:
+                return None
+            return real_lazy_import(name)
+
+        monkeypatch.setattr(weatherbench, 'lazy_import', stub_lazy_import)
 
         real_open_zarr = xr.open_zarr
         captured: dict[str, Any] = {}

--- a/tests/datasets/test_weatherbench.py
+++ b/tests/datasets/test_weatherbench.py
@@ -12,6 +12,9 @@ import torch
 
 from torchgeo.datasets import DatasetNotFoundError, WeatherBench2
 
+pytest.importorskip('xarray', minversion='0.17')
+pytest.importorskip('zarr', minversion='2.18')
+
 # zarr v3 uses asyncio internally, which creates local Unix sockets.
 # Re-enable sockets for this module so --disable-socket doesn't block it.
 pytestmark = pytest.mark.enable_socket
@@ -19,9 +22,6 @@ pytestmark = pytest.mark.enable_socket
 
 def _load_fixture_module() -> Any:
     """Load ``tests/data/weatherbench/data.py`` as an importable module."""
-    pytest.importorskip('xarray', minversion='0.17')
-    pytest.importorskip('zarr', minversion='2.16')
-
     fixture = Path('tests/data/weatherbench/data.py')
     spec = importlib.util.spec_from_file_location('wb2_data', fixture)
     assert spec is not None and spec.loader is not None
@@ -103,11 +103,12 @@ class TestWeatherBench2:
     def test_skips_unreadable_store(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        import xarray as xr
+
         _make_store(tmp_path / 'good.zarr')
         bad = tmp_path / 'bad.zarr'
         bad.mkdir()
 
-        xr = pytest.importorskip('xarray')
         real_open_zarr = xr.open_zarr
 
         def fake_open_zarr(path: Any, **kwargs: Any) -> Any:
@@ -174,13 +175,15 @@ class TestWeatherBench2:
             assert '2m_temperature' in opened.data_vars
 
     def test_spatial_metadata_missing_coords(self) -> None:
-        xr = pytest.importorskip('xarray')
+        import xarray as xr
+
         empty = xr.Dataset()
         with pytest.raises(ValueError, match='missing longitude'):
             WeatherBench2._spatial_metadata(empty, None, None)
 
     def test_spatial_metadata_too_few_coords(self) -> None:
-        xr = pytest.importorskip('xarray')
+        import xarray as xr
+
         sparse = xr.Dataset(coords={'longitude': [0.0], 'latitude': [0.0]})
         with pytest.raises(ValueError, match='fewer than 2'):
             WeatherBench2._spatial_metadata(sparse, None, None)
@@ -191,7 +194,7 @@ class TestWeatherBench2:
         # to :func:`xarray.open_zarr`.
         pytest.importorskip('fsspec')
         pytest.importorskip('gcsfs')
-        xr = pytest.importorskip('xarray')
+        import xarray as xr
 
         real_open_zarr = xr.open_zarr
         captured: dict[str, Any] = {}

--- a/tests/datasets/test_weatherbench.py
+++ b/tests/datasets/test_weatherbench.py
@@ -1,0 +1,90 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from torchgeo.datasets import DatasetNotFoundError, WeatherBench2
+
+# zarr v3 uses asyncio internally, which creates local Unix sockets.
+# Re-enable sockets for this module so --disable-socket doesn't block it.
+pytestmark = pytest.mark.enable_socket
+
+
+def _make_store(store: Path) -> Path:
+    """Build a tiny WeatherBench2-like Zarr fixture under *store*."""
+    pytest.importorskip('xarray', minversion='0.17')
+    pytest.importorskip('zarr', minversion='2.16')
+
+    fixture = Path('tests/data/weatherbench2_era5_zarr/data.py')
+    spec = importlib.util.spec_from_file_location('wb2_data', fixture)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['wb2_data'] = module
+    spec.loader.exec_module(module)
+    module.main(str(store))
+    return store
+
+
+class TestWeatherBench2:
+    @pytest.fixture
+    def store(self, tmp_path: Path) -> Path:
+        return _make_store(tmp_path / 'era5.zarr')
+
+    def test_no_data(self, tmp_path: Path) -> None:
+        with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
+            WeatherBench2(tmp_path / 'missing.zarr')
+
+    def test_getitem(self, store: Path) -> None:
+        ds = WeatherBench2(store, data_vars=('2m_temperature',))
+        sample = ds[ds.bounds]
+        assert isinstance(sample, dict)
+        assert isinstance(sample['image'], torch.Tensor)
+        assert sample['image'].shape[0] == 1
+        assert sample['lat'].ndim == 1
+        assert sample['lon'].ndim == 1
+        assert isinstance(sample['time'], tuple)
+
+    def test_variable_ordering(self, store: Path) -> None:
+        order = ('2m_temperature', '10m_u_component_of_wind')
+        ds = WeatherBench2(store, data_vars=order)
+        sample = ds[ds.bounds]
+        assert tuple(sample['variables'].keys()) == order
+        assert sample['image'].shape[0] == len(order)
+
+    def test_atmos_levels(self, store: Path) -> None:
+        ds = WeatherBench2(store, data_vars=('temperature',))
+        sample = ds[ds.bounds]
+        assert sample['atmos_levels'] == (50.0, 250.0, 500.0, 1000.0)
+
+    def test_image_omitted_for_mixed_shapes(self, store: Path) -> None:
+        ds = WeatherBench2(
+            store, data_vars=('2m_temperature', 'temperature', 'land_sea_mask')
+        )
+        sample = ds[ds.bounds]
+        assert 'image' not in sample
+        assert set(sample['variables']) == {
+            '2m_temperature',
+            'temperature',
+            'land_sea_mask',
+        }
+
+    def test_directory_path(self, tmp_path: Path) -> None:
+        # Passing the parent directory should also discover the .zarr store.
+        _make_store(tmp_path / 'era5.zarr')
+        ds = WeatherBench2(tmp_path, data_vars=('2m_temperature',))
+        sample = ds[ds.bounds]
+        assert isinstance(sample['image'], torch.Tensor)
+
+    def test_storage_options_local_zarr(self, store: Path) -> None:
+        # ``storage_options`` is forwarded to ``xarray.open_zarr``; local paths
+        # should ignore an empty mapping.
+        ds = WeatherBench2(
+            store, data_vars=('2m_temperature',), storage_options={}
+        )
+        sample = ds[ds.bounds]
+        assert isinstance(sample['image'], torch.Tensor)

--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -188,6 +188,7 @@ from .utils import (
 )
 from .vaihingen import Vaihingen2D
 from .vhr10 import VHR10
+from .weatherbench import WeatherBench2
 from .western_usa_live_fuel_moisture import WesternUSALiveFuelMoisture
 from .xbd import XView2, xBD
 from .zuericrop import ZueriCrop
@@ -372,6 +373,7 @@ __all__ = (
     'UnionDataset',
     'Vaihingen2D',
     'VectorDataset',
+    'WeatherBench2',
     'WesternUSALiveFuelMoisture',
     'XView2',
     'XarrayDataset',

--- a/torchgeo/datasets/weatherbench.py
+++ b/torchgeo/datasets/weatherbench.py
@@ -55,10 +55,9 @@ class WeatherBench2(XarrayDataset):
     Each sample contains:
 
     * ``image``: tensor stacked from the requested ``data_vars`` in order, only
-      populated when all selected variables share the same shape (the
-      :class:`~torchgeo.datasets.XarrayDataset` contract). When mixing surface,
-      pressure-level, and static variables, this key is omitted; consume
-      ``variables`` instead.
+      populated when all selected variables share the same shape. When mixing
+      surface, pressure-level, and static variables, this key is omitted;
+      consume ``variables`` instead.
     * ``variables``: mapping from variable name to its tensor, with the
       original (possibly heterogeneous) per-variable shape preserved.
     * ``lat`` / ``lon``: 1-D coordinate tensors for the spatial slice.
@@ -149,11 +148,10 @@ class WeatherBench2(XarrayDataset):
         if not filepaths:
             raise DatasetNotFoundError(self)
 
-        # ``res`` is set inside the loop above (a missing value would have
-        # raised :class:`DatasetNotFoundError`), so it must be defined here.
-        assert res is not None
-        if isinstance(res, int | float):
-            res = (float(res), float(res))
+        # ``res`` is normalized to a tuple inside :meth:`_spatial_metadata`
+        # and a missing value would have raised :class:`DatasetNotFoundError`,
+        # so it must be a populated tuple here.
+        assert isinstance(res, tuple)
         self._res = res
         self.data_vars = list(data_vars) if data_vars is not None else []
         self.index = GeoDataFrame(

--- a/torchgeo/datasets/weatherbench.py
+++ b/torchgeo/datasets/weatherbench.py
@@ -7,7 +7,7 @@ import glob
 import os
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import nullcontext
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -83,7 +83,7 @@ class WeatherBench2(XarrayDataset):
     .. _fsspec: https://filesystem-spec.readthedocs.io/
     .. _gcsfs: https://gcsfs.readthedocs.io/
 
-    .. versionadded:: 0.8
+    .. versionadded:: 0.10
     """
 
     filename_glob = '*.zarr'
@@ -149,6 +149,9 @@ class WeatherBench2(XarrayDataset):
         if not filepaths:
             raise DatasetNotFoundError(self)
 
+        # ``res`` is set inside the loop above (a missing value would have
+        # raised :class:`DatasetNotFoundError`), so it must be defined here.
+        assert res is not None
         if isinstance(res, int | float):
             res = (float(res), float(res))
         self._res = res
@@ -174,7 +177,7 @@ class WeatherBench2(XarrayDataset):
             All Zarr stores in the dataset.
         """
         if isinstance(self.paths, str | os.PathLike):
-            paths: Iterable[Path] = [self.paths]
+            paths: Iterable[Path] = [cast(Path, self.paths)]
         else:
             paths = self.paths
 
@@ -233,9 +236,9 @@ class WeatherBench2(XarrayDataset):
                 [x.step, 0.0, x.start, 0.0, -y.step, y.stop, 0.0, 0.0, 1.0]
             ).reshape(3, 3),
         }
-        # Only populate ``image`` when variables are stackable (homogeneous
-        # shape). For mixed surface/pressure-level/static variables, callers
-        # should use ``variables`` directly (e.g. Aurora's structured Batch).
+        # Only populate ``image`` when all selected variables share a shape;
+        # mixed surface/pressure-level/static variables cannot be stacked, so
+        # callers should consume ``variables`` directly in that case.
         shapes = {tuple(v.shape) for v in variables.values()}
         if len(shapes) == 1:
             sample['image'] = torch.stack(list(variables.values()))
@@ -335,7 +338,13 @@ class WeatherBench2(XarrayDataset):
             for ctx in contexts[1:]:
                 with ctx as more:
                     srcs.append(more)
-            ds = srcs[0] if len(srcs) == 1 else xr.concat(srcs, dim='time')
+            # Pin ``data_vars='all'`` so we stay compatible with both the
+            # current xarray default and the upcoming change to ``None``.
+            ds = (
+                srcs[0]
+                if len(srcs) == 1
+                else xr.concat(srcs, dim='time', data_vars='all')
+            )
 
             lon_name, lat_name = self._coord_names(ds)
             lat_vals = np.asarray(ds[lat_name].values, dtype=float)

--- a/torchgeo/datasets/weatherbench.py
+++ b/torchgeo/datasets/weatherbench.py
@@ -1,0 +1,374 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""WeatherBench 2 dataset."""
+
+import glob
+import os
+from collections.abc import Callable, Iterable, Sequence
+from contextlib import nullcontext
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import shapely
+import torch
+from geopandas import GeoDataFrame
+from pyproj import CRS
+from torch import Tensor
+
+from .errors import DatasetNotFoundError
+from .geo import XarrayDataset
+from .utils import GeoSlice, Path, Sample, lazy_import
+
+
+class WeatherBench2(XarrayDataset):
+    """WeatherBench 2 dataset.
+
+    `WeatherBench <https://sites.research.google/gr/weatherbench/>`__ is an open
+    framework for evaluating ML and physics-based weather forecasting models in a
+    like-for-like fashion.
+
+    This data loader supports several publicly available, cloud-optimized ground-truth
+    and baseline `datasets
+    <https://weatherbench2.readthedocs.io/en/latest/data-guide.html>`__,
+    including a comprehensive copy of the
+    `ERA5 <https://rmets.onlinelibrary.wiley.com/doi/full/10.1002/qj.3803>`__
+    dataset used for training most ML models.
+
+    Stores are read with :func:`xarray.open_zarr`, which supports both local Zarr
+    directories and remote object stores (e.g. ``gs://weatherbench2/...``) via
+    `fsspec`_ and `gcsfs`_. ``paths`` may therefore be:
+
+    * a single local ``*.zarr`` directory,
+    * a directory containing one or more ``*.zarr`` stores,
+    * a ``gs://`` (or other ``://``) URI pointing at a public Zarr store.
+
+    For **public** ``gs://`` buckets (such as WeatherBench2 on GCS), pass
+    ``storage_options={'token': 'anon'}`` when you do not have Google
+    Application Default Credentials
+
+    See the
+    `documentation <https://weatherbench2.readthedocs.io/en/latest/data-guide.html>`__
+    for more information on data availability.
+
+    Each sample contains:
+
+    * ``image``: tensor stacked from the requested ``data_vars`` in order, only
+      populated when all selected variables share the same shape (the
+      :class:`~torchgeo.datasets.XarrayDataset` contract). When mixing surface,
+      pressure-level, and static variables, this key is omitted; consume
+      ``variables`` instead.
+    * ``variables``: mapping from variable name to its tensor, with the
+      original (possibly heterogeneous) per-variable shape preserved.
+    * ``lat`` / ``lon``: 1-D coordinate tensors for the spatial slice.
+    * ``time``: tuple of selected timestamps.
+    * ``atmos_levels``: tuple of pressure levels if any were selected.
+    * ``bounds`` and ``transform``: standard TorchGeo metadata used by
+      :class:`~torchgeo.datasets.GeoDataset`.
+
+    .. note::
+
+       This dataset requires the following additional libraries to be installed:
+
+       * `xarray <https://pypi.org/project/xarray/>`_
+       * `zarr <https://pypi.org/project/zarr/>`_
+       * `fsspec <https://pypi.org/project/fsspec/>`_
+       * `gcsfs <https://pypi.org/project/gcsfs/>`_ (only for ``gs://`` paths)
+
+    If you use this dataset in your research, please cite the following paper:
+
+    * https://arxiv.org/abs/2308.15560
+
+    .. _fsspec: https://filesystem-spec.readthedocs.io/
+    .. _gcsfs: https://gcsfs.readthedocs.io/
+
+    .. versionadded:: 0.8
+    """
+
+    filename_glob = '*.zarr'
+
+    def __init__(
+        self,
+        paths: Path | Iterable[Path] = 'data',
+        crs: CRS | None = None,
+        res: float | tuple[float, float] | None = None,
+        data_vars: Sequence[str] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
+        storage_options: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize a new WeatherBench2 instance.
+
+        Args:
+            paths: a local Zarr store, a directory containing Zarr stores, or a
+                remote URI (``gs://...``) pointing to a Zarr store.
+            crs: :term:`coordinate reference system (CRS)` to assume for the
+                store (defaults to ``EPSG:4326``, which matches WeatherBench2).
+            res: resolution of the store in degrees, as a single value or
+                ``(xres, yres)`` tuple. Inferred from ``longitude``/``latitude``
+                coordinates when omitted.
+            data_vars: list of variable names to load. Defaults to all
+                ``data_vars`` of the first store found.
+            transforms: a function/transform that takes an input sample and
+                returns a transformed version.
+            storage_options: optional keyword arguments forwarded to
+                :func:`xarray.open_zarr` (for example ``{'token': 'anon'}`` for
+                public GCS data without Application Default Credentials).
+
+        Raises:
+            DatasetNotFoundError: If no Zarr stores are found at *paths*.
+            DependencyNotFoundError: If xarray/zarr is not installed.
+        """
+        xr = lazy_import('xarray')
+        lazy_import('zarr')
+        self.paths = paths
+        self.transforms = transforms
+        self.storage_options = storage_options
+
+        filepaths: list[str] = []
+        datetimes: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+        geometries: list[shapely.Polygon] = []
+        for filepath in self.files:
+            try:
+                with self._open_xarray(
+                    filepath, xr, storage_options=self.storage_options
+                ) as src:
+                    _crs, _res, _bounds = self._spatial_metadata(src, crs, res)
+                    crs, res = _crs, _res
+                    data_vars = data_vars or list(src.data_vars.keys())
+                    tmin = pd.Timestamp(src.time.values.min())
+                    tmax = pd.Timestamp(src.time.values.max())
+                    filepaths.append(filepath)
+                    datetimes.append((tmin, tmax))
+                    geometries.append(shapely.box(*_bounds))
+            except (OSError, ValueError):
+                # Skip stores that xarray is unable to read or that are missing
+                # the spatial/temporal coordinates we rely on.
+                continue
+
+        if not filepaths:
+            raise DatasetNotFoundError(self)
+
+        if isinstance(res, int | float):
+            res = (float(res), float(res))
+        self._res = res
+        self.data_vars = list(data_vars) if data_vars is not None else []
+        self.index = GeoDataFrame(
+            {'filepath': filepaths},
+            index=pd.IntervalIndex.from_tuples(
+                datetimes, closed='both', name='datetime'
+            ),
+            geometry=geometries,
+            crs=crs,
+        )
+
+    @property
+    def files(self) -> list[str]:
+        """A list of all Zarr stores in the dataset.
+
+        Unlike :attr:`~torchgeo.datasets.GeoDataset.files`, this implementation
+        treats ``*.zarr`` directories as opaque stores instead of descending into
+        them, and accepts remote ``gs://`` URIs.
+
+        Returns:
+            All Zarr stores in the dataset.
+        """
+        if isinstance(self.paths, str | os.PathLike):
+            paths: Iterable[Path] = [self.paths]
+        else:
+            paths = self.paths
+
+        files: set[str] = set()
+        for path in paths:
+            spath = str(path)
+            if '://' in spath:
+                # Remote URI (e.g. gs://...).
+                files.add(spath)
+            elif os.path.isdir(spath) and spath.endswith('.zarr'):
+                files.add(spath)
+            elif os.path.isdir(spath):
+                pattern = os.path.join(spath, '**', self.filename_glob)
+                files |= set(glob.iglob(pattern, recursive=True))
+        return sorted(files)
+
+    def __getitem__(self, index: GeoSlice) -> Sample:
+        """Retrieve a sample for a spatiotemporal slice.
+
+        Args:
+            index: ``[xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres]`` slice.
+
+        Returns:
+            Sample dict described in the class docstring.
+
+        Raises:
+            IndexError: If *index* is not found in the dataset.
+        """
+        xr = lazy_import('xarray')
+
+        x, y, t = self._disambiguate_slice(index)
+        interval = pd.Interval(t.start, t.stop)
+        df = self.index.iloc[self.index.index.overlaps(interval)]
+        df = df.iloc[:: t.step]
+        df = df.cx[x.start : x.stop, y.start : y.stop]
+
+        if df.empty:
+            raise IndexError(
+                f'index: {index} not found in dataset with bounds: {self.bounds}'
+            )
+
+        ds, lon_name, lat_name, levels = self._open_and_slice(df.filepath, index, xr)
+        variables = self._dataset_to_tensors(ds)
+        lat = torch.as_tensor(np.asarray(ds[lat_name].values, dtype=float))
+        lon = torch.as_tensor(np.asarray(ds[lon_name].values, dtype=float))
+        time = tuple(pd.Timestamp(v) for v in np.atleast_1d(ds.time.values))
+
+        sample: Sample = {
+            'bounds': self._slice_to_tensor(index),
+            'variables': variables,
+            'lat': lat,
+            'lon': lon,
+            'time': time,
+            'atmos_levels': levels,
+            'transform': torch.tensor(
+                [x.step, 0.0, x.start, 0.0, -y.step, y.stop, 0.0, 0.0, 1.0]
+            ).reshape(3, 3),
+        }
+        # Only populate ``image`` when variables are stackable (homogeneous
+        # shape). For mixed surface/pressure-level/static variables, callers
+        # should use ``variables`` directly (e.g. Aurora's structured Batch).
+        shapes = {tuple(v.shape) for v in variables.values()}
+        if len(shapes) == 1:
+            sample['image'] = torch.stack(list(variables.values()))
+        if self.transforms is not None:
+            sample = self.transforms(sample)
+        return sample
+
+    @staticmethod
+    def _open_xarray(
+        path: str, xr: Any | None = None, storage_options: dict[str, Any] | None = None
+    ) -> Any:
+        """Open a Zarr store as an :class:`xarray.Dataset`.
+
+        Lazy-imports :mod:`fsspec` and :mod:`gcsfs` for ``gs://`` paths so the
+        dependency is only required when remote streaming is actually used.
+
+        Args:
+            path: local Zarr directory or ``gs://`` URI.
+            xr: optional cached ``xarray`` module (avoids re-importing).
+            storage_options: optional arguments for :func:`xarray.open_zarr`
+                (passed to ``fsspec`` / ``gcsfs`` for remote stores).
+
+        Returns:
+            A context manager yielding the opened :class:`xarray.Dataset`.
+        """
+        if xr is None:
+            xr = lazy_import('xarray')
+        is_remote = '://' in str(path)
+        if is_remote:
+            lazy_import('fsspec')
+            if str(path).startswith('gs://'):
+                lazy_import('gcsfs')
+        open_kw: dict[str, Any] = {}
+        if storage_options is not None and is_remote:
+            open_kw['storage_options'] = storage_options
+        ds = xr.open_zarr(path, **open_kw)
+        return nullcontext(ds)
+
+    @staticmethod
+    def _coord_names(src: Any) -> tuple[str, str]:
+        """Return the names of the longitude and latitude coordinates."""
+        lon_name = next(
+            (n for n in ('longitude', 'lon') if n in src.coords), 'longitude'
+        )
+        lat_name = next((n for n in ('latitude', 'lat') if n in src.coords), 'latitude')
+        return lon_name, lat_name
+
+    @classmethod
+    def _spatial_metadata(
+        cls, src: Any, crs: CRS | None, res: float | tuple[float, float] | None
+    ) -> tuple[CRS, tuple[float, float], tuple[float, float, float, float]]:
+        """Infer CRS, resolution, and bounds from ``latitude``/``longitude`` coords.
+
+        WeatherBench2 stores are tagged in plain ``EPSG:4326`` and do not carry
+        ``rioxarray`` metadata. We therefore default to ``EPSG:4326`` and infer
+        resolution and bounds from the coordinate arrays.
+        """
+        lon_name, lat_name = cls._coord_names(src)
+        if lon_name not in src.coords or lat_name not in src.coords:
+            raise ValueError('Store is missing longitude/latitude coordinates.')
+
+        lon = np.asarray(src[lon_name].values, dtype=float)
+        lat = np.asarray(src[lat_name].values, dtype=float)
+        if lon.size < 2 or lat.size < 2:
+            raise ValueError('Store has fewer than 2 longitude/latitude values.')
+
+        if res is None:
+            xres = float(abs(lon[1] - lon[0]))
+            yres = float(abs(lat[1] - lat[0]))
+            res = (xres, yres)
+        elif isinstance(res, int | float):
+            res = (float(res), float(res))
+
+        xmin, xmax = float(lon.min()), float(lon.max())
+        ymin, ymax = float(lat.min()), float(lat.max())
+        return crs or CRS.from_epsg(4326), res, (xmin, ymin, xmax, ymax)
+
+    def _open_and_slice(
+        self, filepaths: Sequence[str], index: GeoSlice, xr: Any
+    ) -> tuple[Any, str, str, tuple[float, ...]]:
+        """Open the matching Zarr stores and apply a coordinate slice.
+
+        Returns:
+            ``(dataset, lon_name, lat_name, levels)`` where ``levels`` is the
+            tuple of pressure levels in the slice (empty if not present).
+        """
+        x, y, t = self._disambiguate_slice(index)
+
+        # WeatherBench2 ships as a single store in practice. Concatenate along
+        # the existing time dimension when more than one store is selected.
+        contexts = [
+            self._open_xarray(fp, xr, storage_options=self.storage_options)
+            for fp in filepaths
+        ]
+        with contexts[0] as first:
+            srcs = [first]
+            for ctx in contexts[1:]:
+                with ctx as more:
+                    srcs.append(more)
+            ds = srcs[0] if len(srcs) == 1 else xr.concat(srcs, dim='time')
+
+            lon_name, lat_name = self._coord_names(ds)
+            lat_vals = np.asarray(ds[lat_name].values, dtype=float)
+            lon_vals = np.asarray(ds[lon_name].values, dtype=float)
+
+            # Latitude is often stored in descending order in WeatherBench2.
+            lat_slice = (
+                slice(y.stop, y.start)
+                if lat_vals[0] > lat_vals[-1]
+                else slice(y.start, y.stop)
+            )
+            lon_slice = (
+                slice(x.stop, x.start)
+                if lon_vals[0] > lon_vals[-1]
+                else slice(x.start, x.stop)
+            )
+
+            ds = ds.sel({lon_name: lon_slice, lat_name: lat_slice})
+            ds = ds.sel(time=slice(t.start, t.stop))
+            # Materialize so we don't rely on a context manager at sample time.
+            ds = ds.load()
+
+        levels: tuple[float, ...] = ()
+        if 'level' in ds.coords:
+            levels = tuple(float(v) for v in np.atleast_1d(ds['level'].values))
+        return ds, lon_name, lat_name, levels
+
+    def _dataset_to_tensors(self, ds: Any) -> dict[str, Tensor]:
+        """Materialize selected ``data_vars`` as float32 tensors."""
+        out: dict[str, Tensor] = {}
+        for var in self.data_vars:
+            if var not in ds.data_vars:
+                continue
+            arr = np.asarray(ds[var].values, dtype=np.float32)
+            out[var] = torch.from_numpy(arr)
+        return out

--- a/uv.lock
+++ b/uv.lock
@@ -840,6 +840,18 @@ wheels = [
 ]
 
 [[package]]
+name = "donfig"
+version = "0.8.1.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1034,6 +1046,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/ba/8e6b2091878e99e86a36a814dcaeff652ed48bdb03d53e78e15aaa63a914/geopandas-1.1.3.tar.gz", hash = "sha256:91a31989b6f566012838d21d5f8033f37dce882079ccb7cfdc40d5ccce7f284f", size = 336718, upload-time = "2026-03-09T21:49:09.545Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/78/6a04792ace63a93e162f1305392d500ae8ddcb620e7eb88a22fd622b35bb/geopandas-1.1.3-py3-none-any.whl", hash = "sha256:90d62a64f95eaa3be2ccc115c5f3d6e24208bb11983b390fdc0621a3eccd0230", size = 342514, upload-time = "2026-03-09T21:49:07.973Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
 ]
 
 [[package]]
@@ -2042,6 +2077,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numcodecs"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/cc/55420f3641a67f78392dc0bc5d02cb9eb0a9dcebf2848d1ac77253ca61fa/numcodecs-0.16.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:24e675dc8d1550cd976a99479b87d872cb142632c75cc402fea04c08c4898523", size = 1656287, upload-time = "2025-11-21T02:49:25.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94ddfa4341d1a3ab99989d13b01b5134abb687d3dab2ead54b450aefe4ad5bd6", size = 1148899, upload-time = "2025-11-21T02:49:26.87Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1e/98aaddf272552d9fef1f0296a9939d1487914a239e98678f6b20f8b0a5c8/numcodecs-0.16.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b554ab9ecf69de7ca2b6b5e8bc696bd9747559cb4dd5127bd08d7a28bec59c3a", size = 8534814, upload-time = "2025-11-21T02:49:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6", size = 9173471, upload-time = "2025-11-21T02:49:30.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/20/2fdec87fc7f8cec950d2b0bea603c12dc9f05b4966dc5924ba5a36a61bf6/numcodecs-0.16.5-cp312-cp312-win_amd64.whl", hash = "sha256:845a9857886ffe4a3172ba1c537ae5bcc01e65068c31cf1fce1a844bd1da050f", size = 801412, upload-time = "2025-11-21T02:49:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/38/38/071ced5a5fd1c85ba0e14ba721b66b053823e5176298c2f707e50bed11d9/numcodecs-0.16.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25be3a516ab677dad890760d357cfe081a371d9c0a2e9a204562318ac5969de3", size = 1654359, upload-time = "2025-11-21T02:49:33.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/5f84ba7525577c1b9909fc2d06ef11314825fc4ad4378f61d0e4c9883b4a/numcodecs-0.16.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0107e839ef75b854e969cb577e140b1aadb9847893937636582d23a2a4c6ce50", size = 1144237, upload-time = "2025-11-21T02:49:35.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/00/787ea5f237b8ea7bc67140c99155f9c00b5baf11c49afc5f3bfefa298f95/numcodecs-0.16.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:015a7c859ecc2a06e2a548f64008c0ec3aaecabc26456c2c62f4278d8fc20597", size = 8483064, upload-time = "2025-11-21T02:49:36.454Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e6/d359fdd37498e74d26a167f7a51e54542e642ea47181eb4e643a69a066c3/numcodecs-0.16.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84230b4b9dad2392f2a84242bd6e3e659ac137b5a1ce3571d6965fca673e0903", size = 9126063, upload-time = "2025-11-21T02:49:38.018Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/6663cc0382ddbb866136c255c837bcb96cc7ce5e83562efec55e1b995941/numcodecs-0.16.5-cp313-cp313-win_amd64.whl", hash = "sha256:5088145502ad1ebf677ec47d00eb6f0fd600658217db3e0c070c321c85d6cf3d", size = 799275, upload-time = "2025-11-21T02:49:39.558Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/38e7ca8184c958b51f45d56a4aeceb1134ecde2d8bd157efadc98502cc42/numcodecs-0.16.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b05647b8b769e6bc8016e9fd4843c823ce5c9f2337c089fb5c9c4da05e5275de", size = 1654721, upload-time = "2025-11-21T02:49:40.602Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3832bd1b5af8bb3e413076b7d93318c8e7d7b68935006b9fa36ca057d1725a8f", size = 1146887, upload-time = "2025-11-21T02:49:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/15/e2e1151b5a8b14a15dfd4bb4abccce7fff7580f39bc34092780088835f3a/numcodecs-0.16.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f7b7d24f103187f53135bed28bb9f0ed6b2e14c604664726487bb6d7c882e1", size = 8476987, upload-time = "2025-11-21T02:49:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/16a57fc4d9fb0ba06c600408bd6634f2f1753c54a7a351c99c5e09b51ee2/numcodecs-0.16.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aec9736d81b70f337d89c4070ee3ffeff113f386fd789492fa152d26a15043e4", size = 9102377, upload-time = "2025-11-21T02:49:45.508Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a5/a0425af36c20d55a3ea884db4b4efca25a43bea9214ba69ca7932dd997b4/numcodecs-0.16.5-cp314-cp314-win_amd64.whl", hash = "sha256:b16a14303800e9fb88abc39463ab4706c037647ac17e49e297faa5f7d7dbbf1d", size = 819022, upload-time = "2025-11-21T02:49:47.39Z" },
 ]
 
 [[package]]
@@ -3761,6 +3823,7 @@ all = [
     { name = "types-shapely" },
     { name = "webdataset" },
     { name = "xarray" },
+    { name = "zarr" },
 ]
 datasets = [
     { name = "h5py", marker = "python_full_version < '3.14'" },
@@ -3771,6 +3834,7 @@ datasets = [
     { name = "scipy" },
     { name = "webdataset" },
     { name = "xarray" },
+    { name = "zarr" },
 ]
 docs = [
     { name = "ipywidgets" },
@@ -3850,6 +3914,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.8" },
     { name = "webdataset", marker = "extra == 'datasets'", specifier = ">=0.2.4" },
     { name = "xarray", marker = "extra == 'datasets'", specifier = ">=0.17" },
+    { name = "zarr", marker = "extra == 'datasets'", specifier = ">=2.18" },
 ]
 provides-extras = ["datasets", "docs", "models", "style", "tests", "all"]
 
@@ -4263,4 +4328,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "donfig" },
+    { name = "google-crc32c" },
+    { name = "numcodecs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
 ]


### PR DESCRIPTION
Weatherbench dataset class. Built as a wrapper around XarrayDataset, with overrides which allow for loading from local or streamed .zarr files

Notes
* `_open_and_slice` was meant for creating a sliced (e.g. regional) WB2 dataset, but this might not be the right place for it, and it can also be removed since the first version of the Aurora tutorial won't use it.
* `image` is included because of the original XarrayDataset implementations, but loaders like those for Aurora should need it.
* wasn't sure how to include the dataset line in images.csv since this is not a satellite image dataset


## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
