### PR TITLE
Add utilities for computing valid-data footprints from raster masks

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -15,6 +15,9 @@ import pytest
 import torch
 from numpy.typing import NDArray
 from pytest import MonkeyPatch
+from rasterio import MemoryFile
+from rasterio.transform import from_origin
+from shapely import MultiPolygon, Polygon, box
 from torch import Tensor
 
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
@@ -23,12 +26,14 @@ from torchgeo.datasets.utils import (
     Sample,
     array_to_tensor,
     check_integrity,
+    clean_binary_mask,
     concat_samples,
     disambiguate_timestamp,
     download_and_extract_archive,
     download_url,
     extract_archive,
     find_files,
+    get_valid_footprint_from_datasource,
     lazy_import,
     merge_samples,
     pad_across_batches,
@@ -692,3 +697,83 @@ class TestFindFiles:
         """A path that does not exist inside an archive resolves to nothing."""
         _, archive = temp_archive
         assert find_files(f'/vsizip/{archive}/non_existing.tif') == []
+
+
+def create_test_raster_file(
+    width: int = 100,
+    height: int = 100,
+    nodata_value: float = 0,
+    crs: str = 'EPSG:32633',
+    num_bands: int = 1,
+    with_half_nodata: bool = False,
+) -> MemoryFile:
+    """Creates a synthetic raster file for testing."""
+    base_data = np.ones((height, width), dtype=np.uint8)
+
+    if with_half_nodata:
+        for row in range(height):
+            for col in range(width):
+                if row + col < width:
+                    base_data[row, col] = nodata_value
+
+    data = np.stack([base_data] * num_bands, axis=0)
+    # Realistic Sentinel-2-like origin and 10 m resolution in UTM zone 32N
+    transform = from_origin(600000, 5700000, 10, 10)
+
+    memfile = MemoryFile()
+    with memfile.open(
+        driver='GTiff',
+        height=height,
+        width=width,
+        count=num_bands,
+        dtype=data.dtype,
+        transform=transform,
+        crs=crs,
+        nodata=nodata_value,
+    ) as dataset:
+        dataset.write(data)
+
+    return memfile
+
+
+@pytest.mark.parametrize('num_bands', [1, 3])
+@pytest.mark.parametrize('with_half_nodata', [True, False])
+def test_calc_valid_data_footprint_from_raster_mask(
+    num_bands: int, with_half_nodata: bool
+) -> None:
+    with (
+        create_test_raster_file(
+            num_bands=num_bands, with_half_nodata=with_half_nodata
+        ) as memfile,
+        memfile.open() as dataset,
+    ):
+        # Verify clean_binary_mask's 3D OR logic matches rasterio's own mask combination
+        assert np.array_equal(
+            clean_binary_mask(dataset.dataset_mask()),
+            clean_binary_mask(dataset.read_masks()),
+        )
+
+        footprint = get_valid_footprint_from_datasource(dataset)
+
+        assert isinstance(footprint, Polygon | MultiPolygon)
+        assert footprint.is_valid
+
+        raster_extent = box(*dataset.bounds)
+        expected_area = raster_extent.area
+
+        if with_half_nodata:
+            expected_area /= 2
+
+            relative_error = abs(footprint.area - expected_area) / expected_area
+            # Theoretical bound for triangle: ~2√2/N where N is the raster width in pixels.
+            # For N=100 this is ~2.83%; we allow 4% for floating-point margin.
+            assert relative_error < 0.04
+        else:
+            assert footprint.area == expected_area
+
+
+def test_get_valid_footprint_all_nodata_warns() -> None:
+    with create_test_raster_file(nodata_value=1) as memfile, memfile.open() as dataset:
+        with pytest.warns(UserWarning, match='All pixels are nodata'):
+            footprint = get_valid_footprint_from_datasource(dataset)
+        assert footprint.is_empty

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -704,6 +704,8 @@ def create_test_raster_file(
     height: int = 100,
     nodata_value: float = 0,
     crs: str = 'EPSG:32633',
+    origin: tuple[float, float] = (600000, 5700000),
+    res: float = 10,
     num_bands: int = 1,
     with_half_nodata: bool = False,
 ) -> MemoryFile:
@@ -717,8 +719,7 @@ def create_test_raster_file(
                     base_data[row, col] = nodata_value
 
     data = np.stack([base_data] * num_bands, axis=0)
-    # Realistic Sentinel-2-like origin and 10 m resolution in UTM zone 32N
-    transform = from_origin(600000, 5700000, 10, 10)
+    transform = from_origin(origin[0], origin[1], res, res)
 
     memfile = MemoryFile()
     with memfile.open(
@@ -736,14 +737,29 @@ def create_test_raster_file(
     return memfile
 
 
+@pytest.mark.parametrize(
+    'crs,origin,res',
+    [
+        ('EPSG:32633', (600000, 5700000), 10),  # UTM zone 33N, meters
+        ('EPSG:4326', (16.0, 51.01), 0.0001),  # WGS84, degrees (~11 m/px)
+    ],
+)
 @pytest.mark.parametrize('num_bands', [1, 3])
 @pytest.mark.parametrize('with_half_nodata', [True, False])
 def test_calc_valid_data_footprint_from_raster_mask(
-    num_bands: int, with_half_nodata: bool
+    num_bands: int,
+    with_half_nodata: bool,
+    crs: str,
+    origin: tuple[float, float],
+    res: float,
 ) -> None:
     with (
         create_test_raster_file(
-            num_bands=num_bands, with_half_nodata=with_half_nodata
+            num_bands=num_bands,
+            with_half_nodata=with_half_nodata,
+            crs=crs,
+            origin=origin,
+            res=res,
         ) as memfile,
         memfile.open() as dataset,
     ):

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -12,11 +12,13 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
+import rasterio
 import torch
 from numpy.typing import NDArray
 from pytest import MonkeyPatch
-from rasterio import MemoryFile
+from rasterio import Affine, MemoryFile
 from rasterio.transform import from_origin
+from rasterio.vrt import WarpedVRT
 from shapely import MultiPolygon, Polygon, box
 from torch import Tensor
 
@@ -24,9 +26,10 @@ from torchgeo.datasets import BoundingBox, DependencyNotFoundError
 from torchgeo.datasets.utils import (
     Executable,
     Sample,
+    _binary_mask_to_polygon,
+    _clean_binary_mask,
     array_to_tensor,
     check_integrity,
-    clean_binary_mask,
     concat_samples,
     disambiguate_timestamp,
     download_and_extract_archive,
@@ -699,97 +702,87 @@ class TestFindFiles:
         assert find_files(f'/vsizip/{archive}/non_existing.tif') == []
 
 
-def create_test_raster_file(
-    width: int = 100,
-    height: int = 100,
-    nodata_value: float = 0,
-    crs: str = 'EPSG:32633',
-    origin: tuple[float, float] = (600000, 5700000),
-    res: float = 10,
-    num_bands: int = 1,
-    with_half_nodata: bool = False,
-) -> MemoryFile:
-    """Creates a synthetic raster file for testing."""
-    base_data = np.ones((height, width), dtype=np.uint8)
-
-    if with_half_nodata:
-        for row in range(height):
-            for col in range(width):
-                if row + col < width:
-                    base_data[row, col] = nodata_value
-
-    data = np.stack([base_data] * num_bands, axis=0)
-    transform = from_origin(origin[0], origin[1], res, res)
-
-    memfile = MemoryFile()
-    with memfile.open(
-        driver='GTiff',
-        height=height,
-        width=width,
-        count=num_bands,
-        dtype=data.dtype,
-        transform=transform,
-        crs=crs,
-        nodata=nodata_value,
-    ) as dataset:
-        dataset.write(data)
-
-    return memfile
-
-
 @pytest.mark.parametrize(
-    'crs,origin,res',
+    'res',
     [
-        ('EPSG:32633', (600000, 5700000), 10),  # UTM zone 33N, meters
-        ('EPSG:4326', (16.0, 51.01), 0.0001),  # WGS84, degrees (~11 m/px)
+        10.0,  # meters (e.g. UTM)
+        0.0001,  # degrees (e.g. WGS84)
     ],
 )
-@pytest.mark.parametrize('num_bands', [1, 3])
-@pytest.mark.parametrize('with_half_nodata', [True, False])
-def test_calc_valid_data_footprint_from_raster_mask(
-    num_bands: int,
-    with_half_nodata: bool,
-    crs: str,
-    origin: tuple[float, float],
-    res: float,
-) -> None:
+@pytest.mark.parametrize('north_up', [True, False])
+def test_binary_mask_to_polygon(res: float, north_up: bool) -> None:
+    # Left half valid, right half nodata.
+    image_shape = (100, 100)
+    mask = np.zeros(image_shape, dtype=np.uint8)
+    mask[:, :50] = 255
+    y_res = -res if north_up else res
+    transform = Affine(res, 0.0, 0.0, 0.0, y_res, 0.0)
+
+    footprint = _binary_mask_to_polygon(mask, transform, res)
+
+    assert isinstance(footprint, Polygon | MultiPolygon)
+    assert footprint.is_valid
+    # The straight nodata edge yields an exact rectangle covering half the extent.
+    expected_area = (image_shape[0] * res) * (image_shape[1] * res) / 2
+    assert footprint.area == expected_area
+
+
+# A Sentinel-2 tile whose fake data includes a nodata corner.
+# The .SAFE format omits the nodata value from the raster profile,
+# so we declare it via a WarpedVRT.
+SENTINEL2_TILE = os.path.join(
+    'tests/data/sentinel2',
+    'S2A_MSIL1C_20220412T162841_N0400_R083_T16TFM_20220412T202300.SAFE',
+    'GRANULE/L1C_T16TFM_A035544_20220412T163959/IMG_DATA',
+    'T16TFM_20220412T162841_B02.jp2',
+)
+
+
+def test_get_valid_footprint_all_valid() -> None:
+    # When nodata value is not declared in the raster,
+    # every pixel is valid and the calculated footprint becomes its bounds.
+    with rasterio.open(SENTINEL2_TILE) as dataset:
+        footprint = get_valid_footprint_from_datasource(dataset)
+        assert footprint.equals(box(*dataset.bounds))
+
+
+def test_get_valid_footprint_partial_nodata() -> None:
+    # The .SAFE profile omits the nodata value, so we declare it via src_nodata
     with (
-        create_test_raster_file(
-            num_bands=num_bands,
-            with_half_nodata=with_half_nodata,
-            crs=crs,
-            origin=origin,
-            res=res,
-        ) as memfile,
-        memfile.open() as dataset,
+        rasterio.open(SENTINEL2_TILE) as raster,
+        WarpedVRT(raster, src_nodata=0) as dataset,
     ):
-        # Verify clean_binary_mask's 3D OR logic matches rasterio's own mask combination
+        # _clean_binary_mask's 3D read_masks OR-combine must match the 2D dataset_mask.
         assert np.array_equal(
-            clean_binary_mask(dataset.dataset_mask()),
-            clean_binary_mask(dataset.read_masks()),
+            _clean_binary_mask(dataset.dataset_mask()),
+            _clean_binary_mask(dataset.read_masks()),
         )
 
         footprint = get_valid_footprint_from_datasource(dataset)
-
         assert isinstance(footprint, Polygon | MultiPolygon)
         assert footprint.is_valid
 
-        raster_extent = box(*dataset.bounds)
-        expected_area = raster_extent.area
-
-        if with_half_nodata:
-            expected_area /= 2
-
-            relative_error = abs(footprint.area - expected_area) / expected_area
-            # Theoretical bound for triangle: ~2√2/N where N is the raster width in pixels.
-            # For N=100 this is ~2.83%; we allow 4% for floating-point margin.
-            assert relative_error < 0.04
-        else:
-            assert footprint.area == expected_area
+        bounds = box(*dataset.bounds)
+        # The footprint must not extend beyond the raster bounds.
+        assert bounds.covers(footprint)
+        # The nodata corner removes ~1/8 of the tile, leaving ~7/8 valid.
+        assert footprint.area / bounds.area == pytest.approx(7 / 8, abs=0.02)
 
 
 def test_get_valid_footprint_all_nodata_warns() -> None:
-    with create_test_raster_file(nodata_value=1) as memfile, memfile.open() as dataset:
-        with pytest.warns(UserWarning, match='All pixels are nodata'):
-            footprint = get_valid_footprint_from_datasource(dataset)
-        assert footprint.is_empty
+    # Real acquisitions are never entirely nodata, so build a small all-nodata raster.
+    with MemoryFile() as memfile:
+        with memfile.open(
+            driver='GTiff',
+            height=4,
+            width=4,
+            count=1,
+            dtype='uint8',
+            transform=from_origin(0, 40, 10, 10),
+            nodata=0,
+        ) as dataset:
+            dataset.write(np.zeros((1, 4, 4), dtype=np.uint8))
+        with memfile.open() as dataset:
+            with pytest.warns(UserWarning, match='All pixels are nodata'):
+                footprint = get_valid_footprint_from_datasource(dataset)
+            assert footprint.is_empty

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -33,8 +33,10 @@ import shapely.affinity
 import torch
 from numpy.typing import NDArray
 from pandas import Timedelta, Timestamp
-from rasterio import Affine
-from shapely import Geometry
+from rasterio import Affine, DatasetReader
+from rasterio.features import shapes, sieve
+from rasterio.vrt import WarpedVRT
+from shapely import Geometry, MultiPolygon, Polygon
 from torch import Tensor
 from torchvision.utils import draw_segmentation_masks
 from typing_extensions import deprecated
@@ -1048,3 +1050,149 @@ def find_files(path: Path, filename_glob: str = '*') -> list[str]:
             f for f in all_files if fnmatch.fnmatch(os.path.basename(f), filename_glob)
         }
     return sorted(files)
+
+
+def clean_binary_mask(
+    mask: np.typing.NDArray[np.number], threshold: int = 1
+) -> np.typing.NDArray[np.uint8]:
+    """Convert any rasterio mask to a clean binary mask (uint8 0 or 255).
+
+    Args:
+        mask: input mask array from `DatasetReader.dataset_mask()`
+              or `DatasetReader.read_masks()`.
+              Can be 2D or 3D with values between 0 and 255.
+        threshold: pixel values >= threshold are considered valid.
+            This is needed when/if the mask is based on alpha channel.
+            Defaults to 1 as we assume pixels outside the valid footprint will
+            also have 0 alpha.
+
+    Returns:
+        Binary mask of dtype uint8 with 255 = valid pixels, 0 = invalid.
+        If input is 3D, masks are combined (OR) before thresholding.
+
+    .. versionadded:: 0.9
+    """
+    if mask.ndim == 3:
+        combined = np.any(mask >= threshold, axis=0)
+    else:
+        combined = mask >= threshold
+
+    binary_mask: np.typing.NDArray[np.uint8] = (combined.astype(np.uint8)) * 255
+    return binary_mask
+
+
+def calculate_valid_footprint_from_binary_mask(
+    mask: np.typing.NDArray[np.uint8], transform: Affine, raster_resolution_x: float
+) -> Polygon | MultiPolygon:
+    """Calculates valid data footprint from a binary raster mask.
+
+    Args:
+        mask: binary mask where 255 representing valid pixels
+            and 0 representing nodata pixels
+        transform: affine transform for the raster
+        raster_resolution_x: pixel size in the x direction in CRS units
+
+    Returns:
+        A `Polygon` or `MultiPolygon` representing the valid data footprint of the raster
+
+    .. versionadded:: 0.9
+    """
+    # Fill small nodata holes (< 0.2% of pixels, capped at 800) so minor
+    # sensor artifacts don't fragment the footprint. Cap prevents the threshold
+    # from exceeding the raster size on large images; `or 1` guards against
+    # mask.size being zero.
+    # See https://rasterio.readthedocs.io/en/stable/topics/masks.html#writing-masks
+    max_hole_size = min(int(mask.size * 0.002), 800) or 1
+    sieved_mask = sieve(mask, max_hole_size)
+
+    # Extract one polygon per contiguous valid-data region (value > 0).
+    # Multiple disjoint regions are collected here and merged into a MultiPolygon below.
+    geoms = [g for g, v in shapes(sieved_mask, transform=transform) if v > 0]
+
+    # coordinates[0] = exterior ring, coordinates[1:] = interior holes (if any).
+    vector_footprint = MultiPolygon(
+        [
+            Polygon(feature['coordinates'][0], feature['coordinates'][1:])
+            for feature in geoms
+        ]
+    )
+    # Collapse pixel-staircase edges into straight lines. A staircase step deviates
+    # at most ~1 pixel from the true boundary, so 2 pixels of tolerance cleanly
+    # removes jaggedness without distorting the actual shape. Works for any CRS
+    # since the tolerance is expressed directly in CRS units.
+    simplification_tolerance = 2 * raster_resolution_x
+    return cast(
+        Polygon | MultiPolygon, vector_footprint.simplify(simplification_tolerance)
+    )
+
+
+def get_valid_footprint_from_datasource(
+    src: DatasetReader | WarpedVRT,
+) -> MultiPolygon | Polygon:
+    """Compute the valid data footprint of a raster dataset.
+
+    .. note::
+       If your dataset relies on nodata-value to create the masks, this might
+       add overhead. Consider writing nodata masks to file.
+
+    Analyzes the raster's mask band to determine the spatial extent of valid
+    (non-NoData) pixels, returning the result as a `Polygon` or `MultiPolygon`
+    in the dataset's coordinate reference system.
+
+    For large datasets it is more efficient to pre-compute footprints once and
+    store them, then look them up in
+    :meth:`~torchgeo.datasets.RasterDataset._footprint_from_datasource`
+    rather than recomputing on every dataset initialisation. Pre-compute to a
+    GeoPackage and then load the lookup table before ``super().__init__()``,
+    which is when ``_footprint_from_datasource`` is called for each file:
+
+    Examples:
+        # Pre-compute once
+        rows = []
+        for path in Path('data/').rglob('*.tif'):
+            with rasterio.open(path) as src:
+                rows.append({'filename': path.name,
+                             'geometry': get_valid_footprint_from_datasource(src)})
+        gpd.GeoDataFrame(rows, crs=src.crs).to_file('footprints.gpkg')
+
+        # Use in a RasterDataset subclass
+        class MyDataset(RasterDataset):
+            def __init__(self, root, footprints='footprints.gpkg', **kwargs):
+                gdf = gpd.read_file(footprints).set_index('filename')
+                self._footprints = gdf['geometry'].to_dict()
+                super().__init__(root, **kwargs)
+
+            def _footprint_from_datasource(self, src):
+                name = os.path.basename(src.name)
+                return self._footprints.get(name) or super()._footprint_from_datasource(src)
+
+    Args:
+        src: An open raster dataset, either a `DatasetReader` (from `rasterio.open`)
+            or a `WarpedVRT` instance.
+
+    Returns:
+        A `Polygon` or `MultiPolygon` representing the footprint of valid data
+        in the raster's CRS.
+
+    .. versionadded:: 0.9
+    """
+    import shapely
+
+    valid_data_mask = src.dataset_mask()
+    binary_mask = clean_binary_mask(valid_data_mask)
+
+    if (binary_mask == 255).all():
+        return shapely.box(*src.bounds)
+
+    if (binary_mask == 0).all():
+        warnings.warn(
+            'All pixels are nodata; returning an empty geometry.',
+            UserWarning,
+            stacklevel=2,
+        )
+        return Polygon()
+
+    res_x = src.res[0] if isinstance(src.res, tuple) else src.res
+    return calculate_valid_footprint_from_binary_mask(
+        mask=binary_mask, transform=src.transform, raster_resolution_x=res_x
+    )

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -36,7 +36,7 @@ from pandas import Timedelta, Timestamp
 from rasterio import Affine, DatasetReader
 from rasterio.features import shapes, sieve
 from rasterio.vrt import WarpedVRT
-from shapely import Geometry, MultiPolygon, Polygon
+from shapely import Geometry, MultiPolygon, Polygon, box
 from torch import Tensor
 from torchvision.utils import draw_segmentation_masks
 from typing_extensions import deprecated
@@ -1052,7 +1052,7 @@ def find_files(path: Path, filename_glob: str = '*') -> list[str]:
     return sorted(files)
 
 
-def clean_binary_mask(
+def _clean_binary_mask(
     mask: np.typing.NDArray[np.number], threshold: int = 1
 ) -> np.typing.NDArray[np.uint8]:
     """Convert any rasterio mask to a clean binary mask (uint8 0 or 255).
@@ -1069,8 +1069,6 @@ def clean_binary_mask(
     Returns:
         Binary mask of dtype uint8 with 255 = valid pixels, 0 = invalid.
         If input is 3D, masks are combined (OR) before thresholding.
-
-    .. versionadded:: 0.9
     """
     if mask.ndim == 3:
         combined = np.any(mask >= threshold, axis=0)
@@ -1081,10 +1079,10 @@ def clean_binary_mask(
     return binary_mask
 
 
-def calculate_valid_footprint_from_binary_mask(
+def _binary_mask_to_polygon(
     mask: np.typing.NDArray[np.uint8], transform: Affine, raster_resolution_x: float
 ) -> Polygon | MultiPolygon:
-    """Calculates valid data footprint from a binary raster mask.
+    """Vectorize a binary raster mask into a polygon.
 
     Args:
         mask: binary mask where 255 representing valid pixels
@@ -1093,9 +1091,7 @@ def calculate_valid_footprint_from_binary_mask(
         raster_resolution_x: pixel size in the x direction in CRS units
 
     Returns:
-        A `Polygon` or `MultiPolygon` representing the valid data footprint of the raster
-
-    .. versionadded:: 0.9
+        A `Polygon` or `MultiPolygon` representing the valid data mask
     """
     # Fill small nodata holes (< 0.2% of pixels, capped at 800) so minor
     # sensor artifacts don't fragment the footprint. Cap prevents the threshold
@@ -1110,7 +1106,7 @@ def calculate_valid_footprint_from_binary_mask(
     geoms = [g for g, v in shapes(sieved_mask, transform=transform) if v > 0]
 
     # coordinates[0] = exterior ring, coordinates[1:] = interior holes (if any).
-    vector_footprint = MultiPolygon(
+    vector_mask = MultiPolygon(
         [
             Polygon(feature['coordinates'][0], feature['coordinates'][1:])
             for feature in geoms
@@ -1121,68 +1117,33 @@ def calculate_valid_footprint_from_binary_mask(
     # removes jaggedness without distorting the actual shape. Works for any CRS
     # since the tolerance is expressed directly in CRS units.
     simplification_tolerance = 2 * raster_resolution_x
-    return cast(
-        Polygon | MultiPolygon, vector_footprint.simplify(simplification_tolerance)
-    )
+    return cast(Polygon | MultiPolygon, vector_mask.simplify(simplification_tolerance))
 
 
 def get_valid_footprint_from_datasource(
     src: DatasetReader | WarpedVRT,
 ) -> MultiPolygon | Polygon:
-    """Compute the valid data footprint of a raster dataset.
+    """Compute the valid (non-NoData) data footprint of a raster in its CRS.
 
     .. note::
-       If your dataset relies on nodata-value to create the masks, this might
-       add overhead. Consider writing nodata masks to file.
-
-    Analyzes the raster's mask band to determine the spatial extent of valid
-    (non-NoData) pixels, returning the result as a `Polygon` or `MultiPolygon`
-    in the dataset's coordinate reference system.
-
-    For large datasets it is more efficient to pre-compute footprints once and
-    store them, then look them up in
-    :meth:`~torchgeo.datasets.RasterDataset._footprint_from_datasource`
-    rather than recomputing on every dataset initialisation. Pre-compute to a
-    GeoPackage and then load the lookup table before ``super().__init__()``,
-    which is when ``_footprint_from_datasource`` is called for each file:
-
-    Examples:
-        # Pre-compute once
-        rows = []
-        for path in Path('data/').rglob('*.tif'):
-            with rasterio.open(path) as src:
-                rows.append({'filename': path.name,
-                             'geometry': get_valid_footprint_from_datasource(src)})
-        gpd.GeoDataFrame(rows, crs=src.crs).to_file('footprints.gpkg')
-
-        # Use in a RasterDataset subclass
-        class MyDataset(RasterDataset):
-            def __init__(self, root, footprints='footprints.gpkg', **kwargs):
-                gdf = gpd.read_file(footprints).set_index('filename')
-                self._footprints = gdf['geometry'].to_dict()
-                super().__init__(root, **kwargs)
-
-            def _footprint_from_datasource(self, src):
-                name = os.path.basename(src.name)
-                return self._footprints.get(name) or super()._footprint_from_datasource(src)
+       Deriving masks from a nodata value adds overhead. For large datasets,
+       pre-compute footprints once and look them up in
+       :meth:`~torchgeo.datasets.RasterDataset._footprint_from_datasource`
+       instead of recomputing on every initialisation.
 
     Args:
-        src: An open raster dataset, either a `DatasetReader` (from `rasterio.open`)
-            or a `WarpedVRT` instance.
+        src: An open raster dataset (`DatasetReader` or `WarpedVRT`).
 
     Returns:
-        A `Polygon` or `MultiPolygon` representing the footprint of valid data
-        in the raster's CRS.
+        A `Polygon` or `MultiPolygon` of the valid data footprint.
 
-    .. versionadded:: 0.9
+    .. versionadded:: 0.10
     """
-    import shapely
-
     valid_data_mask = src.dataset_mask()
-    binary_mask = clean_binary_mask(valid_data_mask)
+    binary_mask = _clean_binary_mask(valid_data_mask)
 
     if (binary_mask == 255).all():
-        return shapely.box(*src.bounds)
+        return box(*src.bounds)
 
     if (binary_mask == 0).all():
         warnings.warn(
@@ -1193,6 +1154,6 @@ def get_valid_footprint_from_datasource(
         return Polygon()
 
     res_x = src.res[0] if isinstance(src.res, tuple) else src.res
-    return calculate_valid_footprint_from_binary_mask(
+    return _binary_mask_to_polygon(
         mask=binary_mask, transform=src.transform, raster_resolution_x=res_x
     )


### PR DESCRIPTION
Adds `clean_binary_mask`, `calculate_valid_footprint_from_binary_mask`, and `get_valid_footprint_from_datasource` to `torchgeo.datasets.utils`. These allow a RasterDataset subclass to index each file by its precise valid-data footprint rather than its bounding box, which matters when scenes have significant nodata regions (e.g. satellite swath edges, cloud masks or after re-projection). Intended for use with RasterDataset._footprint_from_datasource in #2903 

For large datasets, footprints can be pre-computed once and stored in a GeoPackage, avoiding the per-run overhead of reading and processing every raster mask. Suggested implementation is found in docstring of `get_valid_footprint_from_datasource`.

## AI Usage Disclosure
<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [X] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
