### PR TITLE
Add Climplicit location encoder

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -10,6 +10,16 @@ Model Architectures
 
 TorchGeo contains a number of model architectures depending on the task you are trying to solve and your model inputs.
 
+Geographic Coordinates (:math:`\scriptstyle B \times 2`)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These location encoders map ``(lon, lat)`` coordinates to an embedding.
+
+.. toctree::
+   :maxdepth: 1
+
+   models/climplicit
+
 1D Time Series (:math:`\scriptstyle B \times T \times C`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -160,3 +170,15 @@ Atmospheric
    :header-rows: 1
    :align: center
    :file: weights/atmospheric.csv
+
+
+Geographic Coordinates
+^^^^^^^^^^^^^^^^^^^^^^^
+
+These weights are for location encoders that take ``(lon, lat)`` coordinates as input.
+
+.. csv-table::
+   :widths: 45 10 10 10
+   :header-rows: 1
+   :align: center
+   :file: weights/location.csv

--- a/docs/api/models/climplicit.rst
+++ b/docs/api/models/climplicit.rst
@@ -1,0 +1,7 @@
+Climplicit
+==========
+
+.. currentmodule:: torchgeo.models
+.. autoclass:: Climplicit
+.. autofunction:: climplicit
+.. autoclass:: Climplicit_Weights

--- a/docs/api/weights/location.csv
+++ b/docs/api/weights/location.csv
@@ -1,0 +1,2 @@
+Weight,Source,Citation,License
+Climplicit_Weights.CHELSA,`link <https://github.com/ecovision-uzh/climplicit>`__,`link <https://arxiv.org/abs/2504.05089>`__,"CC-BY-4.0"

--- a/hubconf.py
+++ b/hubconf.py
@@ -9,6 +9,7 @@
 
 from torchgeo.models import (
     aurora_swin_unet,
+    climplicit,
     convlstm,
     copernicusfm_base,
     croma_base,
@@ -42,6 +43,7 @@ from torchgeo.models import (
 
 __all__ = (
     'aurora_swin_unet',
+    'climplicit',
     'convlstm',
     'copernicusfm_base',
     'croma_base',

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -10,6 +10,7 @@ from torchvision.models._api import WeightsEnum
 
 from torchgeo.models import (
     Aurora_Weights,
+    Climplicit_Weights,
     CopernicusFM_Base_Weights,
     CROMABase_Weights,
     CROMALarge_Weights,
@@ -38,6 +39,7 @@ from torchgeo.models import (
     ViTSmall14_DINOv2_Weights,
     ViTSmall16_Weights,
     aurora_swin_unet,
+    climplicit,
     copernicusfm_base,
     croma_base,
     croma_large,
@@ -75,6 +77,7 @@ from torchgeo.models import (
 
 builders = [
     aurora_swin_unet,
+    climplicit,
     copernicusfm_base,
     croma_base,
     croma_large,
@@ -107,6 +110,7 @@ builders = [
 ]
 enums = [
     Aurora_Weights,
+    Climplicit_Weights,
     CopernicusFM_Base_Weights,
     CROMABase_Weights,
     CROMALarge_Weights,

--- a/tests/models/test_climplicit.py
+++ b/tests/models/test_climplicit.py
@@ -1,0 +1,72 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+from pathlib import Path
+
+import pytest
+import torch
+from _pytest.fixtures import SubRequest
+from pytest import MonkeyPatch
+
+from torchgeo.models import Climplicit, Climplicit_Weights, climplicit
+
+
+class TestClimplicit:
+    @pytest.fixture(params=[*Climplicit_Weights])
+    def weights(self, request: SubRequest) -> Climplicit_Weights:
+        return request.param
+
+    @pytest.fixture
+    def mocked_weights(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+    ) -> Climplicit_Weights:
+        weights = Climplicit_Weights.CHELSA
+        path = tmp_path / f'{weights}.pth'
+        model = Climplicit()
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
+        return weights
+
+    def test_climplicit(self) -> None:
+        batch_size = 2
+        model = Climplicit()
+        coords = torch.randn(batch_size, 2)
+        month = torch.ones(batch_size)
+        out = model(coords, month)
+        assert out.shape == torch.Size([batch_size, 256])
+
+    def test_climplicit_no_month(self) -> None:
+        batch_size = 2
+        model = Climplicit()
+        coords = torch.randn(batch_size, 2)
+        out = model(coords)
+        assert out.shape == torch.Size([batch_size, 1024])
+
+    def test_climplicit_return_chelsa(self) -> None:
+        batch_size = 2
+        model = Climplicit(return_chelsa=True)
+        coords = torch.randn(batch_size, 2)
+        month = torch.ones(batch_size)
+        out = model(coords, month)
+        assert out.shape == torch.Size([batch_size, 11])
+
+    def test_climplicit_return_chelsa_no_month(self) -> None:
+        batch_size = 2
+        model = Climplicit(return_chelsa=True)
+        coords = torch.randn(batch_size, 2)
+        out = model(coords)
+        assert out.shape == torch.Size([batch_size, 44])
+
+    def test_climplicit_no_weights(self) -> None:
+        climplicit()
+
+    def test_climplicit_weights(self, mocked_weights: Climplicit_Weights) -> None:
+        climplicit(weights=mocked_weights)
+
+    def test_transforms(self, weights: Climplicit_Weights) -> None:
+        coords = torch.randn(2, 2)
+        weights.transforms(coords)
+
+    @pytest.mark.slow
+    def test_climplicit_download(self, weights: Climplicit_Weights) -> None:
+        climplicit(weights=weights)

--- a/torchgeo/models/__init__.py
+++ b/torchgeo/models/__init__.py
@@ -8,6 +8,7 @@ from .aurora import Aurora_Weights, aurora_swin_unet
 from .btc import BTC
 from .changestar import ChangeMixin, ChangeStar, ChangeStarFarSeg
 from .changevit import ChangeViT
+from .climplicit import Climplicit, Climplicit_Weights, climplicit
 from .convlstm import ConvLSTM
 from .copernicusfm import CopernicusFM, CopernicusFM_Base_Weights, copernicusfm_base
 from .croma import CROMA, CROMABase_Weights, CROMALarge_Weights, croma_base, croma_large
@@ -84,6 +85,8 @@ __all__ = (
     'ChangeStar',
     'ChangeStarFarSeg',
     'ChangeViT',
+    'Climplicit',
+    'Climplicit_Weights',
     'ConvLSTM',
     'CopernicusFM',
     'CopernicusFM_Base_Weights',
@@ -122,6 +125,7 @@ __all__ = (
     'ViTSmall14_DINOv2_Weights',
     'ViTSmall16_Weights',
     'aurora_swin_unet',
+    'climplicit',
     'copernicusfm_base',
     'croma_base',
     'croma_large',

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 from torchvision.models._api import WeightsEnum
 
 from .aurora import Aurora_Weights, aurora_swin_unet
+from .climplicit import Climplicit_Weights, climplicit
 from .copernicusfm import CopernicusFM_Base_Weights, copernicusfm_base
 from .croma import CROMABase_Weights, CROMALarge_Weights, croma_base, croma_large
 from .dofa import (
@@ -72,6 +73,7 @@ from .vit import (
 
 _model: dict[str, Callable[..., nn.Module]] = {
     'aurora_swin_unet': aurora_swin_unet,
+    'climplicit': climplicit,
     'copernicusfm_base': copernicusfm_base,
     'croma_base': croma_base,
     'croma_large': croma_large,
@@ -107,6 +109,7 @@ _model_weights: dict[
     str | Callable[..., nn.Module], WeightsEnum
 ] = {  # ty :ignore[invalid-assignment]
     aurora_swin_unet: Aurora_Weights,
+    climplicit: Climplicit_Weights,
     copernicusfm_base: CopernicusFM_Base_Weights,
     croma_base: CROMABase_Weights,
     croma_large: CROMALarge_Weights,
@@ -135,6 +138,7 @@ _model_weights: dict[
     vit_large_patch16_224: ViTLarge16_Weights,
     vit_small_patch14_dinov2: ViTSmall14_DINOv2_Weights,
     'aurora_swin_unet': Aurora_Weights,
+    'climplicit': Climplicit_Weights,
     'copernicusfm_base': CopernicusFM_Base_Weights,
     'croma_base': CROMABase_Weights,
     'croma_large': CROMALarge_Weights,

--- a/torchgeo/models/climplicit.py
+++ b/torchgeo/models/climplicit.py
@@ -1,0 +1,406 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+#
+# Based on the original code: https://github.com/ecovision-uzh/climplicit
+
+"""Climplicit climatic implicit location encoder."""
+
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torchvision.models._api import Weights, WeightsEnum
+
+# CHELSA bioclimatic variables reconstructed by the regression head, in output order.
+_CHELSA_VARIABLES = (
+    'cmi',
+    'clt',
+    'hurs',
+    'pet',
+    'pr',
+    'rsds',
+    'sfcWind',
+    'tas',
+    'tasmax',
+    'tasmin',
+    'vpd',
+)
+
+# Per-variable mean/std used to de-standardize the CHELSA reconstruction, shape (1, 11).
+_CHELSA_MEAN = torch.tensor(
+    [
+        -264.1493656,
+        3912.44628016,
+        5921.65964573,
+        9385.47468266,
+        697.03653109,
+        15219.37926928,
+        3498.8511804,
+        2819.56006368,
+        2864.08583811,
+        2773.46759638,
+        8039.37322797,
+    ]
+).unsqueeze(0)
+_CHELSA_STD = torch.tensor(
+    [
+        1042.67560332,
+        1767.94018571,
+        1185.91587823,
+        6639.79069994,
+        883.56243405,
+        7843.49167037,
+        1637.09237995,
+        174.43791946,
+        181.69448751,
+        167.07485901,
+        7516.98198719,
+    ]
+).unsqueeze(0)
+
+
+class Direct(nn.Module):
+    """Direct positional encoding.
+
+    Linearly rescales ``(lon, lat)`` coordinates in degrees to the ``[-1, 1]`` range
+    expected by a SIREN, based on the supported coordinate extent.
+    """
+
+    def __init__(
+        self,
+        lon_min: float = -180.0,
+        lon_max: float = 180.0,
+        lat_min: float = -90.0,
+        lat_max: float = 90.0,
+    ) -> None:
+        """Initialize a new Direct instance.
+
+        Args:
+            lon_min: Minimum longitude in degrees.
+            lon_max: Maximum longitude in degrees.
+            lat_min: Minimum latitude in degrees.
+            lat_max: Maximum latitude in degrees.
+        """
+        super().__init__()
+        self.lon_min = lon_min
+        self.lon_max = lon_max
+        self.lat_min = lat_min
+        self.lat_max = lat_max
+
+    def forward(self, coords: Tensor) -> Tensor:
+        """Rescale coordinates to ``[-1, 1]``.
+
+        Args:
+            coords: Coordinate tensor of shape (B, 2) holding ``(lon, lat)`` in degrees.
+
+        Returns:
+            Rescaled coordinate tensor of shape (B, 2).
+        """
+        lon, lat = coords[:, 0], coords[:, 1]
+        lon = 2 * (lon - self.lon_min) / (self.lon_max - self.lon_min) - 1
+        lat = 2 * (lat - self.lat_min) / (self.lat_max - self.lat_min) - 1
+        return torch.stack([lon, lat], dim=1).float()
+
+
+class Sine(nn.Module):
+    """Sine activation with a configurable angular frequency ``w0``."""
+
+    def __init__(self, w0: float = 1.0) -> None:
+        """Initialize a new Sine instance.
+
+        Args:
+            w0: Angular frequency of the sine activation.
+        """
+        super().__init__()
+        self.w0 = w0
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply the sine activation.
+
+        Args:
+            x: Input tensor.
+
+        Returns:
+            ``sin(w0 * x)``.
+        """
+        return torch.sin(self.w0 * x)
+
+
+class Siren(nn.Module):
+    """A single SIREN layer with an optional residual connection and H-SIREN activation.
+
+    When ``residual_connections`` is True, the pre-activation vector of the previous layer
+    is averaged into the current pre-activation vector (only when their shapes match),
+    keeping the residual stream within SIREN's distributional constraints. When ``h_siren``
+    is True, the first layer applies ``sin(sinh(2x))`` instead of ``sin(x)``, which widens
+    the supported frequency set and reduces over-smoothing.
+    """
+
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        w0: float = 1.0,
+        c: float = 6.0,
+        is_first: bool = False,
+        activation: nn.Module | None = None,
+        residual_connections: bool = False,
+        h_siren: bool = False,
+    ) -> None:
+        """Initialize a new Siren instance.
+
+        Args:
+            dim_in: Input dimension.
+            dim_out: Output dimension.
+            w0: Angular frequency of the sine activation.
+            c: Constant used to scale the weight initialization variance.
+            is_first: Whether this is the first layer of the network.
+            activation: Activation module to use. Defaults to :class:`Sine`.
+            residual_connections: Whether to enable the ReSIREN residual connection.
+            h_siren: Whether to use the H-SIREN first-layer activation.
+        """
+        super().__init__()
+        self.dim_in = dim_in
+        self.dim_out = dim_out
+        self.is_first = is_first
+        self.h_siren = h_siren
+        self.residual_connections = residual_connections
+
+        weight = torch.zeros(dim_out, dim_in)
+        bias = torch.zeros(dim_out)
+        w_std = (1 / dim_in) if is_first else (math.sqrt(c / dim_in) / w0)
+        weight.uniform_(-w_std, w_std)
+        bias.uniform_(-w_std, w_std)
+
+        self.weight = nn.Parameter(weight)
+        self.bias = nn.Parameter(bias)
+        self.activation = Sine(w0) if activation is None else activation
+
+    def forward(
+        self, x: Tensor, prev_gaussian: Tensor | None = None
+    ) -> tuple[Tensor, Tensor]:
+        """Forward pass of the SIREN layer.
+
+        Args:
+            x: Input tensor of shape (B, dim_in).
+            prev_gaussian: Pre-activation vector of the previous layer, used for the
+                residual connection.
+
+        Returns:
+            A tuple of the activated output and the pre-activation vector (gaussian).
+        """
+        out = F.linear(x, self.weight, self.bias)
+        if (
+            self.residual_connections
+            and prev_gaussian is not None
+            and out.shape == prev_gaussian.shape
+        ):
+            out = (out + prev_gaussian) / 2
+        gaussian = out
+        if self.h_siren and self.is_first:
+            out = torch.sinh(2 * out)
+        out = self.activation(out)
+        return out, gaussian
+
+
+class SirenNet(nn.Module):
+    """Sinusoidal Representation Network (SIREN) with residual connections (ReSIREN).
+
+    Adapted from the SatCLIP location encoder
+    (https://github.com/microsoft/satclip/blob/main/satclip/location_encoder.py) and
+    extended with residual connections and the H-SIREN first-layer activation.
+    """
+
+    def __init__(
+        self,
+        dim_in: int,
+        dim_hidden: int,
+        dim_out: int,
+        num_layers: int,
+        w0: float = 1.0,
+        w0_initial: float = 30.0,
+        h_siren: bool = False,
+        residual_connections: bool = False,
+    ) -> None:
+        """Initialize a new SirenNet instance.
+
+        Args:
+            dim_in: Input dimension.
+            dim_hidden: Hidden dimension of every SIREN layer.
+            dim_out: Output (embedding) dimension.
+            num_layers: Number of hidden SIREN layers.
+            w0: Angular frequency for the hidden layers.
+            w0_initial: Angular frequency for the first layer.
+            h_siren: Whether to use the H-SIREN first-layer activation.
+            residual_connections: Whether to enable ReSIREN residual connections.
+        """
+        super().__init__()
+        self.layers = nn.ModuleList()
+        for ind in range(num_layers):
+            is_first = ind == 0
+            self.layers.append(
+                Siren(
+                    dim_in=dim_in if is_first else dim_hidden,
+                    dim_out=dim_hidden,
+                    w0=w0_initial if is_first else w0,
+                    is_first=is_first,
+                    h_siren=h_siren,
+                    residual_connections=residual_connections,
+                )
+            )
+        self.last_layer = Siren(
+            dim_in=dim_hidden, dim_out=dim_out, w0=w0, activation=nn.Identity()
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass of the network.
+
+        Args:
+            x: Input tensor of shape (B, dim_in).
+
+        Returns:
+            Output embedding of shape (B, dim_out).
+        """
+        gaussian = None
+        for layer in self.layers:
+            x, gaussian = layer(x, gaussian)
+        x, _ = self.last_layer(x, gaussian)
+        return x
+
+
+class Climplicit(nn.Module):
+    """Climplicit climatic implicit location encoder.
+
+    Climplicit encodes ``(lon, lat)`` coordinates (and optionally a month) into a 256-d
+    climatic embedding using a residual H-SIREN network pretrained to reconstruct CHELSA
+    bioclimatic variables. When no month is provided, embeddings for March, June,
+    September, and December are concatenated into a single 1024-d embedding. The model can
+    optionally return the de-standardized CHELSA reconstruction instead of the embedding.
+
+    If you use this model in your research, please cite the following paper:
+
+    * https://arxiv.org/abs/2504.05089
+
+    .. versionadded:: 0.10
+    """
+
+    def __init__(self, return_chelsa: bool = False) -> None:
+        """Initialize a new Climplicit instance.
+
+        Args:
+            return_chelsa: If True, return the de-standardized CHELSA reconstruction
+                instead of the climatic embedding.
+        """
+        super().__init__()
+        self.return_chelsa = return_chelsa
+        self.pos_embedding = Direct(lon_min=-180, lon_max=180, lat_min=-90, lat_max=90)
+        self.location_encoder = SirenNet(
+            dim_in=4,
+            dim_hidden=512,
+            dim_out=256,
+            num_layers=16,
+            h_siren=True,
+            residual_connections=True,
+        )
+        self.chelsa_regressor = nn.Linear(256, len(_CHELSA_VARIABLES))
+        self.register_buffer('chelsa_mean', _CHELSA_MEAN, persistent=False)
+        self.register_buffer('chelsa_std', _CHELSA_STD, persistent=False)
+
+    def _embed(self, loc: Tensor, month: Tensor) -> Tensor:
+        """Encode rescaled coordinates for a single month.
+
+        Args:
+            loc: Rescaled coordinate tensor of shape (B, 2).
+            month: Month tensor of shape (B,) with values in ``[1, 12]``.
+
+        Returns:
+            The climatic embedding, or the CHELSA reconstruction if ``return_chelsa``.
+        """
+        angle = month / 12 * math.pi * 2
+        loc_month = torch.cat(
+            [
+                loc,
+                torch.sin(angle).unsqueeze(dim=-1),
+                torch.cos(angle).unsqueeze(dim=-1),
+            ],
+            dim=-1,
+        )
+        x = self.location_encoder(loc_month)
+        if self.return_chelsa:
+            x = self.chelsa_regressor(x)
+            x = x * self.chelsa_std + self.chelsa_mean
+        return x
+
+    def forward(self, coordinates: Tensor, month: Tensor | None = None) -> Tensor:
+        """Forward pass of the Climplicit model.
+
+        Args:
+            coordinates: Coordinate tensor of shape (B, 2) holding ``(lon, lat)`` in
+                degrees.
+            month: Optional month tensor of shape (B,) with values in ``[1, 12]``. If
+                None, embeddings for March, June, September, and December are concatenated.
+
+        Returns:
+            A climatic embedding of shape (B, 256) (or (B, 1024) if *month* is None), or
+            the CHELSA reconstruction of shape (B, 11) (or (B, 44)) if ``return_chelsa``.
+        """
+        loc = self.pos_embedding(coordinates)
+        if month is None:
+            res = []
+            for m in (3, 6, 9, 12):
+                months = torch.ones(coordinates.shape[0], device=coordinates.device) * m
+                res.append(self._embed(loc, months))
+            return torch.cat(res, dim=-1)
+        return self._embed(loc, month)
+
+
+# Transforms are a no-op: Climplicit consumes raw (lon, lat) coordinates directly.
+_climplicit_transforms = nn.Identity()
+
+
+class Climplicit_Weights(WeightsEnum):
+    """Climplicit model weights.
+
+    .. versionadded:: 0.10
+    """
+
+    CHELSA = Weights(
+        url='https://hf.co/Jobedo/climplicit/resolve/main/climplicit-3341daa2.pth',
+        transforms=_climplicit_transforms,
+        meta={
+            'dataset': 'CHELSA',
+            'publication': 'https://arxiv.org/abs/2504.05089',
+            'repo': 'https://github.com/ecovision-uzh/climplicit',
+            'variables': list(_CHELSA_VARIABLES),
+            'embed_dim': 256,
+        },
+    )
+
+
+def climplicit(
+    weights: Climplicit_Weights | None = None, *args: Any, **kwargs: Any
+) -> Climplicit:
+    """Climplicit climatic implicit location encoder.
+
+    If you use this model in your research, please cite the following paper:
+
+    * https://arxiv.org/abs/2504.05089
+
+    .. versionadded:: 0.10
+
+    Args:
+        weights: Pre-trained model weights to use.
+        *args: Additional arguments to pass to :class:`Climplicit`.
+        **kwargs: Additional keyword arguments to pass to :class:`Climplicit`.
+
+    Returns:
+        A Climplicit model.
+    """
+    model = Climplicit(*args, **kwargs)
+
+    if weights is not None:
+        model.load_state_dict(weights.get_state_dict(progress=True), strict=True)
+
+    return model


### PR DESCRIPTION
## AI Usage Disclosure

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution

## Summary

This PR adds **Climplicit**, a climatic implicit location encoder from the Climplicit project
([ICLR 2025 Workshops, arXiv:2504.05089](https://arxiv.org/abs/2504.05089)). It maps `(lon, lat)`
coordinates (and optionally a month) to a 256-d climatic embedding using a residual H-SIREN network
pretrained to reconstruct CHELSA bioclimatic variables.

### Relationship to other location-encoder PRs

This is not the first location encoder in flight — it overlaps with two concurrent PRs:

* #3640 (SatCLIP) — also adds a `SirenNet`, a "Geographic Coordinates (`B x 2`)" model category,
  and `docs/api/weights/location.csv`. My `SirenNet` is in fact adapted from SatCLIP.
* #3656 (GeoCLIP, draft).

Because of that, this PR will conflict with #3640 on `models.rst`, `weights/location.csv`,
`__init__.py`, `api.py`, `hubconf.py`, and `test_api.py`. I'm happy to **rebase onto whichever
lands first** and to consolidate the shared pieces — in particular reusing a single shared
`SirenNet` and the `location.csv` schema / "Location" docs section introduced by #3640 — however
the maintainers prefer. Just let me know the preferred ordering.

The code and pretrained weights are released by the Climplicit authors under MIT (code) and
CC-BY-4.0 (weights) — see [ecovision-uzh/climplicit#1](https://github.com/ecovision-uzh/climplicit/issues/1),
where @adamjstewart invited us to contribute the model.

## What's included

Following the model-contribution checklist:

* `torchgeo/models/climplicit.py` — `Direct` positional encoding, `SirenNet` (residual H-SIREN),
  the `Climplicit` model, `Climplicit_Weights` (the `CHELSA` pretrained weights), and the
  `climplicit()` builder.
* `torchgeo/models/__init__.py`, `torchgeo/models/api.py`, `hubconf.py` — registration.
* `tests/models/test_climplicit.py` + `tests/models/test_api.py` — tests (100% coverage of the
  new module).
* `docs/api/models/climplicit.rst`, `docs/api/models.rst`, `docs/api/weights/location.csv` — docs.

No new dependencies (only `torch` / `torchvision`).

## Usage

```python
from torchgeo.models import climplicit, Climplicit_Weights

model = climplicit(weights=Climplicit_Weights.CHELSA)   # pretrained
embeddings = model(coords)                              # coords: (B, 2) lon/lat in degrees -> (B, 1024)
```

* `Climplicit()` / `climplicit()` give a randomly-initialized model; pretrained weights are opt-in.
* With a `month` argument the output is `(B, 256)`; without it, embeddings for March/June/September/
  December are concatenated into `(B, 1024)`.
* `return_chelsa=True` returns the de-standardized CHELSA reconstruction instead of the embedding.

## Verification

* Output is **bit-exact** against the upstream Climplicit reference for the embedding, no-month, and
  CHELSA-reconstruction paths.
* `ruff format`, `ruff check`, and `ty` pass; `pytest` passes with 100% coverage of the new module.
* The `@pytest.mark.slow` download test loads the real pretrained weights from Hugging Face with
  `strict=True`.

## Citation

```bibtex
@article{dollinger2025climplicit,
  title={Climplicit: Climatic Implicit Embeddings for Global Ecological Tasks},
  author={Dollinger, Johannes and Robert, Damien and Plekhanova, Elena and Drees, Lukas and Wegner, Jan Dirk},
  journal={International Conference on Learning Representations (ICLR) Workshops},
  year={2025}
}
```
