### PR TITLE
transforms: add LeeFilter for SAR speckle reduction

### DIFF
--- a/tests/transforms/test_sar.py
+++ b/tests/transforms/test_sar.py
@@ -1,0 +1,148 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import kornia.augmentation as K
+import numpy as np
+import pytest
+import torch
+from scipy.ndimage import uniform_filter
+
+from torchgeo.datasets.utils import Sample
+from torchgeo.transforms import LeeFilter
+from torchgeo.transforms.sar import lee_filter
+
+
+@pytest.fixture
+def sample() -> Sample:
+    rng = np.random.default_rng(0)
+    speckle = rng.exponential(scale=1.0, size=(1, 8, 8))
+    return {
+        'image': torch.from_numpy(speckle).float(),
+        'mask': torch.zeros(1, 8, 8, dtype=torch.long),
+    }
+
+
+@pytest.fixture
+def batch() -> Sample:
+    rng = np.random.default_rng(1)
+    speckle = rng.exponential(scale=1.0, size=(2, 1, 8, 8))
+    return {
+        'image': torch.from_numpy(speckle).float(),
+        'mask': torch.zeros(2, 1, 8, 8, dtype=torch.long),
+    }
+
+
+def _numpy_lee_reference(
+    image: np.ndarray, window_size: int, num_looks: float, eps: float = 1e-8
+) -> np.ndarray:
+    """Reference Lee filter using scipy.ndimage on a 2D NumPy array."""
+    image = image.astype(np.float64)
+    sigma_v_sq = 1.0 / num_looks
+    mean_local = uniform_filter(image, size=window_size, mode='mirror')
+    mean_sq_local = uniform_filter(image * image, size=window_size, mode='mirror')
+    var_local = np.clip(mean_sq_local - mean_local**2, 0.0, None)
+    var_signal = np.clip(var_local - sigma_v_sq * mean_local**2, 0.0, None)
+    weight = var_signal / (var_signal + sigma_v_sq * mean_local**2 + eps)
+    return mean_local + weight * (image - mean_local)
+
+
+def _make_synthetic_sar(seed: int = 0, size: int = 64) -> np.ndarray:
+    """Bright square on dark background with unit-mean exponential speckle."""
+    rng = np.random.default_rng(seed)
+    signal = np.ones((size, size), dtype=np.float64)
+    signal[size // 4 : 3 * size // 4, size // 4 : 3 * size // 4] = 5.0
+    speckle = rng.exponential(scale=1.0, size=(size, size))
+    return signal * speckle
+
+
+class TestLeeFilterFunction:
+    @pytest.mark.parametrize('window_size', [3, 5, 7])
+    @pytest.mark.parametrize('num_looks', [1.0, 5.0])
+    def test_matches_numpy_reference(self, window_size: int, num_looks: float) -> None:
+        img_np = _make_synthetic_sar()
+        ref = _numpy_lee_reference(img_np, window_size, num_looks)
+        x = torch.from_numpy(img_np).unsqueeze(0).unsqueeze(0)
+        out = lee_filter(x, window_size=window_size, num_looks=num_looks)
+        out_np = out.squeeze().numpy()
+        np.testing.assert_allclose(out_np, ref, rtol=1e-5, atol=1e-5)
+
+    def test_preserves_shape(self) -> None:
+        x = torch.rand(2, 3, 16, 16)
+        out = lee_filter(x, window_size=5)
+        assert out.shape == x.shape
+
+    def test_non_negative_output(self) -> None:
+        x = torch.rand(1, 1, 16, 16) * 10
+        out = lee_filter(x, window_size=7)
+        assert (out >= 0).all()
+
+    def test_reduces_variance_in_homogeneous_region(self) -> None:
+        rng = np.random.default_rng(42)
+        speckle = rng.exponential(scale=1.0, size=(64, 64)) * 3.0
+        x = torch.from_numpy(speckle).float().unsqueeze(0).unsqueeze(0)
+        out = lee_filter(x, window_size=9).squeeze().numpy()
+        assert out.var() < speckle.var() * 0.5
+
+    def test_preserves_edge_contrast_vs_mean(self) -> None:
+        img_np = _make_synthetic_sar(seed=1)
+        x = torch.from_numpy(img_np).float().unsqueeze(0).unsqueeze(0)
+        lee_out = lee_filter(x, window_size=7).squeeze().numpy()
+        mean_out = uniform_filter(img_np, size=7, mode='mirror')
+        size = img_np.shape[0]
+        strip_lee = lee_out[size // 4 - 4 : size // 4 + 4, :].std()
+        strip_mean = mean_out[size // 4 - 4 : size // 4 + 4, :].std()
+        assert strip_lee > strip_mean
+
+    @pytest.mark.parametrize('bad', [0, -1, 4, 8])
+    def test_rejects_invalid_window_size(self, bad: int) -> None:
+        with pytest.raises(ValueError, match='window_size'):
+            lee_filter(torch.zeros(1, 1, 8, 8), window_size=bad)
+
+    @pytest.mark.parametrize('bad', [0.0, -1.0])
+    def test_rejects_invalid_num_looks(self, bad: float) -> None:
+        with pytest.raises(ValueError, match='num_looks'):
+            lee_filter(torch.zeros(1, 1, 8, 8), window_size=5, num_looks=bad)
+
+
+class TestLeeFilter:
+    def test_sample(self, sample: Sample) -> None:
+        aug = K.AugmentationSequential(
+            LeeFilter(window_size=5, p=1.0), keepdim=True, data_keys=None
+        )
+        output = aug(sample)
+        assert output['image'].shape == sample['image'].shape
+
+    def test_batch(self, batch: Sample) -> None:
+        aug = K.AugmentationSequential(LeeFilter(window_size=5, p=1.0), data_keys=None)
+        output = aug(batch)
+        assert output['image'].shape == batch['image'].shape
+
+    @pytest.mark.parametrize('num_looks', [1.0, 5.0])
+    def test_num_looks(self, num_looks: float, batch: Sample) -> None:
+        aug = K.AugmentationSequential(
+            LeeFilter(window_size=5, num_looks=num_looks, p=1.0), data_keys=None
+        )
+        output = aug(batch)
+        assert output['image'].shape == batch['image'].shape
+
+    def test_same_on_batch(self, batch: Sample) -> None:
+        aug = K.AugmentationSequential(
+            LeeFilter(window_size=5, p=1.0, same_on_batch=True), data_keys=None
+        )
+        output = aug(batch)
+        assert output['image'].shape == batch['image'].shape
+
+    def test_p_zero_is_identity(self, batch: Sample) -> None:
+        aug = K.AugmentationSequential(LeeFilter(p=0.0), data_keys=None)
+        output = aug(batch)
+        assert torch.equal(output['image'], batch['image'])
+
+    @pytest.mark.parametrize('bad', [0, -1, 4, 8])
+    def test_rejects_invalid_window_size(self, bad: int) -> None:
+        with pytest.raises(ValueError, match='window_size'):
+            LeeFilter(window_size=bad)
+
+    @pytest.mark.parametrize('bad', [0.0, -1.0])
+    def test_rejects_invalid_num_looks(self, bad: float) -> None:
+        with pytest.raises(ValueError, match='num_looks'):
+            LeeFilter(num_looks=bad)

--- a/tests/transforms/test_sar.py
+++ b/tests/transforms/test_sar.py
@@ -5,11 +5,14 @@ import kornia.augmentation as K
 import numpy as np
 import pytest
 import torch
-from scipy.ndimage import uniform_filter
 
 from torchgeo.datasets.utils import Sample
 from torchgeo.transforms import LeeFilter
 from torchgeo.transforms.sar import lee_filter
+
+pytest.importorskip('scipy', minversion='1.11.2')
+
+from scipy.ndimage import uniform_filter
 
 
 @pytest.fixture

--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -20,6 +20,7 @@ from .indices import (
     AppendSWI,
     AppendTriBandNormalizedDifferenceIndex,
 )
+from .sar import LeeFilter
 from .spatial import SatSlideMix
 from .temporal import Rearrange
 
@@ -38,6 +39,7 @@ __all__ = (
     'AppendRBNDVI',
     'AppendSWI',
     'AppendTriBandNormalizedDifferenceIndex',
+    'LeeFilter',
     'RandomGrayscale',
     'Rearrange',
     'SatSlideMix',

--- a/torchgeo/transforms/sar.py
+++ b/torchgeo/transforms/sar.py
@@ -1,0 +1,166 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""SAR-specific transforms for synthetic aperture radar imagery."""
+
+import torch
+import torch.nn.functional as F
+from kornia.augmentation import IntensityAugmentationBase2D
+from torch import Tensor
+
+
+def _box_filter(x: Tensor, window_size: int) -> Tensor:
+    """Apply a per-channel box (mean) filter over the spatial dimensions.
+
+    Args:
+        x: Input tensor of shape ``(B, C, H, W)``.
+        window_size: Odd integer side length of the smoothing window.
+
+    Returns:
+        Smoothed tensor of identical shape.
+    """
+    pad = window_size // 2
+    x_padded = F.pad(x, (pad, pad, pad, pad), mode='reflect')
+    kernel = torch.ones(
+        1, 1, window_size, window_size, device=x.device, dtype=x.dtype
+    ) / float(window_size * window_size)
+    channels = x.shape[1]
+    kernel = kernel.expand(channels, 1, window_size, window_size)
+    return F.conv2d(x_padded, kernel, groups=channels)
+
+
+def lee_filter(
+    image: Tensor, window_size: int = 7, num_looks: float = 1.0, eps: float = 1e-8
+) -> Tensor:
+    r"""Apply the Lee filter to a SAR intensity image.
+
+    The Lee (1980) filter assumes a multiplicative speckle model
+    :math:`x = s \cdot v` where :math:`s` is the underlying signal and
+    :math:`v` is unit-mean speckle with variance
+    :math:`\sigma_v^2 = 1 / L` for an :math:`L`-look intensity image. The
+    local linear minimum mean square error (LMMSE) estimator is
+
+    .. math::
+
+        \hat{s} = \mu + k \cdot (x - \mu),
+        \quad
+        k = \frac{\sigma_s^2}{\sigma_s^2 + \sigma_v^2 \mu^2}
+
+    where :math:`\mu` is the local mean and
+    :math:`\sigma_s^2 = \max(\sigma_x^2 - \sigma_v^2 \mu^2, 0)` is the
+    estimated signal variance under the multiplicative-noise model. In
+    homogeneous regions the filter behaves like a mean filter; near edges
+    it preserves detail by giving the local mean less weight.
+
+    If you use this method in your research, please cite the following paper:
+
+    * https://doi.org/10.1109/TPAMI.1980.4766994
+
+    Args:
+        image: SAR intensity tensor of shape ``(B, C, H, W)``. Values are
+            assumed to be non-negative intensities, not amplitudes or dB.
+        window_size: Odd integer size of the local statistics window. Larger
+            values produce more smoothing at the cost of detail.
+        num_looks: Equivalent number of looks (ENL) of the input image.
+            Single-look complex (SLC) intensity has ``num_looks=1``.
+            Sentinel-1 GRDH typically has ``num_looks`` near 5.
+        eps: Numerical floor to avoid division by zero in flat regions.
+
+    Returns:
+        Filtered tensor of the same shape and dtype as ``image``.
+
+    Raises:
+        ValueError: If ``window_size`` is not a positive odd integer.
+        ValueError: If ``num_looks`` is not strictly positive.
+
+    .. versionadded:: 0.10
+    """
+    if window_size < 1 or window_size % 2 == 0:
+        raise ValueError(
+            f'window_size must be a positive odd integer, got {window_size}'
+        )
+    if num_looks <= 0:
+        raise ValueError(f'num_looks must be > 0, got {num_looks}')
+
+    sigma_v_sq = 1.0 / float(num_looks)
+
+    mean_local = _box_filter(image, window_size)
+    mean_sq_local = _box_filter(image * image, window_size)
+    var_local = (mean_sq_local - mean_local * mean_local).clamp(min=0.0)
+
+    var_signal = (var_local - sigma_v_sq * mean_local * mean_local).clamp(min=0.0)
+    weight = var_signal / (var_signal + sigma_v_sq * mean_local * mean_local + eps)
+
+    return mean_local + weight * (image - mean_local)
+
+
+class LeeFilter(IntensityAugmentationBase2D):
+    """Lee speckle reduction filter for SAR imagery.
+
+    Applies the classic Lee (1980) adaptive filter to reduce multiplicative
+    speckle noise while preserving edges and structural detail. Operates on
+    SAR intensity imagery with non-negative values; amplitude and dB inputs
+    should be converted to intensity beforehand.
+
+    If you use this method in your research, please cite the following paper:
+
+    * https://doi.org/10.1109/TPAMI.1980.4766994
+
+    .. versionadded:: 0.10
+    """
+
+    def __init__(
+        self,
+        window_size: int = 7,
+        num_looks: float = 1.0,
+        p: float = 1.0,
+        same_on_batch: bool = False,
+        keepdim: bool = False,
+    ) -> None:
+        """Initialize a new LeeFilter instance.
+
+        Args:
+            window_size: Odd integer size of the local statistics window.
+            num_looks: Equivalent number of looks (ENL) of the input SAR data.
+                Single-look complex (SLC) intensity has ``num_looks=1``.
+            p: Probability of applying the filter to each sample.
+            same_on_batch: Apply the same transformation across the batch.
+            keepdim: Whether to keep the output shape the same as input (True)
+                or broadcast it to the batch form (False).
+
+        Raises:
+            ValueError: If ``window_size`` is not a positive odd integer.
+            ValueError: If ``num_looks`` is not strictly positive.
+        """
+        super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
+        if window_size < 1 or window_size % 2 == 0:
+            raise ValueError(
+                f'window_size must be a positive odd integer, got {window_size}'
+            )
+        if num_looks <= 0:
+            raise ValueError(f'num_looks must be > 0, got {num_looks}')
+        self.flags = {'window_size': window_size, 'num_looks': num_looks}
+
+    def apply_transform(
+        self,
+        input: Tensor,
+        params: dict[str, Tensor],
+        flags: dict[str, int | float],
+        transform: Tensor | None = None,
+    ) -> Tensor:
+        """Apply the Lee filter to the input SAR image.
+
+        Args:
+            input: The input tensor.
+            params: Generated parameters.
+            flags: Static parameters.
+            transform: The geometric transformation tensor.
+
+        Returns:
+            The filtered tensor.
+        """
+        return lee_filter(
+            input,
+            window_size=int(flags['window_size']),
+            num_looks=float(flags['num_looks']),
+        )


### PR DESCRIPTION
Adds the classic Lee (1980) adaptive filter for despeckling SAR intensity imagery as a Kornia-style `IntensityAugmentationBase2D`.

This is PR 1 of the proposal in #3645. Refined Lee and Frost will follow in separate PRs.

### What this adds

- `torchgeo.transforms.LeeFilter` — Kornia-compatible despeckling transform
- `torchgeo.transforms.sar.lee_filter` — functional API
- `tests/transforms/test_sar.py` — 28 tests, 100% coverage of the new module

### Decisions (per @adamjstewart's answers in #3645)

1. Module location: `torchgeo/transforms/sar.py`
2. `num_looks=1.0` default (SLC); docstring notes Sentinel-1 GRDH users should pass ~5
3. `IntensityAugmentationBase2D` base, `p=1` default
4. Single input format (intensity); amplitude/dB conversion will be handled in a follow-up PR

### Test plan

- `pytest tests/transforms/test_sar.py` → 28 passed
- 100% coverage on `torchgeo/transforms/sar.py` (verified via `coverage report`)
- `ruff format && ruff check && ty check` → all green

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
