### PR TITLE
L7 Irish/L8 Biome: fix datamodule/trainer warning

### DIFF
--- a/tests/conf/l7irish.yaml
+++ b/tests/conf/l7irish.yaml
@@ -12,7 +12,6 @@ data:
   class_path: L7IrishDataModule
   init_args:
     batch_size: 1
-    patch_size: 32
-    length: 5
+    patch_size: 16
   dict_kwargs:
     paths: 'tests/data/l7irish'

--- a/tests/conf/l8biome.yaml
+++ b/tests/conf/l8biome.yaml
@@ -12,7 +12,6 @@ data:
   class_path: L8BiomeDataModule
   init_args:
     batch_size: 1
-    patch_size: 32
-    length: 5
+    patch_size: 16
   dict_kwargs:
     paths: 'tests/data/l8biome'


### PR DESCRIPTION
Fixes the following warning in CI:
```
tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-l7irish]
tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-l8biome]
  D:\a\torchgeo\torchgeo\.venv\Lib\site-packages\torchmetrics\utilities\prints.py:43: UserWarning: The ``compute`` method of metric MulticlassAccuracy was called before the ``update`` method which may lead to errors, as metric states have not yet been updated.
    warnings.warn(*args, **kwargs)
```
Basically, after my sampler PR, we subtract $$\sqrt{2}\cdot 32/2$$ from each bbox, so we end up with an empty dataframe. This means that the datamodule tests are running with a for-loop over 0 samples. Thus, the forward pass is skipped and we try to log metrics that don't yet exist. Changing the patch size to be 1/2 the size of the tile fixes this. But this also raises the question of how the sampler should behave when it has 0 length or when the tile size == the patch size.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
