### PR TITLE
docs: convert tutorial notebooks from pip to uv

### DIFF
--- a/docs/tutorials/change_detection.ipynb
+++ b/docs/tutorials/change_detection.ipynb
@@ -33,7 +33,7 @@
    "id": "3",
    "metadata": {},
    "outputs": [],
-   "source": "%pip install torchgeo tensorboard"
+   "source": "!uv pip install torchgeo tensorboard"
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/cli.ipynb
+++ b/docs/tutorials/cli.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/contribute_non_geo_dataset.ipynb
+++ b/docs/tutorials/contribute_non_geo_dataset.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/custom_raster_dataset.ipynb
+++ b/docs/tutorials/custom_raster_dataset.ipynb
@@ -93,7 +93,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install torchgeo planetary_computer pystac"
+    "!uv pip install torchgeo planetary_computer pystac"
    ]
   },
   {

--- a/docs/tutorials/custom_segmentation_trainer.ipynb
+++ b/docs/tutorials/custom_segmentation_trainer.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/earth_surface_water.ipynb
+++ b/docs/tutorials/earth_surface_water.ipynb
@@ -74,7 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install torchgeo scikit-learn planetary-computer pystac"
+    "!uv pip install torchgeo scikit-learn planetary-computer pystac"
    ]
   },
   {

--- a/docs/tutorials/earthquake_detection.ipynb
+++ b/docs/tutorials/earthquake_detection.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo h5py scikit-learn"
+    "!uv pip install torchgeo h5py scikit-learn"
    ]
   },
   {

--- a/docs/tutorials/embeddings.ipynb
+++ b/docs/tutorials/embeddings.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "# On Colab, this ensures the latest TorchGeo is available.\n",
     "\n",
-    "%pip install torchgeo scikit-learn tqdm"
+    "!uv pip install torchgeo scikit-learn tqdm"
    ]
   },
   {

--- a/docs/tutorials/indices.ipynb
+++ b/docs/tutorials/indices.ipynb
@@ -64,7 +64,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/naip_road_segmentation.ipynb
+++ b/docs/tutorials/naip_road_segmentation.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/pretrained_weights.ipynb
+++ b/docs/tutorials/pretrained_weights.ipynb
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/pytorch.ipynb
+++ b/docs/tutorials/pytorch.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/torchgeo.ipynb
+++ b/docs/tutorials/torchgeo.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install torchgeo"
+    "!uv pip install torchgeo"
    ]
   },
   {

--- a/docs/tutorials/trainers.ipynb
+++ b/docs/tutorials/trainers.ipynb
@@ -50,7 +50,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install torchgeo tensorboard"
+    "!uv pip install torchgeo tensorboard"
    ]
   },
   {

--- a/docs/tutorials/transforms.ipynb
+++ b/docs/tutorials/transforms.ipynb
@@ -66,7 +66,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install torchgeo ipywidgets"
+    "!uv pip install torchgeo ipywidgets"
    ]
   },
   {


### PR DESCRIPTION
Converts all tutorial notebooks from `%pip install` to `!uv pip install`, 
as uv is significantly faster and is already pre-installed on both Google 
Colab and Lightning Studios.

15 notebooks updated. `contribute_datamodule.ipynb` and `geospatial.ipynb` 
were untouched as they contain no install cells.

Addresses part of #2905 (partially since README and other files tracked separately).

<!-- Check one of the following boxes to help us better review your PR -->
## AI Usage Disclosure
- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
