### PR TITLE
Documentation: fix uv installation instructions

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -66,7 +66,8 @@ To develop TorchGeo itself, clone the repository, create a new virtual environme
    $ git clone https://github.com/torchgeo/torchgeo.git
    $ cd torchgeo
    $ uv venv
-   $ . .venv/bin/activate
+   $ source .venv/bin/activate  # macOS/Linux
+   $ .venv\Scripts\activate     # Windows
    $ uv sync
 
 See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -66,7 +66,7 @@ To develop TorchGeo itself, clone the repository, create a new virtual environme
    $ git clone https://github.com/torchgeo/torchgeo.git
    $ cd torchgeo
    $ uv venv
-   $ . .venv/bin/activate.sh
+   $ . .venv/bin/activate
    $ uv sync
 
 See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -57,7 +57,7 @@ Optional dependencies can be added using extras:
 
 .. code-block:: console
 
-   $ uv add torchgeo[datasets,models]
+   $ uv add torchgeo --extra datasets --extra models
 
 To develop TorchGeo itself, clone the repository, create a new virtual environment, and sync the dependencies:
 
@@ -68,7 +68,7 @@ To develop TorchGeo itself, clone the repository, create a new virtual environme
    $ uv venv
    $ source .venv/bin/activate  # macOS/Linux
    $ .venv\Scripts\activate     # Windows
-   $ uv sync
+   $ uv sync --extra all
 
 See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -59,15 +59,12 @@ Optional dependencies can be added using extras:
 
    $ uv add torchgeo --extra datasets --extra models
 
-To develop TorchGeo itself, clone the repository, create a new virtual environment, and sync the dependencies:
+To develop TorchGeo itself, clone the repository and sync the dependencies:
 
 .. code-block:: console
 
    $ git clone https://github.com/torchgeo/torchgeo.git
    $ cd torchgeo
-   $ uv venv
-   $ source .venv/bin/activate  # macOS/Linux
-   $ .venv\Scripts\activate     # Windows
    $ uv sync --extra all
 
 See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -59,18 +59,14 @@ Optional dependencies can be added using extras:
 
    $ uv add torchgeo[datasets,models]
 
-To develop TorchGeo itself, clone the repository and add it as an editable dependency:
+To develop TorchGeo itself, clone the repository, create a new virtual environment, and sync the dependencies:
 
 .. code-block:: console
 
    $ git clone https://github.com/torchgeo/torchgeo.git
    $ cd torchgeo
-   $ uv add --editable .
-
-To sync all dependencies after making changes:
-
-.. code-block:: console
-
+   $ uv venv
+   $ . .venv/bin/activate.sh
    $ uv sync
 
 See the `uv documentation <https://docs.astral.sh/uv/>`_ for more details.


### PR DESCRIPTION
Previous instructions don't work at all?
```console
> uv add --editable .
error: Requirement name `torchgeo` matches project name `torchgeo`, but self-dependencies are not permitted without the `--dev` or `--optional` flags. If your project name (`torchgeo`) is shadowing that of a third-party dependency, consider renaming the project.
```

@nuglifeleoji

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
