### PR TITLE
DLRSD: fix empty-split UserWarnings in trainer tests

### DIFF
--- a/tests/conf/dlrsd.yaml
+++ b/tests/conf/dlrsd.yaml
@@ -10,5 +10,7 @@ data:
   class_path: DLRSDDataModule
   init_args:
     batch_size: 1
+    val_split_pct: 0.34
+    test_split_pct: 0.34
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd.yaml
+++ b/tests/conf/dlrsd.yaml
@@ -10,7 +10,7 @@ data:
   class_path: DLRSDDataModule
   init_args:
     batch_size: 1
-    val_split_pct: 0.34
-    test_split_pct: 0.34
+    val_split_pct: 0.3
+    test_split_pct: 0.3
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd_multilabel.yaml
+++ b/tests/conf/dlrsd_multilabel.yaml
@@ -10,7 +10,7 @@ data:
   class_path: DLRSDMultilabelDataModule
   init_args:
     batch_size: 1
-    val_split_pct: 0.34
-    test_split_pct: 0.34
+    val_split_pct: 0.3
+    test_split_pct: 0.3
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd_multilabel.yaml
+++ b/tests/conf/dlrsd_multilabel.yaml
@@ -10,5 +10,7 @@ data:
   class_path: DLRSDMultilabelDataModule
   init_args:
     batch_size: 1
+    val_split_pct: 0.34
+    test_split_pct: 0.34
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd_multilabel_no_val.yaml
+++ b/tests/conf/dlrsd_multilabel_no_val.yaml
@@ -11,5 +11,6 @@ data:
   init_args:
     batch_size: 1
     val_split_pct: 0
+    test_split_pct: 0.34
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd_multilabel_no_val.yaml
+++ b/tests/conf/dlrsd_multilabel_no_val.yaml
@@ -11,6 +11,6 @@ data:
   init_args:
     batch_size: 1
     val_split_pct: 0
-    test_split_pct: 0.34
+    test_split_pct: 0.3
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd_no_val.yaml
+++ b/tests/conf/dlrsd_no_val.yaml
@@ -11,5 +11,6 @@ data:
   init_args:
     batch_size: 1
     val_split_pct: 0
+    test_split_pct: 0.34
   dict_kwargs:
     root: 'tests/data/dlrsd'

--- a/tests/conf/dlrsd_no_val.yaml
+++ b/tests/conf/dlrsd_no_val.yaml
@@ -11,6 +11,6 @@ data:
   init_args:
     batch_size: 1
     val_split_pct: 0
-    test_split_pct: 0.34
+    test_split_pct: 0.3
   dict_kwargs:
     root: 'tests/data/dlrsd'


### PR DESCRIPTION
Closes the `UserWarning: Length of split at index N is 0` warnings emitted by the DLRSD trainer tests after #3498 merged.

## Problem

The fake test data in `tests/data/dlrsd/` only contains 4 images. With the datamodule defaults (`val_split_pct=0.1`, `test_split_pct=0.2`) and the no-val variant (`val_split_pct=0`, `test_split_pct=0.2`), `torch.utils.data.random_split` floors fractions and ends up with an empty split:

```
[0.7, 0.1, 0.2] * 4  ->  [3, 1, 0]
[0.8, 0.2]      * 4  ->  [4, 0]
```

That triggers Lightning/PyTorch's `UserWarning: Length of split at index N is 0`, visible in CI runs for:

- `tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-dlrsd]`
- `tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-dlrsd_no_val]`
- `tests/trainers/test_classification.py::TestClassificationTask::test_trainer[True-dlrsd_multilabel]`
- `tests/trainers/test_classification.py::TestClassificationTask::test_trainer[True-dlrsd_multilabel_no_val]`

## Fix

Override `val_split_pct` / `test_split_pct` in the four trainer conf YAMLs (matching the `spacenet1.yaml` 0.34/0.34 precedent for 3-way splits with small fake data) so every split has at least one sample:

```
[0.32, 0.34, 0.34] * 4  ->  [2, 1, 1]
[0.66, 0.34]       * 4  ->  [3, 1]
```

Verified locally by re-running the datamodule `setup('fit')` under `python -W error::UserWarning` — no warnings emitted, all three splits non-empty.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
