### PR TITLE
GeoDataset: ensure axis-aligned bounding boxes after reprojection

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -129,6 +129,19 @@ class TestGeoDataset:
     def test_crs(self, dataset: GeoDataset, crs: CRS) -> None:
         dataset.crs = crs
 
+    def test_crs_geometry_envelope(self) -> None:
+        # Reprojection densifies edges and turns axis-aligned bounding boxes
+        # into curved polygons. The crs setter must restore them to envelopes
+        # so samplers (which sample within geometry.bounds) never produce
+        # queries that fall outside the dataset's geometry.
+        ds = CustomGeoDataset(
+            bounds=[(-2_500_000, 2_500_000, 0, 3_000_000, MINT, MAXT)],
+            crs=CRS.from_epsg(5070),
+        )
+        ds.crs = CRS.from_epsg(32616)
+        for geom in ds.index.geometry:
+            assert geom.equals(shapely.box(*geom.bounds))
+
     def test_and_two(self) -> None:
         ds1 = CustomGeoDataset()
         ds2 = CustomGeoDataset()
@@ -898,6 +911,13 @@ class TestIntersectionDataset:
         assert ds1.res == ds2.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds) == 1
         assert isinstance(sample['image'], torch.Tensor)
+        # After reprojection, the geometry must be an axis-aligned bounding
+        # box so that samplers (which sample within geometry.bounds) never
+        # produce queries that fall outside the dataset's geometry.
+        for geom in ds.index.geometry:
+            assert geom.equals(shapely.box(*geom.bounds))
+        for geom in ds2.index.geometry:
+            assert geom.equals(shapely.box(*geom.bounds))
 
     def test_different_crs_12_3(self) -> None:
         ds1 = RasterDataset(

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -276,6 +276,7 @@ class GeoDataset(Dataset[Sample], abc.ABC):
 
         print(f'Converting {self.__class__.__name__} CRS from {self.crs} to {new_crs}')
         self.index.to_crs(new_crs, inplace=True)
+        self.index['geometry'] = self.index.geometry.envelope
 
     @property
     def res(self) -> tuple[float, float]:
@@ -1541,6 +1542,7 @@ class IntersectionDataset(GeoDataset):
             new_crs: New :term:`coordinate reference system (CRS)`.
         """
         self.index.to_crs(new_crs, inplace=True)
+        self.index['geometry'] = self.index.geometry.envelope
         self.datasets[0].crs = new_crs
         self.datasets[1].crs = new_crs
 
@@ -1685,6 +1687,7 @@ class UnionDataset(GeoDataset):
             new_crs: New :term:`coordinate reference system (CRS)`.
         """
         self.index.to_crs(new_crs, inplace=True)
+        self.index['geometry'] = self.index.geometry.envelope
         self.datasets[0].crs = new_crs
         self.datasets[1].crs = new_crs
 


### PR DESCRIPTION
Fixes a regression introduced when GeoDataset migrated from rtree to geopandas (#2747). Running

```
python -m torchgeo fit --config tests/conf/io_raw.yaml
```

fails with a spurious `IndexError` from CDL.

When reprojecting in the IntersectionDataset, geopandas turns the index geometry from a bbox into an actual polygon (which is curved in the IoBench case). `RandomGeoSampler` then samples from .bounds, and some samples will be outside the intersection area.

This adds tests so this doesn't happen again. Would also love IOBench to be an integration test.

I verified that IOBench runs after this