### PR TITLE
CODEOWNERS: use specialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Components
-datamodules/ @ashnair1 @robmarkcole
+datamodules/ @ashnair1 @robmarkcole @nilsleh
 datasets/ @nilsleh @adamjstewart
 losses/ @calebrob6
 models/ @isaaccorley @ashnair1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Components
-datamodules/ @ashnair1 @robmarkcole @nilsleh
+datamodules/ @nilsleh @robmarkcole
 datasets/ @nilsleh @adamjstewart
-losses/ @calebrob6
+losses/ @calebrob6 @adamjstewart
 models/ @isaaccorley @ashnair1
 samplers/ @adamjstewart @nilsleh
 trainers/ @robmarkcole @calebrob6
-transforms/ @isaaccorley @calebrob6
+transforms/ @ashnair1 @isaaccorley @calebrob6
 
 # Policy documents, requires 2/3 approval
 /.github/* @adamjstewart @calebrob6 @isaaccorley @nilsleh @ashnair1 @robmarkcole

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,13 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @adamjstewart @calebrob6 @isaaccorley @nilsleh @ashnair1
+
+# Components
+datamodules/ @ashnair1 @robmarkcole
+datasets/ @nilsleh @adamjstewart
+losses/ @calebrob6
+models/ @isaaccorley @ashnair1
+samplers/ @adamjstewart @nilsleh
+trainers/ @robmarkcole @calebrob6
+transforms/ @isaaccorley
+
+# Policy documents, requires 2/3 approval
+/.github/* @adamjstewart @calebrob6 @isaaccorley @nilsleh @ashnair1 @robmarkcole

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@ losses/ @calebrob6
 models/ @isaaccorley @ashnair1
 samplers/ @adamjstewart @nilsleh
 trainers/ @robmarkcole @calebrob6
-transforms/ @isaaccorley
+transforms/ @isaaccorley @calebrob6
 
 # Policy documents, requires 2/3 approval
 /.github/* @adamjstewart @calebrob6 @isaaccorley @nilsleh @ashnair1 @robmarkcole


### PR DESCRIPTION
Until now, all maintainers were asked to review every PR. In theory, this should lead to more reviews. However, in practice, this leads to the [bystander effect](https://en.wikipedia.org/wiki/Bystander_effect), where everyone assumes someone else will review the PR so they don't need to.

I would like to ask individual maintainers to maintain different parts of the repository. I've tried to assign everyone to at least 2 components, and specifically components that they've historically contributed more to, but feel free to switch components or sign up for more. Of course, anyone can still review any PR they want to. I'm hoping that these people serve as the first line of defense and _most_ PRs have at least 2 approvals before merging.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
