### PR TITLE
datasets: send a torchgeo User-Agent in download_url

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -7,12 +7,14 @@ import re
 import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import pytest
 import torch
 from numpy.typing import NDArray
+from pytest import MonkeyPatch
 from torch import Tensor
 
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
@@ -381,6 +383,23 @@ def test_download_url(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match=r'Downloaded file .* is corrupted'):
         download_url(url, tmp_path, md5=md5 + '2')
+
+
+def test_download_url_interrupted(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    url = Path('tests/data/vhr10/NWPU VHR-10 dataset.zip').absolute().as_uri()
+    filename = 'NWPU VHR-10 dataset.zip'
+
+    def interrupt(*args: Any, **kwargs: Any) -> None:
+        raise OSError('simulated network reset')
+
+    monkeypatch.setattr(shutil, 'copyfileobj', interrupt)
+
+    with pytest.raises(OSError, match='simulated network reset'):
+        download_url(url, tmp_path, filename=filename)
+
+    # Neither a truncated final file nor a leftover temporary file should remain.
+    assert not (tmp_path / filename).exists()
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_download_and_extract_archive(tmp_path: Path) -> None:

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -425,12 +425,17 @@ def download_url(
         # TODO: use gdown if we want Google Drive support
         # TODO: use requests if we want redirect support
         # TODO: use tqdm if we want a progress bar
-        # Some hosts (e.g. Source Cooperative for FieldsOfTheWorld) reject the
-        # default ``Python-urllib/X.Y`` user agent with HTTP 403, so identify
-        # ourselves explicitly.
         request = urllib.request.Request(url, headers={'User-Agent': 'torchgeo'})
-        with urllib.request.urlopen(request) as response, open(fpath, 'wb') as f:
-            shutil.copyfileobj(response, f)
+        # Stream to a temporary file and atomically replace on success so an
+        # interrupted download cannot leave a truncated file behind.
+        tmp = f'{fpath}.tmp'
+        try:
+            with urllib.request.urlopen(request) as response, open(tmp, 'wb') as f:
+                shutil.copyfileobj(response, f)
+            os.replace(tmp, fpath)
+        finally:
+            if os.path.exists(tmp):
+                os.remove(tmp)
         if not check_integrity(fpath, md5, **kwargs):
             raise RuntimeError(f"Downloaded file '{fpath}' is corrupted.")
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -425,7 +425,12 @@ def download_url(
         # TODO: use gdown if we want Google Drive support
         # TODO: use requests if we want redirect support
         # TODO: use tqdm if we want a progress bar
-        urllib.request.urlretrieve(url, fpath)
+        # Some hosts (e.g. Source Cooperative for FieldsOfTheWorld) reject the
+        # default ``Python-urllib/X.Y`` user agent with HTTP 403, so identify
+        # ourselves explicitly.
+        request = urllib.request.Request(url, headers={'User-Agent': 'torchgeo'})
+        with urllib.request.urlopen(request) as response, open(fpath, 'wb') as f:
+            shutil.copyfileobj(response, f)
         if not check_integrity(fpath, md5, **kwargs):
             raise RuntimeError(f"Downloaded file '{fpath}' is corrupted.")
 


### PR DESCRIPTION
Closes #3730. Source Cooperative (which hosts the FieldsOfTheWorld archives) rejects the default Python-urllib/X.Y user agent with HTTP 403. download_url now builds a urllib Request with User-Agent: torchgeo and streams the response to disk via urlopen.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution