### PR TITLE
Add branch coverage for GlobalBuildingMap(GBM) plot

### DIFF
--- a/tests/datasets/test_gbm.py
+++ b/tests/datasets/test_gbm.py
@@ -44,11 +44,10 @@ class TestGlobalBuildingMap:
         sample['prediction'] = sample['mask']
         dataset.plot(sample, suptitle='Test')
         plt.close()
-
         sample = dataset[dataset.bounds]
         dataset.plot(sample, show_titles=False)
         plt.close()
-
+        sample = dataset[dataset.bounds]
         sample['prediction'] = sample['mask']
         dataset.plot(sample, show_titles=False)
         plt.close()

--- a/tests/datasets/test_gbm.py
+++ b/tests/datasets/test_gbm.py
@@ -45,6 +45,14 @@ class TestGlobalBuildingMap:
         dataset.plot(sample, suptitle='Test')
         plt.close()
 
+        sample = dataset[dataset.bounds]
+        dataset.plot(sample, show_titles=False)
+        plt.close()
+
+        sample['prediction'] = sample['mask']
+        dataset.plot(sample, show_titles=False)
+        plt.close()
+
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             GlobalBuildingMap(tmp_path)


### PR DESCRIPTION
Adds the missing branch coverage for the GlobalBuildingMap.plot method.

Right now the test only hits the default path, so a few branches never get exercised:
- show_titles=False 
- a sample with no 'prediction' key
- suptitle=None

Part of #2501


## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans 
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution