### PR TITLE
RegressionTask: use RegressionMixin

### DIFF
--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -202,11 +202,6 @@ class TestRegressionTask:
         )
         trainer.predict(model=model, datamodule=datamodule)
 
-    def test_invalid_loss(self) -> None:
-        match = "Loss type 'invalid_loss' is not valid."
-        with pytest.raises(ValueError, match=match):
-            RegressionTask(model='resnet18', loss='invalid_loss')
-
     @pytest.mark.parametrize(
         'model_name', ['resnet18', 'efficientnetv2_s', 'vit_base_patch16_224']
     )

--- a/torchgeo/trainers/mixins.py
+++ b/torchgeo/trainers/mixins.py
@@ -149,25 +149,34 @@ class RegressionMixin(LightningModule):
         """
         num_outputs = self.hparams['num_outputs']
         labels = self.hparams['labels']
-        metrics = MetricCollection(
-            {
-                'RMSE': ClasswiseWrapper(
-                    MeanSquaredError(squared=False, num_outputs=num_outputs),
-                    labels=labels,
-                    prefix='RMSE_',
-                ),
-                'MSE': ClasswiseWrapper(
-                    MeanSquaredError(squared=True, num_outputs=num_outputs),
-                    labels=labels,
-                    prefix='MSE_',
-                ),
-                'MAE': ClasswiseWrapper(
-                    MeanAbsoluteError(num_outputs=num_outputs),
-                    labels=labels,
-                    prefix='MAE_',
-                ),
-            }
-        )
+        if num_outputs > 1:
+            metrics = MetricCollection(
+                {
+                    'RMSE': ClasswiseWrapper(
+                        MeanSquaredError(squared=False, num_outputs=num_outputs),
+                        labels=labels,
+                        prefix='RMSE_',
+                    ),
+                    'MSE': ClasswiseWrapper(
+                        MeanSquaredError(squared=True, num_outputs=num_outputs),
+                        labels=labels,
+                        prefix='MSE_',
+                    ),
+                    'MAE': ClasswiseWrapper(
+                        MeanAbsoluteError(num_outputs=num_outputs),
+                        labels=labels,
+                        prefix='MAE_',
+                    ),
+                }
+            )
+        else:
+            metrics = MetricCollection(
+                {
+                    'RMSE': MeanSquaredError(squared=False),
+                    'MSE': MeanSquaredError(squared=True),
+                    'MAE': MeanAbsoluteError(),
+                }
+            )
         self.train_metrics = metrics.clone(prefix='train_')
         self.val_metrics = metrics.clone(prefix='val_')
         self.test_metrics = metrics.clone(prefix='test_')

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -4,16 +4,15 @@
 """Trainers for regression."""
 
 import os
+from typing import Literal
 
 import kornia.augmentation as K
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
 import timm
 import torch
-import torch.nn as nn
 from matplotlib.figure import Figure
 from torch import Tensor
-from torchmetrics import MeanAbsoluteError, MeanSquaredError, MetricCollection
 from torchvision.models._api import WeightsEnum
 
 from ..datamodules import BaseDataModule
@@ -22,9 +21,10 @@ from ..datasets.utils import Sample
 from ..models import FCN, get_weight
 from . import utils
 from .base import BaseTask
+from .mixins import RegressionMixin
 
 
-class RegressionTask(BaseTask):
+class RegressionTask(RegressionMixin, BaseTask):
     """Regression."""
 
     target_key = 'label'
@@ -36,8 +36,9 @@ class RegressionTask(BaseTask):
         weights: WeightsEnum | str | bool | None = None,
         in_channels: int = 3,
         num_outputs: int = 1,
+        labels: list[str] | None = None,
         num_filters: int = 3,
-        loss: str = 'mse',
+        loss: Literal['mae', 'mse'] = 'mse',
         lr: float = 1e-3,
         patience: int = 10,
         freeze_backbone: bool = False,
@@ -58,6 +59,7 @@ class RegressionTask(BaseTask):
                 or None for random weights, or the path to a saved model state dict.
             in_channels: Number of input channels to model.
             num_outputs: Number of prediction outputs.
+            labels: List of feature names.
             num_filters: Number of filters. Only applicable when model='fcn'.
             loss: One of 'mse' or 'mae'.
             lr: Learning rate for optimizer.
@@ -77,6 +79,9 @@ class RegressionTask(BaseTask):
         .. versionchanged:: 0.5
            *learning_rate* and *learning_rate_schedule_patience* were renamed to
            *lr* and *patience*.
+
+        .. versionadded:: 0.10
+           The *labels* parameter.
         """
         self.weights = weights
         super().__init__()
