### PR TITLE
Silence improper Lightning usage warning

### DIFF
--- a/tests/trainers/test_spatiotemporal_segmentation.py
+++ b/tests/trainers/test_spatiotemporal_segmentation.py
@@ -39,6 +39,7 @@ class TestSpatioTemporalSegmentationTask:
         except MisconfigurationException:
             pass
 
+    @pytest.mark.filterwarnings(r'ignore:You are trying to `self.log\(\)`')
     def test_binary_task(self) -> None:
         model = SpatioTemporalSegmentationTask(
             in_channels=3, task='binary', loss='bce', hidden_dim=8, num_layers=1


### PR DESCRIPTION
Silences the following warning in CI:
```
tests/trainers/test_spatiotemporal_segmentation.py::TestSpatioTemporalSegmentationTask::test_binary_task
  /Users/Adam/torchgeo/.venv/lib/python3.14/site-packages/lightning/pytorch/core/module.py:451: You are trying to `self.log()` but the `self.trainer` reference is not registered on the model yet. This is most likely because the model hasn't been passed to the `Trainer`
```
The _correct_ way to do this would be to create a dataset/datamodule and pass it to a trainer. We currently don't have one for binary/multilabel spatiotemporal semantic segmentation, so I opted to ignore the warning for now.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
