### PR TITLE
Silence deprecation warning about torch.jit.script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,8 @@ filterwarnings = [
     # https://github.com/pydantic/pydantic/issues/12618
     "ignore:Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.:UserWarning",
     "ignore:ForwardRef._evaluate is a private API and is retained for compatibility:DeprecationWarning",
+    # https://github.com/pytorch/pytorch/pull/167669
+    'ignore:`torch.jit.script` is not supported in Python 3.14\+ and may break.:DeprecationWarning',
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS


### PR DESCRIPTION
Silences the following warning in CI:
```
.venv/lib/python3.14/site-packages/torch/jit/_script.py:1482: 43 warnings
  /Users/Adam/torchgeo/.venv/lib/python3.14/site-packages/torch/jit/_script.py:1482: DeprecationWarning: `torch.jit.script` is not supported in Python 3.14+ and may break. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(
```
We aren't using JIT, so it's out of our control.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
