### PR TITLE
feat: Add GeoTIFFWriter callback for chunked COG writing

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,7 @@
 # TorchGeo modules
+callbacks:
+  - changed-files:
+      - any-glob-to-any-file: 'torchgeo/callbacks/**'
 datamodules:
   - changed-files:
       - any-glob-to-any-file: 'torchgeo/datamodules/**'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,9 @@ changelog:
     - title: Backwards-incompatible changes
       labels:
         - backwards-incompatible
+    - title: Callbacks
+      labels:
+        - callbacks
     - title: Dependencies
       labels:
         - dependencies

--- a/docs/api/callbacks.rst
+++ b/docs/api/callbacks.rst
@@ -1,0 +1,4 @@
+torchgeo.callbacks
+==================
+
+.. automodule:: torchgeo.callbacks

--- a/docs/api/callbacks.rst
+++ b/docs/api/callbacks.rst
@@ -1,4 +1,0 @@
-torchgeo.callbacks
-==================
-
-.. automodule:: torchgeo.callbacks

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,6 +6,7 @@ Complete API documentation for all TorchGeo modules.
 .. toctree::
    :maxdepth: 2
 
+   callbacks
    datamodules
    datasets
    losses

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,7 +6,6 @@ Complete API documentation for all TorchGeo modules.
 .. toctree::
    :maxdepth: 2
 
