### PR TITLE
Build backend: setuptools -> uv-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
 requires = [
-    # setuptools 77.0.1+ required for PEP 639 support
-    "setuptools>=77.0.1",
+    # uv-build 0.7+ required for bdist reorganization
+    "uv_build>=0.7,<0.12",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "uv_build"
 
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
 name = "torchgeo"
+version = "0.10.0.dev0"
 description = "TorchGeo: datasets, samplers, transforms, and pre-trained models for geospatial data"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -87,7 +88,6 @@ dependencies = [
     # can be removed once Python 3.13 is minimum supported version
     "typing-extensions>=4.8",
 ]
-dynamic = ["version"]
 
 [project.optional-dependencies]
 datasets = [
@@ -252,16 +252,6 @@ split-on-trailing-comma = false
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
-[tool.setuptools.dynamic]
-version = {attr = "torchgeo.__version__"}
-
-[tool.setuptools.package-data]
-torchgeo = ["py.typed"]
-
-[tool.setuptools.packages.find]
-include = ["torchgeo*"]
-
 [tool.ty.rules]
 deprecated = "ignore"
 unresolved-attribute = "ignore"
@@ -270,3 +260,6 @@ unresolved-import = "ignore"
 [tool.ty.src]
 include = ["torchgeo", "tests"]
 exclude = ["tests/data"]
+
+[tool.uv.build-backend]
+module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -3709,6 +3709,7 @@ wheels = [
 
 [[package]]
 name = "torchgeo"
+version = "0.10.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
We've successfully dodged plenty of new hype build tools in the past (flit, poetry, hatch) but uv feels different. Since we are actively using it as a build _frontend_, we should consider using it as a build _backend_ too.

### Pros

* 8x faster than setuptools (1.4 s -> 170 ms)

### Cons

* Does not yet support dynamic version metadata: https://github.com/astral-sh/uv/issues/11718
* Lacks a lot of other setuptools features, but we don't use those right now anyway
* A bit buggy in my experience: https://github.com/astral-sh/uv/issues/19403, https://github.com/astral-sh/uv/issues/19404

Any other pros/cons I'm missing that could help us decide?

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
