### PR TITLE
docs: fix version switcher CORS error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ html_theme = 'pydata_sphinx_theme'
 
 # Define the version we use for matching in the version switcher.
 version_match = os.environ.get('READTHEDOCS_VERSION')
-json_url = 'https://torchgeo.readthedocs.io/en/latest/_static/switcher.json'
+json_url = 'https://docs.torchgeo.org/en/latest/_static/switcher.json'
 
 # If READTHEDOCS_VERSION doesn't exist, we're not on RTD
 # If it is an integer, we're in a PR build and the version isn't correct.


### PR DESCRIPTION
The version switcher dropdown was failing to load when accessing docs via docs.torchgeo.org due to a CORS error. This PR updates the URL so that switcher JSON is fetched from the same origin as the docs

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