-   callbacks
    datamodules
    datasets
    losses

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ needs_sphinx = '5.3'
 nitpicky = True
 nitpick_ignore = [
     # Undocumented classes
+    ('py:class', 'affine.Affine'),
     ('py:class', 'kornia.augmentation._2d.intensity.base.IntensityAugmentationBase2D'),
     ('py:class', 'kornia.augmentation._3d.geometric.base.GeometricAugmentationBase3D'),
     ('py:class', 'kornia.augmentation.base._AugmentationBase'),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ nitpick_ignore = [
     ('py:class', 'torchmetrics.Recall'),
     ('py:class', 'torchmetrics.detection.mean_ap.MeanAveragePrecision'),
     # Undocumented classes
+    ('py:class', 'affine.Affine'),
     ('py:class', 'kornia.augmentation._2d.intensity.base.IntensityAugmentationBase2D'),
     ('py:class', 'kornia.augmentation._3d.geometric.base.GeometricAugmentationBase3D'),
     ('py:class', 'kornia.augmentation.base._AugmentationBase'),

--- a/tests/callbacks/__init__.py
+++ b/tests/callbacks/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for callbacks."""

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -203,6 +203,34 @@ class TestGeoTIFFWriter:
         with rasterio.open(output) as src:
             assert src.compression.name == 'deflate'
 
+    def test_failed_cog_translation_cleans_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a failed COG translation removes partial output."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        def failing_copy(*args: object, **kwargs: object) -> None:
+            output.touch()
+            raise RuntimeError('COG translation failed')
+
+        monkeypatch.setattr('rasterio.shutil.copy', failing_copy)
+
+        with pytest.raises(RuntimeError, match='COG translation failed'), writer:
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+
+        assert not writer.tmp_path.exists()
+        assert not output.exists()
+
     def test_exception_cleans_up(self, tmp_path: Path) -> None:
         """Test an exception in the with block propagates and leaves no files."""
         output = tmp_path / 'test.tif'

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -181,6 +181,28 @@ class TestGeoTIFFWriter:
             assert src.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG'
             assert src.overviews(1)
 
+    def test_cog_kwargs_forwarded(self, tmp_path: Path) -> None:
+        """Test that extra kwargs are forwarded to the COG driver."""
+        output = tmp_path / 'test_deflate.tif'
+        transform = Affine(1, 0, 0, 0, -1, 1024)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=1024,
+            height=1024,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+            compress='deflate',
+        )
+
+        data = np.ones((1024, 1024), dtype=np.uint8)
+        with writer:
+            writer.write_chunk(data, 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.compression.name == 'deflate'
+
     def test_exception_cleans_up(self, tmp_path: Path) -> None:
         """Test an exception in the with block propagates and leaves no files."""
         output = tmp_path / 'test.tif'

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import rasterio
-from rasterio.transform import Affine
+from affine import Affine
 
 from torchgeo.callbacks.writer import GeoTIFFWriter
 
@@ -157,24 +157,6 @@ class TestGeoTIFFWriter:
         with rasterio.open(output) as src:
             assert src.nodata is None
 
-    def test_write_without_context_raises(self, tmp_path: Path) -> None:
-        """Test writing without context manager raises error."""
-        output = tmp_path / 'test.tif'
-        transform = Affine(1, 0, 0, 0, -1, 100)
-
-        writer = GeoTIFFWriter(
-            output_path=output,
-            width=64,
-            height=64,
-            num_bands=1,
-            crs='EPSG:32631',
-            transform=transform,
-        )
-
-        data = np.ones((64, 64), dtype=np.uint8)
-        with pytest.raises(RuntimeError, match='Writer not opened'):
-            writer.write_chunk(data, 0, 0)
-
     def test_finalize_creates_cog(self, tmp_path: Path) -> None:
         """Test finalize produces a valid Cloud-Optimized GeoTIFF."""
         output = tmp_path / 'test_cog.tif'
@@ -187,7 +169,7 @@ class TestGeoTIFFWriter:
             num_bands=1,
             crs='EPSG:32631',
             transform=transform,
-            cog_config={'overview_resampling': 'nearest'},
+            overview_resampling='nearest',
         )
 
         data = np.ones((1024, 1024), dtype=np.uint8)
@@ -213,10 +195,9 @@ class TestGeoTIFFWriter:
             transform=transform,
         )
 
-        with pytest.raises(ValueError, match='boom'):
-            with writer:
-                writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
-                raise ValueError('boom')
+        with pytest.raises(ValueError, match='boom'), writer:
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+            raise ValueError('boom')
 
         assert not writer.tmp_path.exists()
         assert not output.exists()

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -35,6 +35,8 @@ class TestGeoTIFFWriter:
         with writer:
             writer.write_chunk(data, 0, 0)
 
+        writer.finalize()
+
         with rasterio.open(output) as src:
             assert src.width == 64
             assert src.height == 64
@@ -62,6 +64,8 @@ class TestGeoTIFFWriter:
             writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 3, 64, 0)
             writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 4, 64, 64)
 
+        writer.finalize()
+
         with rasterio.open(output) as src:
             data = src.read(1)
             assert data[0, 0] == 1
@@ -87,26 +91,28 @@ class TestGeoTIFFWriter:
         with pytest.raises(RuntimeError, match='Writer not opened'):
             writer.write_chunk(data, 0, 0)
 
-    def test_finalize_with_overviews(self, tmp_path: Path) -> None:
-        """Test finalize creates overviews when configured."""
+    def test_finalize_creates_cog(self, tmp_path: Path) -> None:
+        """Test finalize produces a valid Cloud-Optimized GeoTIFF."""
         output = tmp_path / 'test_cog.tif'
-        transform = Affine(1, 0, 0, 0, -1, 256)
+        transform = Affine(1, 0, 0, 0, -1, 1024)
 
         writer = GeoTIFFWriter(
             output_path=output,
-            width=256,
-            height=256,
+            width=1024,
+            height=1024,
             num_bands=1,
             crs='EPSG:32631',
             transform=transform,
-            cog_config={'overviews': [2, 4], 'overview_resampling': 'nearest'},
+            cog_config={'overview_resampling': 'nearest'},
         )
 
-        data = np.ones((256, 256), dtype=np.uint8)
+        data = np.ones((1024, 1024), dtype=np.uint8)
         with writer:
             writer.write_chunk(data, 0, 0)
 
         writer.finalize()
 
+        assert not writer.tmp_path.exists()
         with rasterio.open(output) as src:
-            assert src.overviews(1) == [2, 4]
+            assert src.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG'
+            assert src.overviews(1)

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -116,6 +116,47 @@ class TestGeoTIFFWriter:
             assert src.dtypes[0] == 'float32'
             np.testing.assert_array_equal(src.read(1), data)
 
+    def test_nodata(self, tmp_path: Path) -> None:
+        """Test nodata value is written to the output."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+            nodata=0,
+        )
+
+        with writer:
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.nodata == 0
+
+    def test_nodata_default_none(self, tmp_path: Path) -> None:
+        """Test the default nodata of None does not break writing."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        with writer:
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.nodata is None
+
     def test_write_without_context_raises(self, tmp_path: Path) -> None:
         """Test writing without context manager raises error."""
         output = tmp_path / 'test.tif'

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -231,6 +231,46 @@ class TestGeoTIFFWriter:
         assert not writer.tmp_path.exists()
         assert not output.exists()
 
+    def test_output_path_exists(self, tmp_path: Path) -> None:
+        """Test that entering the writer raises if output_path already exists."""
+        output = tmp_path / 'test.tif'
+        output.touch()
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        with pytest.raises(FileExistsError, match='already exists'):
+            writer.__enter__()
+
+    def test_overwrite(self, tmp_path: Path) -> None:
+        """Test that overwrite=True allows replacing an existing file."""
+        output = tmp_path / 'test.tif'
+        output.touch()
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+            overwrite=True,
+        )
+
+        with writer:
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.width == 64
+
     def test_exception_cleans_up(self, tmp_path: Path) -> None:
         """Test an exception in the with block propagates and leaves no files."""
         output = tmp_path / 'test.tif'

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -35,8 +35,6 @@ class TestGeoTIFFWriter:
         with writer:
             writer.write_chunk(data, 0, 0)
 
-        writer.finalize()
-
         with rasterio.open(output) as src:
             assert src.width == 64
             assert src.height == 64
@@ -63,8 +61,6 @@ class TestGeoTIFFWriter:
             writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 2, 0, 64)
             writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 3, 64, 0)
             writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 4, 64, 64)
-
-        writer.finalize()
 
         with rasterio.open(output) as src:
             data = src.read(1)
@@ -110,9 +106,29 @@ class TestGeoTIFFWriter:
         with writer:
             writer.write_chunk(data, 0, 0)
 
-        writer.finalize()
-
         assert not writer.tmp_path.exists()
         with rasterio.open(output) as src:
             assert src.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG'
             assert src.overviews(1)
+
+    def test_exception_cleans_up(self, tmp_path: Path) -> None:
+        """Test an exception in the with block propagates and leaves no files."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        with pytest.raises(ValueError, match='boom'):
+            with writer:
+                writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+                raise ValueError('boom')
+
+        assert not writer.tmp_path.exists()
+        assert not output.exists()

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -1,0 +1,112 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for GeoTIFF writer."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import Affine
+
+from torchgeo.callbacks.writer import GeoTIFFWriter
+
+
+class TestGeoTIFFWriter:
+    """Tests for GeoTIFFWriter."""
+
+    def test_write_single_chunk(self, tmp_path: Path) -> None:
+        """Test writing single chunk."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        data = np.arange(64 * 64, dtype=np.uint8).reshape(64, 64)
+
+        with writer:
+            writer.write_chunk(data, 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.width == 64
+            assert src.height == 64
+            assert src.crs.to_string() == 'EPSG:32631'
+            assert src.transform == transform
+            np.testing.assert_array_equal(src.read(1), data)
+
+    def test_write_multiple_chunks(self, tmp_path: Path) -> None:
+        """Test writing multiple chunks."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=128,
+            height=128,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        with writer:
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8), 0, 0)
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 2, 0, 64)
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 3, 64, 0)
+            writer.write_chunk(np.ones((64, 64), dtype=np.uint8) * 4, 64, 64)
+
+        with rasterio.open(output) as src:
+            data = src.read(1)
+            assert data[0, 0] == 1
+            assert data[0, 127] == 2
+            assert data[127, 0] == 3
+            assert data[127, 127] == 4
+
+    def test_write_without_context_raises(self, tmp_path: Path) -> None:
+        """Test writing without context manager raises error."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        data = np.ones((64, 64), dtype=np.uint8)
+        with pytest.raises(RuntimeError, match='Writer not opened'):
+            writer.write_chunk(data, 0, 0)
+
+    def test_finalize_with_overviews(self, tmp_path: Path) -> None:
+        """Test finalize creates overviews when configured."""
+        output = tmp_path / 'test_cog.tif'
+        transform = Affine(1, 0, 0, 0, -1, 256)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=256,
+            height=256,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+            cog_config={'overviews': [2, 4], 'overview_resampling': 'nearest'},
+        )
+
+        data = np.ones((256, 256), dtype=np.uint8)
+        with writer:
+            writer.write_chunk(data, 0, 0)
+
+        writer.finalize()
+
+        with rasterio.open(output) as src:
+            assert src.overviews(1) == [2, 4]

--- a/tests/callbacks/test_writer.py
+++ b/tests/callbacks/test_writer.py
@@ -69,6 +69,53 @@ class TestGeoTIFFWriter:
             assert data[127, 0] == 3
             assert data[127, 127] == 4
 
+    def test_write_multi_band(self, tmp_path: Path) -> None:
+        """Test writing multi-band chunks."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=3,
+            crs='EPSG:32631',
+            transform=transform,
+        )
+
+        data = np.arange(3 * 64 * 64, dtype=np.uint8).reshape(3, 64, 64)
+
+        with writer:
+            writer.write_chunk(data, 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.count == 3
+            np.testing.assert_array_equal(src.read(), data)
+
+    def test_write_float(self, tmp_path: Path) -> None:
+        """Test writing float chunks."""
+        output = tmp_path / 'test.tif'
+        transform = Affine(1, 0, 0, 0, -1, 100)
+
+        writer = GeoTIFFWriter(
+            output_path=output,
+            width=64,
+            height=64,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=transform,
+            dtype='float32',
+        )
+
+        data = np.random.rand(64, 64).astype(np.float32)
+
+        with writer:
+            writer.write_chunk(data, 0, 0)
+
+        with rasterio.open(output) as src:
+            assert src.dtypes[0] == 'float32'
+            np.testing.assert_array_equal(src.read(1), data)
+
     def test_write_without_context_raises(self, tmp_path: Path) -> None:
         """Test writing without context manager raises error."""
         output = tmp_path / 'test.tif'

--- a/torchgeo/callbacks/__init__.py
+++ b/torchgeo/callbacks/__init__.py
@@ -2,7 +2,3 @@
 # Licensed under the MIT License.
 
 """TorchGeo callbacks."""
-
-from .writer import GeoTIFFWriter
-
-__all__ = ['GeoTIFFWriter']

--- a/torchgeo/callbacks/__init__.py
+++ b/torchgeo/callbacks/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""TorchGeo callbacks."""
+
+from .writer import GeoTIFFWriter
+
+__all__ = ['GeoTIFFWriter']

--- a/torchgeo/callbacks/__init__.py
+++ b/torchgeo/callbacks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
 """TorchGeo callbacks."""

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 import rasterio
+import rasterio.shutil
 from rasterio.transform import Affine
 from rasterio.windows import Window
 
@@ -68,6 +69,7 @@ class GeoTIFFWriter:
         self.dtype = dtype
         self.cog_config = cog_config or {}
 
+        self.tmp_path = self.output_path.with_suffix('.tmp.tif')
         self.dataset: Any = None
 
     def __enter__(self) -> GeoTIFFWriter:
@@ -86,9 +88,10 @@ class GeoTIFFWriter:
             'transform': self.transform,
             'tiled': True,
             'compress': self.cog_config.get('compress', 'lzw'),
+            'BIGTIFF': 'IF_SAFER',
         }
 
-        self.dataset = rasterio.open(self.output_path, 'w', **kwargs)
+        self.dataset = rasterio.open(self.tmp_path, 'w', **kwargs)
         return self
 
     def write_chunk(
@@ -120,29 +123,18 @@ class GeoTIFFWriter:
             self.dataset.close()
 
     def finalize(self) -> None:
-        """Build overview pyramids for Cloud-Optimized GeoTIFF.
+        """Translate the written GTiff into a Cloud-Optimized GeoTIFF.
 
-        Builds internal overviews at the specified levels using the configured
-        resampling method. Overviews enable efficient visualization at multiple
-        zoom levels without loading the full resolution image.
+        Streams the temporary GTiff through the GDAL COG driver, which builds
+        overviews so it validates as a COG, without loading the full resolution
+        image into memory.
         """
-        if self.cog_config.get('overviews'):
-            overview_levels = self.cog_config['overviews']
-            resampling = self.cog_config.get('overview_resampling', 'nearest')
-
-            from rasterio.enums import Resampling
-
-            resampling_map = {
-                'nearest': Resampling.nearest,
-                'bilinear': Resampling.bilinear,
-                'cubic': Resampling.cubic,
-                'average': Resampling.average,
-                'mode': Resampling.mode,
-            }
-
-            resampling_method = resampling_map.get(
-                resampling.lower(), Resampling.nearest
-            )
-
-            with rasterio.open(self.output_path, 'r+') as dst:
-                dst.build_overviews(overview_levels, resampling_method)
+        rasterio.shutil.copy(
+            self.tmp_path,
+            self.output_path,
+            driver='COG',
+            compress=self.cog_config.get('compress', 'lzw'),
+            overview_resampling=self.cog_config.get('overview_resampling', 'nearest'),
+            BIGTIFF='IF_SAFER',
+        )
+        self.tmp_path.unlink()

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -164,5 +164,8 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
                 BIGTIFF='IF_SAFER',
                 **extra,
             )