@@ -109,45 +114,6 @@ class RegressionTask(BaseTask):
             for param in self.model.get_classifier().parameters():  # ty: ignore[call-non-callable]
                 param.requires_grad = True
 
-    def configure_losses(self) -> None:
-        """Initialize the loss criterion.
-
-        Raises:
-            ValueError: If *loss* is invalid.
-        """
-        loss: str = self.hparams['loss']
-        if loss == 'mse':
-            self.criterion: nn.Module = nn.MSELoss()
-        elif loss == 'mae':
-            self.criterion = nn.L1Loss()
-        else:
-            raise ValueError(
-                f"Loss type '{loss}' is not valid. "
-                "Currently, supports 'mse' or 'mae' loss."
-            )
-
-    def configure_metrics(self) -> None:
-        """Initialize the performance metrics.
-
-        * :class:`~torchmetrics.MeanSquaredError`: The average of the squared
-          differences between the predicted and actual values (MSE) and its
-          square root (RMSE). Lower values are better.
-        * :class:`~torchmetrics.MeanAbsoluteError`: The average of the absolute
-          differences between the predicted and actual values (MAE).
-          Lower values are better.
-        """
-        metrics = MetricCollection(
-            # https://github.com/astral-sh/ty/issues/2985
-            {
-                'RMSE': MeanSquaredError(squared=False),
-                'MSE': MeanSquaredError(squared=True),
-                'MAE': MeanAbsoluteError(),
-            }
-        )
-        self.train_metrics = metrics.clone(prefix='train_')
-        self.val_metrics = metrics.clone(prefix='val_')
-        self.test_metrics = metrics.clone(prefix='test_')
-
     def training_step(
         self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
@@ -171,7 +137,6 @@ class RegressionTask(BaseTask):
         loss: Tensor = self.criterion(y_hat, y)
         self.log('train_loss', loss, batch_size=batch_size)
         self.train_metrics(y_hat, y)
-        self.log_dict(self.train_metrics, batch_size=batch_size)
 
         return loss
 
@@ -195,7 +160,6 @@ class RegressionTask(BaseTask):
         loss = self.criterion(y_hat, y)
         self.log('val_loss', loss, batch_size=batch_size)
         self.val_metrics(y_hat, y)
-        self.log_dict(self.val_metrics, batch_size=batch_size)
 
         if (
             batch_idx < 10
@@ -251,7 +215,6 @@ class RegressionTask(BaseTask):
         loss = self.criterion(y_hat, y)
         self.log('test_loss', loss, batch_size=batch_size)
         self.test_metrics(y_hat, y)
-        self.log_dict(self.test_metrics, batch_size=batch_size)
 
     def predict_step(
         self, batch: Sample, batch_idx: int, dataloader_idx: int = 0


### PR DESCRIPTION
#3668 introduced a new `RegressionMixin`, analogous to the `ClassificationMixin` added in #3328. This is already used in `TemporalRegressionTask`, this PR now adds it to `RegressionTask`.

This also fixes a bug in `RegressionMixin` that broke when `num_outputs == 1`. `ClasswiseWrapper` can only be used when `num_outputs > 1`.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
