### PR TITLE
docs: Skip case study notebooks from pytest collection

### DIFF
--- a/docs/tutorials/conftest.py
+++ b/docs/tutorials/conftest.py
@@ -1,0 +1,8 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+collect_ignore = [
+    'earth_surface_water.ipynb',
+    'earthquake_detection.ipynb',
+    'naip_road_segmentation.ipynb',
+]

--- a/docs/tutorials/conftest.py
+++ b/docs/tutorials/conftest.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 collect_ignore = [
+    'change_detection.ipynb',
     'earth_surface_water.ipynb',
     'earthquake_detection.ipynb',
     'naip_road_segmentation.ipynb',


### PR DESCRIPTION
As agreed within the TSC, we want to enable more sophisticated and long running case studies within TorchGeo. A pragmatic way to do this, without overwhelming the CI runners is disabling tests for the case studies. 

Skips testing for the existing case studies. With this approach every new case study needs to be added to the `collect_ignore` list. The upside is, that the URLs to existing case studies stay the same.

The alternative is moving them into a subdirectory and excluding it from pytest, but that would've changed the URLs for those pages on the docs site and broken any existing links.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
