### PR TITLE
Plotting normalization: ignore nodata pixels

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -9,10 +9,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
-import numpy.typing
 import pandas as pd
 import pytest
 import torch
+from numpy.typing import NDArray
+from torch import Tensor
 
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
 from torchgeo.datasets.utils import (
@@ -543,20 +544,18 @@ def test_nonexisting_directory(tmp_path: Path) -> None:
         assert subdir.cwd() == subdir
 
 
-def test_percentile_normalization() -> None:
-    img = np.array([[1, 2], [98, 100]])
+@pytest.mark.parametrize('img', [np.random.rand(2, 2), np.zeros((2, 2))])
+def test_percentile_normalization(img: NDArray[np.float64]) -> None:
     match = 'Use torchgeo.datasets.utils.quantile_normalization instead'
     with pytest.warns(DeprecationWarning, match=match):
-        img = percentile_normalization(img, 2, 98)
-    assert img.min() == 0
-    assert img.max() == 1
+        img = percentile_normalization(img)
+    assert 0 <= img.min() <= img.max() <= 1
 
 
-def test_quantile_normalization() -> None:
-    img = torch.rand(3, 16, 16)
+@pytest.mark.parametrize('img', [torch.rand(2, 2), torch.zeros(2, 2)])
+def test_quantile_normalization(img: Tensor) -> None:
     img = quantile_normalization(img)
-    assert img.min() == 0
-    assert img.max() == 1
+    assert 0 <= img.min() <= img.max() <= 1
 
 
 @pytest.mark.parametrize(

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -28,6 +28,7 @@ import pandas as pd
 import rasterio
 import shapely.affinity
 import torch
+from numpy.typing import NDArray
 from pandas import Timedelta, Timestamp
 from rasterio import Affine
 from shapely import Geometry
@@ -797,11 +798,11 @@ def rgb_to_mask(
 
 @deprecated('Use torchgeo.datasets.utils.quantile_normalization instead')
 def percentile_normalization(
-    img: np.typing.NDArray[np.int_],
+    img: NDArray,
     lower: float = 2,
     upper: float = 98,
     axis: int | Sequence[int] | None = None,
-) -> np.typing.NDArray[np.int_]:
+) -> NDArray:
     """Applies percentile normalization to an input image.
 
     Specifically, this will rescale the values in the input such that values <= the
@@ -818,9 +819,15 @@ def percentile_normalization(
     Returns:
         normalized version of ``img``
 
+    Raises:
+        AssertionError: If *lower* is higher than *upper*.
+
     .. versionadded:: 0.2
     .. versiondeprecated:: 0.10
     """
+    if not np.any(img):
+        return img
+
     assert lower < upper
     lower_percentile = np.percentile(img[img != 0], lower, axis=axis)
     upper_percentile = np.percentile(img[img != 0], upper, axis=axis)
@@ -849,6 +856,9 @@ def quantile_normalization(
 
     .. versionadded:: 0.10
     """
+    if torch.count_nonzero(img) == 0:
+        return img
+
     lower = torch.quantile(img[img != 0], lower, dim, interpolation='higher')
     upper = torch.quantile(img[img != 0], upper, dim, interpolation='lower')
     img = (img - lower) / (upper - lower + 1e-5)

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -822,8 +822,8 @@ def percentile_normalization(
     .. versiondeprecated:: 0.10
     """
     assert lower < upper
-    lower_percentile = np.percentile(img[img > 0], lower, axis=axis)
-    upper_percentile = np.percentile(img[img > 0], upper, axis=axis)
+    lower_percentile = np.percentile(img[img != 0], lower, axis=axis)
+    upper_percentile = np.percentile(img[img != 0], upper, axis=axis)
     img_normalized = np.clip(
         (img - lower_percentile) / (upper_percentile - lower_percentile + 1e-5), 0, 1
     )
@@ -849,8 +849,8 @@ def quantile_normalization(
 
     .. versionadded:: 0.10
     """
-    lower = torch.quantile(img[img > 0], lower, dim, interpolation='higher')
-    upper = torch.quantile(img[img > 0], upper, dim, interpolation='lower')
+    lower = torch.quantile(img[img != 0], lower, dim, interpolation='higher')
+    upper = torch.quantile(img[img != 0], upper, dim, interpolation='lower')
     img = (img - lower) / (upper - lower + 1e-5)
     return torch.clamp(img, 0, 1)
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -822,8 +822,8 @@ def percentile_normalization(
     .. versiondeprecated:: 0.10
     """
     assert lower < upper
-    lower_percentile = np.percentile(img, lower, axis=axis)
-    upper_percentile = np.percentile(img, upper, axis=axis)
+    lower_percentile = np.percentile(img[img > 0], lower, axis=axis)
+    upper_percentile = np.percentile(img[img > 0], upper, axis=axis)
     img_normalized = np.clip(
         (img - lower_percentile) / (upper_percentile - lower_percentile + 1e-5), 0, 1
     )
@@ -849,8 +849,8 @@ def quantile_normalization(
 
     .. versionadded:: 0.10
     """
-    lower = torch.quantile(img, lower, dim, interpolation='higher')
-    upper = torch.quantile(img, upper, dim, interpolation='lower')
+    lower = torch.quantile(img[img > 0], lower, dim, interpolation='higher')
+    upper = torch.quantile(img[img > 0], upper, dim, interpolation='lower')
     img = (img - lower) / (upper - lower + 1e-5)
     return torch.clamp(img, 0, 1)
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -802,6 +802,7 @@ def percentile_normalization(
     lower: float = 2,
     upper: float = 98,
     axis: int | Sequence[int] | None = None,
+    nodata: int = 0,
 ) -> NDArray:
     """Applies percentile normalization to an input image.
 
@@ -815,6 +816,7 @@ def percentile_normalization(
         upper: upper percentile in range [0,100]
         axis: Axis or axes along which the percentiles are computed. The default
             is to compute the percentile(s) along a flattened version of the array.
+        nodata: Nodata value to ignore during quantile calculation.
 
     Returns:
         normalized version of ``img``
@@ -825,12 +827,12 @@ def percentile_normalization(
     .. versionadded:: 0.2
     .. versiondeprecated:: 0.10
     """
-    if not np.any(img):
+    if (img == nodata).all():
         return img
 
     assert lower < upper
-    lower_percentile = np.percentile(img[img != 0], lower, axis=axis)
-    upper_percentile = np.percentile(img[img != 0], upper, axis=axis)
+    lower_percentile = np.percentile(img[img != nodata], lower, axis=axis)
+    upper_percentile = np.percentile(img[img != nodata], upper, axis=axis)
     img_normalized = np.clip(
         (img - lower_percentile) / (upper_percentile - lower_percentile + 1e-5), 0, 1
     )
@@ -841,6 +843,7 @@ def quantile_normalization(
     img: Tensor,
     lower: float | Tensor = 0.02,
     upper: float | Tensor = 0.98,
+    nodata: float = 0,
     dim: int | None = None,
 ) -> Tensor:
     """Normalize and clip an input image to a specific quantile range.
@@ -849,6 +852,7 @@ def quantile_normalization(
         img: Image to normalize.
         lower: Lower quantile in range [0, 1].
         upper: Upper quantile in range [0, 1].
+        nodata: Nodata value to ignore during quantile calculation.
         dim: Dimension to reduce.
 
     Returns:
@@ -856,11 +860,11 @@ def quantile_normalization(
 
     .. versionadded:: 0.10
     """
-    if torch.count_nonzero(img) == 0:
+    if (img == nodata).all():
         return img
 
-    lower = torch.quantile(img[img != 0], lower, dim, interpolation='higher')
-    upper = torch.quantile(img[img != 0], upper, dim, interpolation='lower')
+    lower = torch.quantile(img[img != nodata], lower, dim, interpolation='higher')
+    upper = torch.quantile(img[img != nodata], upper, dim, interpolation='lower')
     img = (img - lower) / (upper - lower + 1e-5)
     return torch.clamp(img, 0, 1)
 


### PR DESCRIPTION
For images containing nodata pixels, these zeros completely throw off our math during normalization. For reproducibility, the below figures are from our I/O Bench dataset.

### Before

<img width="400" height="400" alt="before" src="https://github.com/user-attachments/assets/d9092a34-5716-4af9-a8d0-c0588fe2f3cb" />

### After

<img width="400" height="400" alt="after" src="https://github.com/user-attachments/assets/63ecc7f7-2a35-4783-895c-7adc6a80c637" />

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
