### PR TITLE
Run ty in uv env during pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,25 +16,12 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: ty check
-        language: python
+        # Run in the locked uv environment so the ty version and type stubs
+        # always match pyproject.toml/uv.lock and CI, instead of a separate
+        # dependency list here that drifts out of sync.
+        entry: uv run --locked --extra datasets --extra models --extra style --extra tests ty check
+        language: system
         pass_filenames: false
-        additional_dependencies:
-          - ty>=0.0.33
-          - einops>=0.6.0
-          - kornia>=0.7.4
-          - lightning>=2.0.9
-          - matplotlib>=3.9.2
-          - numpy>=1.24
-          - pandas-stubs>=2.1.1
-          - pillow>=10.4.0
-          - pytest>=7.3
-          - timm>=1.0.16
-          - torch>=2.8
-          - torchmetrics>=1.6.2
-          - torchvision>=0.18
-          - types-requests>=2.25
-          - types-shapely>=2.0.2
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,6 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        # Run in the locked uv environment so the ty version and type stubs
-        # always match pyproject.toml/uv.lock and CI, instead of a separate
-        # dependency list here that drifts out of sync.
         entry: uv run --locked --extra datasets --extra models --extra style --extra tests ty check
         language: system
         pass_filenames: false


### PR DESCRIPTION
Last time I bumped ty in pre-commit I could not find a way to automatically keep it in sync with pyproject.toml. Did some research and found out it is possible to run it from the uv environment instead of duplicating the dependencies here.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [X] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
