### PR TITLE
SkyScript: tokenize caption

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,6 @@ nitpick_ignore = [
     ('py:class', 'torchvision.models.swin_transformer.SwinTransformer'),
     # Internal type aliases we don't yet want to expose
     ('py:class', 'torchgeo.datasets.openstreetmap.OSMClassConfig'),
-    ('py:class', 'torchgeo.datasets.skyscript.CaptionSample'),
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,6 +177,7 @@ intersphinx_mapping = {
     'shapely': ('https://shapely.readthedocs.io/en/stable/', None),
     'sklearn': ('https://scikit-learn.org/stable/', None),
     'timm': ('https://huggingface.co/docs/timm/main/en/', None),
+    'tokenizers': ('https://huggingface.co/docs/tokenizers/main/en/', None),
     'torch': ('https://docs.pytorch.org/docs/stable/', None),
     'torchmetrics': ('https://lightning.ai/docs/torchmetrics/stable/', None),
     'torchvision': ('https://docs.pytorch.org/vision/stable/', None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ datasets = [
     "rioxarray>=0.14.1",
     # scipy 1.11.2+ required for Python 3.12 wheels
     "scipy>=1.11.2",
+    # tokenizers 0.14+ required for Python 3.12 wheels
+    "tokenizers>=0.14",
     # webdataset 0.2.4+ required for PyTorch tuple seed support
     "webdataset>=0.2.4",
     # xarray 0.17+ required by rioxarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,8 @@ datasets = [
     # scipy 1.11.2+ required for Python 3.12 wheels
     "scipy>=1.11.2",
     # tokenizers 0.14+ required for Python 3.12 wheels
-    "tokenizers>=0.14",
+    # tokenizers does not yet provide wheels for Python 3.14t
+    "tokenizers>=0.14; python_version<'3.14'",
     # webdataset 0.2.4+ required for PyTorch tuple seed support
     "webdataset>=0.2.4",
     # xarray 0.17+ required by rioxarray

--- a/tests/datasets/test_skyscript.py
+++ b/tests/datasets/test_skyscript.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 from torchgeo.datasets import DatasetNotFoundError, SkyScript
 
-pytest.importorskip('tokenizers', minversion='0.14')
+tokenizers = pytest.importorskip('tokenizers', minversion='0.14')
 
 
 class TestSkyScript:
@@ -32,6 +32,14 @@ class TestSkyScript:
 
     def test_len(self, dataset: SkyScript) -> None:
         assert len(dataset) == 2
+
+    def test_tokenizer(self, dataset: SkyScript) -> None:
+        tokenizer = tokenizers.Tokenizer(tokenizers.models.BPE())
+        dataset = SkyScript(dataset.root, tokenizer=tokenizer)
+        x = dataset[0]
+        assert isinstance(x, dict)
+        assert isinstance(x['image'], Tensor)
+        assert isinstance(x['caption'], Tensor)
 
     def test_already_downloaded(self, dataset: SkyScript) -> None:
         shutil.rmtree(os.path.join(dataset.root, 'images2'))

--- a/tests/datasets/test_skyscript.py
+++ b/tests/datasets/test_skyscript.py
@@ -26,7 +26,7 @@ class TestSkyScript:
         x = dataset[0]
         assert isinstance(x, dict)
         assert isinstance(x['image'], Tensor)
-        assert isinstance(x['caption'], str)
+        assert isinstance(x['caption'], Tensor)
 
     def test_len(self, dataset: SkyScript) -> None:
         assert len(dataset) == 2

--- a/tests/datasets/test_skyscript.py
+++ b/tests/datasets/test_skyscript.py
@@ -13,6 +13,8 @@ from torch import Tensor
 
 from torchgeo.datasets import DatasetNotFoundError, SkyScript
 
+pytest.importorskip('tokenizers', minversion='0.14')
+
 
 class TestSkyScript:
     @pytest.fixture

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -6,7 +6,7 @@
 import pathlib
 import textwrap
 from collections.abc import Callable
-from typing import ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import numpy as np
 import pandas as pd
@@ -26,6 +26,9 @@ from .utils import (
     extract_archive,
     lazy_import,
 )
+
+if TYPE_CHECKING:
+    import tokenizers
 
 
 class SkyScript(NonGeoDataset):
@@ -79,6 +82,7 @@ class SkyScript(NonGeoDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
+        tokenizer: 'tokenizers.models.Model | None' = None,
     ) -> None:
         """Initialize a new SkyScript instance.
 
@@ -89,14 +93,18 @@ class SkyScript(NonGeoDataset):
                 entry and returns a transformed version.
             download: If True, download dataset and store it in the root directory.
             checksum: If True, check the MD5 of the downloaded files (may be slow).
+            tokenizer: A pre-trained tokenizer
+                (defaults to :class:`~tokenizers.models.BPE`).
 
         Raises:
             AssertionError: If *split* is invalid.
             DatasetNotFoundError: If dataset is not found and *download* is False.
             DependencyNotFoundError: If tokenizers is not installed.
+
+        .. versionadded:: 0.10
+           The *tokenizer* parameter.
         """
         assert split in self.caption_files
-        tokenizers = lazy_import('tokenizers')
 
         self.root = pathlib.Path(root)
         self.split = split
@@ -107,11 +115,15 @@ class SkyScript(NonGeoDataset):
         self._verify()
 
         self.captions = pd.read_csv(self.root / self.caption_files[split])
-        train_captions = pd.read_csv(self.root / self.caption_files['train'])
 
-        self.tokenizer = tokenizers.Tokenizer(tokenizers.models.BPE())
-        trainer = tokenizers.trainers.BpeTrainer()
-        self.tokenizer.train_from_iterator(train_captions['title'], trainer)
+        if tokenizer is None:
+            tokenizers = lazy_import('tokenizers')
+            self.tokenizer = tokenizers.Tokenizer(tokenizers.models.BPE())
+            trainer = tokenizers.trainers.BpeTrainer()
+            train_captions = pd.read_csv(self.root / self.caption_files['train'])
+            self.tokenizer.train_from_iterator(train_captions['title'], trainer)
+        else:
+            self.tokenizer = tokenizer
 
     def __len__(self) -> int:
         """Return the number of images in the dataset.

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -3,9 +3,9 @@
 
 """SkyScript dataset."""
 
-import os
+import pathlib
 from collections.abc import Callable
-from typing import ClassVar, Literal, NotRequired, TypedDict
+from typing import ClassVar, Literal
 
 import numpy as np
 import pandas as pd
@@ -14,19 +14,17 @@ from einops import rearrange
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from PIL import Image
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, download_url, extract_archive
-
-
-class CaptionSample(TypedDict):
-    """Sample for image captioning."""
-
-    image: Tensor
-    caption: str
-    prediction: NotRequired[str]
+from .utils import (
+    Path,
+    Sample,
+    download_and_extract_archive,
+    download_url,
+    extract_archive,
+    lazy_import,
+)
 
 
 class SkyScript(NonGeoDataset):
@@ -40,6 +38,11 @@ class SkyScript(NonGeoDataset):
     If you use this dataset in your research, please cite it using the following format:
 
     * https://arxiv.org/abs/2312.12856
+
+    .. note::
+       This dataset requires the following additional library to be installed:
+
+       * `tokenizers <https://pypi.org/project/tokenizers/>`_ to tokenize the captions
 
     .. versionadded:: 0.6
     """
@@ -72,7 +75,7 @@ class SkyScript(NonGeoDataset):
         self,
         root: Path = 'data',
         split: Literal['train', 'val', 'test'] = 'train',
-        transforms: Callable[[CaptionSample], CaptionSample] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -89,10 +92,12 @@ class SkyScript(NonGeoDataset):
         Raises:
             AssertionError: If *split* is invalid.
             DatasetNotFoundError: If dataset is not found and *download* is False.
+            DependencyNotFoundError: If tokenizers is not installed.
         """
         assert split in self.caption_files
+        tokenizers = lazy_import('tokenizers')
 
-        self.root = root
+        self.root = pathlib.Path(root)
         self.split = split
         self.transforms = transforms
         self.download = download
@@ -100,7 +105,12 @@ class SkyScript(NonGeoDataset):
 
         self._verify()
 
-        self.captions = pd.read_csv(os.path.join(self.root, self.caption_files[split]))
+        self.captions = pd.read_csv(self.root / self.caption_files[split])
+        train_captions = pd.read_csv(self.root / self.caption_files['train'])
+
+        self.tokenizer = tokenizers.Tokenizer(tokenizers.models.BPE())
+        trainer = tokenizers.trainers.BpeTrainer()
+        self.tokenizer.train_from_iterator(train_captions['title'], trainer)
 
     def __len__(self) -> int:
         """Return the number of images in the dataset.
@@ -110,7 +120,7 @@ class SkyScript(NonGeoDataset):
         """
         return len(self.captions)
 
-    def __getitem__(self, index: int) -> CaptionSample:  # ty: ignore[invalid-method-override]
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -120,13 +130,14 @@ class SkyScript(NonGeoDataset):
             A dict containing image and caption at index.
         """
         filepath, title = self.captions.iloc[index][:2]
+        output = self.tokenizer.encode(title)
 
-        with Image.open(os.path.join(self.root, filepath)) as img:
+        with Image.open(self.root / filepath) as img:
             array = np.array(img, dtype=np.float32)
             array = rearrange(array, 'h w c -> c h w')
             image = torch.from_numpy(array)
 
-        sample: CaptionSample = {'image': image, 'caption': title}
+        sample = {'image': image, 'caption': torch.tensor(output.ids)}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -138,12 +149,12 @@ class SkyScript(NonGeoDataset):
         md5: str | None
         for directory, md5 in zip(self.image_dirs, self.image_md5s):
             # Check if the extracted files already exist
-            if os.path.isdir(os.path.join(self.root, directory)):
+            if (self.root / directory).is_dir():
                 continue
 
             # Check if the zip files have already been downloaded
-            if os.path.isfile(os.path.join(self.root, f'{directory}.zip')):
-                extract_archive(os.path.join(self.root, f'{directory}.zip'))
+            if (self.root / f'{directory}.zip').is_file():
+                extract_archive(self.root / f'{directory}.zip')
                 continue
 
             # Check if the user requested to download the dataset
@@ -155,17 +166,15 @@ class SkyScript(NonGeoDataset):
             md5 = md5 if self.checksum else None
             download_and_extract_archive(url, self.root, md5=md5)
 
-        # Download the caption file
-        if self.download:
-            url = self.url.format(self.caption_files[self.split])
-            md5 = self.caption_md5s[self.split] if self.checksum else None
-            download_url(url, self.root, md5=md5)
+        # Download the caption files
+        for split in {'train', self.split}:
+            if self.download:
+                url = self.url.format(self.caption_files[split])
+                md5 = self.caption_md5s[split] if self.checksum else None
+                download_url(url, self.root, md5=md5)
 
     def plot(
-        self,
-        sample: CaptionSample,
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 
@@ -184,9 +193,11 @@ class SkyScript(NonGeoDataset):
         ax.axis('off')
 
         if show_titles:
-            title = sample['caption']
+            caption = sample['caption'].numpy()
+            title = self.tokenizer.decode(caption)
             if 'prediction' in sample:
-                title += '\n' + sample['prediction']
+                caption = sample['prediction'].numpy()
+                title += '\n' + self.tokenizer.decode(caption)
             ax.set_title(title)
 
         if suptitle is not None:

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -4,6 +4,7 @@
 """SkyScript dataset."""
 
 import pathlib
+import textwrap
 from collections.abc import Callable
 from typing import ClassVar, Literal
 
@@ -194,11 +195,11 @@ class SkyScript(NonGeoDataset):
 
         if show_titles:
             caption = sample['caption'].numpy()
-            title = self.tokenizer.decode(caption)
+            title = textwrap.wrap(self.tokenizer.decode(caption))
             if 'prediction' in sample:
                 caption = sample['prediction'].numpy()
-                title += '\n' + self.tokenizer.decode(caption)
-            ax.set_title(title)
+                title += textwrap.wrap(self.tokenizer.decode(caption))
+            ax.set_title('\n'.join(title))
 
         if suptitle is not None:
             plt.suptitle(suptitle)

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -140,7 +140,7 @@ class SkyScript(NonGeoDataset):
             index: Index to return.
 
         Returns:
-            A dict containing image and caption at index.
+            A dict containing image and tokenized caption at index.
         """
         filepath, title = self.captions.iloc[index][:2]
         output = self.tokenizer.encode(title)

--- a/uv.lock
+++ b/uv.lock
@@ -3696,6 +3696,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3790,6 +3817,7 @@ all = [
     { name = "scipy" },
     { name = "sphinx" },
     { name = "sphinx-github-changelog" },
+    { name = "tokenizers" },
     { name = "ty" },
     { name = "types-geopandas" },
     { name = "types-requests" },
@@ -3804,6 +3832,7 @@ datasets = [
     { name = "pandas", extra = ["parquet"] },
     { name = "rioxarray" },
     { name = "scipy" },
+    { name = "tokenizers" },
     { name = "webdataset" },
     { name = "xarray" },
 ]
@@ -3875,6 +3904,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8" },
     { name = "sphinx-github-changelog", marker = "extra == 'docs'", specifier = ">=1.7.2" },
     { name = "timm", specifier = ">=1.0.3" },
+    { name = "tokenizers", marker = "extra == 'datasets'", specifier = ">=0.14" },
     { name = "torch", specifier = ">=2.2" },
     { name = "torchgeo", extras = ["datasets", "docs", "models", "style", "tests"], marker = "extra == 'all'" },
     { name = "torchmetrics", extras = ["detection"], specifier = ">=1.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -3700,7 +3700,7 @@ name = "tokenizers"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
 wheels = [
@@ -3817,7 +3817,7 @@ all = [
     { name = "scipy" },
     { name = "sphinx" },
     { name = "sphinx-github-changelog" },
-    { name = "tokenizers" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
     { name = "ty" },
     { name = "types-geopandas" },
     { name = "types-requests" },
@@ -3832,7 +3832,7 @@ datasets = [
     { name = "pandas", extra = ["parquet"] },
     { name = "rioxarray" },
     { name = "scipy" },
-    { name = "tokenizers" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
     { name = "webdataset" },
     { name = "xarray" },
 ]
@@ -3904,7 +3904,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8" },
     { name = "sphinx-github-changelog", marker = "extra == 'docs'", specifier = ">=1.7.2" },
     { name = "timm", specifier = ">=1.0.3" },
-    { name = "tokenizers", marker = "extra == 'datasets'", specifier = ">=0.14" },
+    { name = "tokenizers", marker = "python_full_version < '3.14' and extra == 'datasets'", specifier = ">=0.14" },
     { name = "torch", specifier = ">=2.2" },
     { name = "torchgeo", extras = ["datasets", "docs", "models", "style", "tests"], marker = "extra == 'all'" },
     { name = "torchmetrics", extras = ["detection"], specifier = ">=1.5" },


### PR DESCRIPTION
This is the only remaining dataset in TorchGeo that doesn't return `dict[str, Tensor]`. Str can't be moved to the GPU, so tokenization is needed at some point. This could probably be done in a datamodule, but we don't have a trainer for image captioning, so I put it in the dataset for now.

> [!WARNING]
> I'm an NLP novice, so please tell me if I'm doing anything dumb.

### Example

Caption: "a satellite image of roof shape of gabled, building part, building material of stone"
Encoding: [2468, 24129]
Successful decoding in the plot method:

<img width="640" height="480" alt="skyscript" src="https://github.com/user-attachments/assets/fb8ee950-af4b-4b1d-b33d-91da9330078c" />

@JamesBrockUoB can you help review? We can use the same logic in #3595 to make it simpler.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