+        except Exception:
+            self.output_path.unlink(missing_ok=True)
+            raise
         finally:
             self.tmp_path.unlink(missing_ok=True)

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -42,6 +42,7 @@ class GeoTIFFWriter:
         crs: Any,
         transform: Affine,
         dtype: str = 'uint8',
+        nodata: float | None = None,
         cog_config: dict[str, Any] | None = None,
     ) -> None:
         """Initialize writer.
@@ -54,6 +55,7 @@ class GeoTIFFWriter:
             crs: Coordinate reference system.
             transform: Affine transform.
             dtype: Output data type.
+            nodata: Value to use for nodata pixels.
             cog_config: Optional COG configuration.
         """
         self.output_path = Path(output_path)
@@ -63,6 +65,7 @@ class GeoTIFFWriter:
         self.crs = crs
         self.transform = transform
         self.dtype = dtype
+        self.nodata = nodata
         self.cog_config = cog_config or {}
 
         self.tmp_path = self.output_path.with_suffix('.tmp.tif')
@@ -82,6 +85,7 @@ class GeoTIFFWriter:
             'dtype': self.dtype,
             'crs': self.crs,
             'transform': self.transform,
+            'nodata': self.nodata,
             'tiled': True,
             'compress': self.cog_config.get('compress', 'lzw'),
             'BIGTIFF': 'IF_SAFER',

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -50,6 +50,7 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
         transform: Affine,
         dtype: str = 'uint8',
         nodata: float | None = None,
