### PR TITLE
Silence torch.jit.script warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,8 @@ filterwarnings = [
     "ignore:ForwardRef._evaluate is a private API and is retained for compatibility:DeprecationWarning",
     # https://github.com/pytorch/pytorch/pull/167669
     'ignore:`torch.jit.script` is not supported in Python 3.14\+ and may break.:DeprecationWarning',
+    # https://github.com/kornia/kornia/issues/3727
+    'ignore:`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.:DeprecationWarning',
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS


### PR DESCRIPTION
Silences the following warning:
```
.venv/lib/python3.12/site-packages/torch/jit/_script.py:1488: 43 warnings
  /Users/Adam/torchgeo/.venv/lib/python3.12/site-packages/torch/jit/_script.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(
```
I get this locally but don't see it in CI, so may be due to slight differences in versions.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
