### PR TITLE
IntersectionDataset: drop suffixes after geopandas.overlay

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -50,11 +50,12 @@ class CustomGeoDataset(GeoDataset):
         res: float | tuple[float, float] = (1, 1),
         paths: str | os.PathLike[str] | Iterable[str | os.PathLike[str]] | None = None,
     ) -> None:
+        data = {'filepath': ['file.tif'] * len(bounds)}
         geometry = [shapely.box(b[0], b[2], b[1], b[3]) for b in bounds]
         index = pd.IntervalIndex.from_tuples(
             [(b[4], b[5]) for b in bounds], closed='both', name='datetime'
         )
-        self.index = GeoDataFrame(index=index, geometry=geometry, crs=crs)
+        self.index = GeoDataFrame(data, index=index, geometry=geometry, crs=crs)
         self.res = res
         self.paths = paths or []
 
@@ -149,7 +150,7 @@ class TestGeoDataset:
         ds2 = CustomGeoDataset()
         ds3 = CustomGeoDataset()
         ds4 = CustomGeoDataset()
-        dataset = (ds1 & ds2) & (ds3 & ds4)
+        dataset = ds1 & ds2 & ds3 & ds4
         assert isinstance(dataset, IntersectionDataset)
         assert len(dataset) == 1
 
@@ -173,7 +174,7 @@ class TestGeoDataset:
         ds2 = CustomGeoDataset()
         ds3 = CustomGeoDataset()
         ds4 = CustomGeoDataset()
-        dataset = (ds1 | ds2) | (ds3 | ds4)
+        dataset = ds1 | ds2 | ds3 | ds4
         assert isinstance(dataset, UnionDataset)
         assert len(dataset) == 4
 
@@ -761,7 +762,7 @@ class TestNonGeoDataset:
         ds2 = CustomNonGeoDataset()
         ds3 = CustomNonGeoDataset()
         ds4 = CustomNonGeoDataset()
-        dataset = (ds1 + ds2) + (ds3 + ds4)
+        dataset = ds1 + ds2 + ds3 + ds4
         assert isinstance(dataset, ConcatDataset)
         assert len(dataset) == 8
 
@@ -815,7 +816,7 @@ class TestNonGeoClassificationDataset:
         ds2 = NonGeoClassificationDataset(root)
         ds3 = NonGeoClassificationDataset(root)
         ds4 = NonGeoClassificationDataset(root)
-        dataset = (ds1 + ds2) + (ds3 + ds4)
+        dataset = ds1 + ds2 + ds3 + ds4
         assert isinstance(dataset, ConcatDataset)
         assert len(dataset) == 8
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1471,10 +1471,18 @@ class IntersectionDataset(GeoDataset):
         if self.index.empty:
             raise RuntimeError('Datasets have no spatial intersection')
 
+        # Ensure that resulting index has same columns as original
+        # Suffixes may be okay for 1 intersection but not for many
+        self.index['filepath'] = self.index.pop('filepath_1')
+        self.index.pop('filepath_2')
+
+        name = 'datetime'
+        datetime_1 = pd.IntervalIndex(list(self.index.pop('datetime_1')), name=name)
+        datetime_2 = pd.IntervalIndex(list(self.index.pop('datetime_2')), name=name)
+        self.index.index = datetime_1
+
         # Temporal intersection
         if not spatial_only:
-            datetime_1 = pd.IntervalIndex(list(self.index.pop('datetime_1')))
-            datetime_2 = pd.IntervalIndex(list(self.index.pop('datetime_2')))
             mint = np.maximum(datetime_1.left, datetime_2.left)
             maxt = np.minimum(datetime_1.right, datetime_2.right)
             valid = maxt >= mint

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1471,10 +1471,10 @@ class IntersectionDataset(GeoDataset):
         if self.index.empty:
             raise RuntimeError('Datasets have no spatial intersection')
 
-        # Ensure that resulting index has same columns as original
-        # Suffixes may be okay for 1 intersection but not for many
-        self.index['filepath'] = self.index.pop('filepath_1')
-        self.index.pop('filepath_2')
+        # Remove duplicate columns with a suffix
+        # Pandas does not allow suffixes of suffixes
+        columns = ['filepath_1', 'filepath_2']
+        self.index.drop(columns=columns, inplace=True, errors='ignore')
 
         name = 'datetime'
         datetime_1 = pd.IntervalIndex(list(self.index.pop('datetime_1')), name=name)


### PR DESCRIPTION
Depending on the number of datasets you want to take the intersection of and the order of parentheses, you can quickly end up with suffixes of suffixes, which are disallowed in a pandas merge. This PR ensures that all IntersectionDatasets lack suffixes, allowing for infinitely many intersections. It also adds tests that fail for the previous code but work with the new code to prevent regressions.

@simonreise can you test this and try to break it?

Fixes #3721 

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
