### PR TITLE
NAIP Road Segmentation: fix missing cell ids

### DIFF
--- a/docs/tutorials/naip_road_segmentation.ipynb
+++ b/docs/tutorials/naip_road_segmentation.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f77143aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,6 +13,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3508e814",
    "metadata": {},
    "source": [
     "# NAIP Road Segmentation\n",
@@ -21,6 +23,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "478038fe",
    "metadata": {},
    "source": [
     "## Introduction\n",
@@ -44,6 +47,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3d9c2c12",
    "metadata": {},
    "source": [
     "## Environment\n",
@@ -54,6 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "711c651b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,6 +67,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5bf949da",
    "metadata": {},
    "source": [
     "## Imports\n",
@@ -77,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d58ccb5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,6 +97,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0160ad02",
    "metadata": {},
    "source": [
     "## Dataset\n",
@@ -102,6 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7a4384be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,6 +132,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ab5ba1e8",
    "metadata": {},
    "source": [
     "## Visualize Input Image\n",
@@ -133,6 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0825bb56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,6 +157,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5b1935da",
    "metadata": {},
    "source": [
     "## Load Pre-trained Model\n",
@@ -158,6 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "695e988b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,6 +181,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11790f1c",
    "metadata": {},
    "source": [
     "## Run Inference\n",
@@ -178,6 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b3b773bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,6 +208,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d96b73b6",
    "metadata": {},
    "source": [
     "## Visualize Ground Truth vs Prediction\n",
@@ -210,6 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d1e5d4a4",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Fixes the following warning in CI:
```
reading sources... [ 94%] tutorials/naip_road_segmentation
/home/docs/checkouts/readthedocs.org/user_builds/torchgeo/envs/latest/lib/python3.14/site-packages/nbformat/__init__.py:96: MissingIDFieldWarning: Cell is missing an id field, this will become a hard error in future nbformat versions. You may want to use `normalize()` on your notebooks before validations (available since nbformat 5.1.4). Previous versions of nbformat are fixing this issue transparently, and will stop doing so in the future.
  validate(nb)
```
Looks like this bug was introduced by Claude Opus 4.6: https://github.com/torchgeo/torchgeo/pull/3446/changes/0843bb36cc69ea98c360bd4b84afadefb9a3a33e

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
