### PR TITLE
docs: mention uv in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The recommended way to install TorchGeo is with [pip](https://pip.pypa.io/en/sta
 pip install torchgeo
 ```
 
+or with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv add torchgeo
+```
+
 For [conda](https://docs.conda.io/en/latest/) and [spack](https://spack.io/) installation instructions, see the [documentation](https://torchgeo.readthedocs.io/en/stable/user/installation.html).
 
 ## Documentation


### PR DESCRIPTION
Adds `uv add torchgeo` as an alternative installation method alongside pip in the README, consistent with the uv section already added to `docs/user/installation.rst`.

Partial progress on #2905.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