+        overwrite: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize writer.
@@ -63,6 +64,7 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
             transform: Affine transform.
             dtype: Output data type.
             nodata: Value to use for nodata pixels.
+            overwrite: If True, overwrite an existing file at *output_path*.
             **kwargs: Additional keyword arguments passed to the GDAL COG
                 driver (e.g. ``compress``, ``overview_resampling``).
         """
@@ -74,6 +76,7 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
         self.transform = transform
         self.dtype = dtype
         self.nodata = nodata
+        self.overwrite = overwrite
         self.kwargs = kwargs
 
         self.tmp_path = self.output_path.with_suffix('.tmp.tif')
@@ -85,6 +88,10 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
         Returns:
             GeoTIFFWriter instance.
         """
+        if self.output_path.exists() and not self.overwrite:
+            msg = f'Output path already exists: {self.output_path}'
+            raise FileExistsError(msg)
+
         self.dataset = rasterio.open(
             self.tmp_path,
             'w',

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -1,0 +1,148 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""GeoTIFF writer with Cloud-Optimized GeoTIFF support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import rasterio
+from rasterio.transform import Affine
+from rasterio.windows import Window
+
+
+class GeoTIFFWriter:
+    """GeoTIFF writer with chunked writing and COG support.
+
+    Example::
+
+        writer = GeoTIFFWriter(
+            output_path='output.tif',
+            width=1024,
+            height=1024,
+            num_bands=1,
+            crs='EPSG:32631',
+            transform=Affine(...),
+        )
+
+        with writer:
+            for chunk_y, chunk_x, chunk_data in chunks:
+                writer.write_chunk(chunk_data, chunk_y, chunk_x)
+
+        writer.finalize()
+
+    """
+
+    def __init__(
+        self,
+        output_path: str | Path,
+        width: int,
+        height: int,
+        num_bands: int,
+        crs: Any,
+        transform: Affine,
+        dtype: str = 'uint8',
+        cog_config: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize writer.
+
+        Args:
+            output_path: Path to save GeoTIFF.
+            width: Image width in pixels.
+            height: Image height in pixels.
+            num_bands: Number of bands.
+            crs: Coordinate reference system.
+            transform: Affine transform.
+            dtype: Output data type.
+            cog_config: Optional COG configuration.
+        """
+        self.output_path = Path(output_path)
+        self.width = width
+        self.height = height
+        self.num_bands = num_bands
+        self.crs = crs
+        self.transform = transform
+        self.dtype = dtype
+        self.cog_config = cog_config or {}
+
+        self.dataset: Any = None
+
+    def __enter__(self) -> GeoTIFFWriter:
+        """Open GeoTIFF for writing.
+
+        Returns:
+            GeoTIFFWriter instance.
+        """
+        kwargs = {
+            'driver': 'GTiff',
+            'height': self.height,
+            'width': self.width,
+            'count': self.num_bands,
+            'dtype': self.dtype,
+            'crs': self.crs,
+            'transform': self.transform,
+            'tiled': True,
+            'compress': self.cog_config.get('compress', 'lzw'),
+        }
+
+        self.dataset = rasterio.open(self.output_path, 'w', **kwargs)
+        return self
+
+    def write_chunk(
+        self, data: np.typing.NDArray[np.uint8], y_offset: int, x_offset: int
+    ) -> None:
+        """Write a chunk to the output GeoTIFF.
+
+        Args:
+            data: Chunk data of shape (H, W) for single band.
+            y_offset: Row offset in output.
+            x_offset: Column offset in output.
+        """
+        if self.dataset is None:
+            raise RuntimeError('Writer not opened. Use with statement.')
+
+        h, w = data.shape
+        window = Window(x_offset, y_offset, w, h)  # ty: ignore[too-many-positional-arguments]
+        self.dataset.write(data, 1, window=window)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Close dataset on exit.
+
+        Args:
+            exc_type: Exception type.
+            exc_val: Exception value.
+            exc_tb: Exception traceback.
+        """
+        if self.dataset:
+            self.dataset.close()
+
+    def finalize(self) -> None:
+        """Build overview pyramids for Cloud-Optimized GeoTIFF.
+
+        Builds internal overviews at the specified levels using the configured
+        resampling method. Overviews enable efficient visualization at multiple
+        zoom levels without loading the full resolution image.
+        """
+        if self.cog_config.get('overviews'):
+            overview_levels = self.cog_config['overviews']
+            resampling = self.cog_config.get('overview_resampling', 'nearest')
+
+            from rasterio.enums import Resampling
+
+            resampling_map = {
+                'nearest': Resampling.nearest,
+                'bilinear': Resampling.bilinear,
+                'cubic': Resampling.cubic,
+                'average': Resampling.average,
+                'mode': Resampling.mode,
+            }
+
+            resampling_method = resampling_map.get(
+                resampling.lower(), Resampling.nearest
+            )
+
+            with rasterio.open(self.output_path, 'r+') as dst:
+                dst.build_overviews(overview_levels, resampling_method)

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 import rasterio
 import rasterio.shutil
+from pyproj import CRS
 from rasterio.transform import Affine
 from rasterio.windows import Window
 
@@ -31,6 +32,7 @@ class GeoTIFFWriter:
             for chunk_y, chunk_x, chunk_data in chunks:
                 writer.write_chunk(chunk_data, chunk_y, chunk_x)
 
+    .. versionadded:: 0.10
     """
 
     def __init__(
@@ -39,7 +41,7 @@ class GeoTIFFWriter:
         width: int,
         height: int,
         num_bands: int,
-        crs: Any,
+        crs: CRS | str,
         transform: Affine,
         dtype: str = 'uint8',
         nodata: float | None = None,

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -5,18 +5,23 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+import contextlib
+import pathlib
+import types
+from typing import Any, Self
 
 import numpy as np
 import rasterio
 import rasterio.shutil
-from pyproj import CRS
+from rasterio.crs import CRS
+from rasterio.io import DatasetWriter
 from rasterio.transform import Affine
 from rasterio.windows import Window
 
+from torchgeo.datasets.utils import Path
 
-class GeoTIFFWriter:
+
+class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
     """GeoTIFF writer with chunked writing and COG support.
 
     Example::
@@ -37,7 +42,7 @@ class GeoTIFFWriter:
 
     def __init__(
         self,
-        output_path: str | Path,
+        output_path: Path,
         width: int,
         height: int,
         num_bands: int,
@@ -45,7 +50,7 @@ class GeoTIFFWriter:
         transform: Affine,
         dtype: str = 'uint8',
         nodata: float | None = None,
-        cog_config: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize writer.
 
@@ -58,9 +63,10 @@ class GeoTIFFWriter:
             transform: Affine transform.
             dtype: Output data type.
             nodata: Value to use for nodata pixels.
-            cog_config: Optional COG configuration.
+            **kwargs: Additional keyword arguments passed to the GDAL COG
+                driver (e.g. ``compress``, ``overview_resampling``).
         """
-        self.output_path = Path(output_path)
+        self.output_path = pathlib.Path(output_path)
         self.width = width
         self.height = height
         self.num_bands = num_bands
@@ -68,32 +74,32 @@ class GeoTIFFWriter:
         self.transform = transform
         self.dtype = dtype
         self.nodata = nodata
-        self.cog_config = cog_config or {}
+        self.kwargs = kwargs
 
         self.tmp_path = self.output_path.with_suffix('.tmp.tif')
-        self.dataset: Any = None
+        self.dataset: DatasetWriter | None = None
 
-    def __enter__(self) -> GeoTIFFWriter:
+    def __enter__(self) -> Self:
         """Open GeoTIFF for writing.
 
         Returns:
             GeoTIFFWriter instance.
         """
-        kwargs = {
-            'driver': 'GTiff',
-            'height': self.height,
-            'width': self.width,
-            'count': self.num_bands,
-            'dtype': self.dtype,
-            'crs': self.crs,
-            'transform': self.transform,
-            'nodata': self.nodata,
-            'tiled': True,
-            'compress': self.cog_config.get('compress', 'lzw'),
-            'BIGTIFF': 'IF_SAFER',
-        }
-
-        self.dataset = rasterio.open(self.tmp_path, 'w', **kwargs)
+        self.dataset = rasterio.open(
+            self.tmp_path,
+            'w',
+            driver='GTiff',
+            height=self.height,
+            width=self.width,
+            count=self.num_bands,
+            dtype=self.dtype,
+            crs=self.crs,
+            transform=self.transform,
+            nodata=self.nodata,
+            tiled=True,
+            compress=self.kwargs.get('compress', 'lzw'),
+            BIGTIFF='IF_SAFER',
+        )
         return self
 
     def write_chunk(
@@ -107,16 +113,18 @@ class GeoTIFFWriter:
             y_offset: Row offset in output.
             x_offset: Column offset in output.
         """
-        if self.dataset is None:
-            raise RuntimeError('Writer not opened. Use with statement.')
-
         if data.ndim == 2:
             data = data[np.newaxis]
         _, h, w = data.shape
-        window = Window(x_offset, y_offset, w, h)  # ty: ignore[too-many-positional-arguments]
+        window = Window(x_offset, y_offset, w, h)
         self.dataset.write(data, window=window)
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
         """Finalize the COG on exit and clean up the temporary file.
 
         Args:
@@ -146,10 +154,8 @@ class GeoTIFFWriter:
                 self.tmp_path,
                 self.output_path,
                 driver='COG',
-                compress=self.cog_config.get('compress', 'lzw'),
-                overview_resampling=self.cog_config.get(
-                    'overview_resampling', 'nearest'
-                ),
+                compress=self.kwargs.get('compress', 'lzw'),
+                overview_resampling=self.kwargs.get('overview_resampling', 'nearest'),
                 BIGTIFF='IF_SAFER',
             )
         finally:

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -20,20 +20,16 @@ class GeoTIFFWriter:
 
     Example::
 
-        writer = GeoTIFFWriter(
+        with GeoTIFFWriter(
             output_path='output.tif',
             width=1024,
             height=1024,
             num_bands=1,
             crs='EPSG:32631',
             transform=Affine(...),
-        )
-
-        with writer:
+        ) as writer:
             for chunk_y, chunk_x, chunk_data in chunks:
                 writer.write_chunk(chunk_data, chunk_y, chunk_x)
-
-        writer.finalize()
 
     """
 
@@ -112,7 +108,7 @@ class GeoTIFFWriter:
         self.dataset.write(data, 1, window=window)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Close dataset on exit.
+        """Finalize the COG on exit and clean up the temporary file.
 
         Args:
             exc_type: Exception type.
@@ -121,20 +117,31 @@ class GeoTIFFWriter:
         """
         if self.dataset:
             self.dataset.close()
+            self.dataset = None
 
-    def finalize(self) -> None:
+        if exc_type is not None:
+            self.tmp_path.unlink(missing_ok=True)
+            return
+
+        self._finalize()
+
+    def _finalize(self) -> None:
         """Translate the written GTiff into a Cloud-Optimized GeoTIFF.
 
         Streams the temporary GTiff through the GDAL COG driver, which builds
         overviews so it validates as a COG, without loading the full resolution
         image into memory.
         """
-        rasterio.shutil.copy(
-            self.tmp_path,
-            self.output_path,
-            driver='COG',
-            compress=self.cog_config.get('compress', 'lzw'),
-            overview_resampling=self.cog_config.get('overview_resampling', 'nearest'),
-            BIGTIFF='IF_SAFER',
-        )
-        self.tmp_path.unlink()
+        try:
+            rasterio.shutil.copy(
+                self.tmp_path,
+                self.output_path,
+                driver='COG',
+                compress=self.cog_config.get('compress', 'lzw'),
+                overview_resampling=self.cog_config.get(
+                    'overview_resampling', 'nearest'
+                ),
+                BIGTIFF='IF_SAFER',
+            )
+        finally:
+            self.tmp_path.unlink(missing_ok=True)

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -149,6 +149,11 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
         overviews so it validates as a COG, without loading the full resolution
         image into memory.
         """
+        extra = {
+            k: v
+            for k, v in self.kwargs.items()
+            if k not in ('compress', 'overview_resampling')
+        }
         try:
             rasterio.shutil.copy(
                 self.tmp_path,
@@ -157,6 +162,7 @@ class GeoTIFFWriter(contextlib.AbstractContextManager['GeoTIFFWriter']):
                 compress=self.kwargs.get('compress', 'lzw'),
                 overview_resampling=self.kwargs.get('overview_resampling', 'nearest'),
                 BIGTIFF='IF_SAFER',
+                **extra,
             )
         finally:
             self.tmp_path.unlink(missing_ok=True)

--- a/torchgeo/callbacks/writer.py
+++ b/torchgeo/callbacks/writer.py
@@ -91,21 +91,24 @@ class GeoTIFFWriter:
         return self
 
     def write_chunk(
-        self, data: np.typing.NDArray[np.uint8], y_offset: int, x_offset: int
+        self, data: np.typing.NDArray[Any], y_offset: int, x_offset: int
     ) -> None:
         """Write a chunk to the output GeoTIFF.
 
         Args:
-            data: Chunk data of shape (H, W) for single band.
+            data: Chunk data of shape (H, W) for single band or (C, H, W) for
+                multi-band.
             y_offset: Row offset in output.
             x_offset: Column offset in output.
         """
         if self.dataset is None:
             raise RuntimeError('Writer not opened. Use with statement.')
 
-        h, w = data.shape
+        if data.ndim == 2:
+            data = data[np.newaxis]
+        _, h, w = data.shape
         window = Window(x_offset, y_offset, w, h)  # ty: ignore[too-many-positional-arguments]
-        self.dataset.write(data, 1, window=window)
+        self.dataset.write(data, window=window)
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Finalize the COG on exit and clean up the temporary file.


### PR DESCRIPTION
This is the first of three PRs splitting up the tiled-inference-callabck #3214 (check out the archtitecture overview there for more context about how this will be used). 

Adds `GeoTIFFWriter`, a rasterio-based utility for writing Cloud-Optimized GeoTIFFs in chunks without loading the full scene into memory. It uses LZW compression, tiled layout, and optional overview building via GDAL if available. 

The writer is a context manager, meaning you open it, call `write_chunk()` for each spatial tile, then `finalize()` builds the overviews and closes the file. No torchgeo internal dependencies, fully standalone. 

PR2 (blending utilities) and PR3 (TiledInferenceCallback) build on top of this.


## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
