### PR TITLE
Add missing version for ty in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies:
+          - ty>=0.0.33
           - einops>=0.6.0
           - kornia>=0.7.4
           - lightning>=2.0.9


### PR DESCRIPTION
This makes local checks behave the same as github action checks.
https://github.com/torchgeo/torchgeo/blob/3a7eda8221e86accee93e53e4e3f7f6f09db1566/pyproject.toml#L139

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [X] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
