### PR TITLE
Tests: close all plots to avoid plot handle leak

### DIFF
--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -59,12 +59,14 @@ class TestCanadianBuildingFootprints:
         index = dataset.bounds
         x = dataset[index]
         dataset.plot(x, suptitle='Test')
+        plt.close()
 
     def test_plot_prediction(self, dataset: CanadianBuildingFootprints) -> None:
         index = dataset.bounds
         x = dataset[index]
         x['prediction'] = x['mask'].clone()
         dataset.plot(x, suptitle='Prediction')
+        plt.close()
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_eurocrops.py
+++ b/tests/datasets/test_eurocrops.py
@@ -60,12 +60,14 @@ class TestEuroCrops:
         index = dataset.bounds
         x = dataset[index]
         dataset.plot(x, suptitle='Test')
+        plt.close()
 
     def test_plot_prediction(self, dataset: EuroCrops) -> None:
         index = dataset.bounds
         x = dataset[index]
         x['prediction'] = x['mask'].clone()
         dataset.plot(x, suptitle='Prediction')
+        plt.close()
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):


### PR DESCRIPTION
Solves the following transient warning in CI:
```
tests/datasets/test_eurocrops.py::TestEuroCrops::test_plot_prediction[dataset2]
  /home/runner/work/torchgeo/torchgeo/torchgeo/datasets/eurocrops.py:260: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.
    fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(4, 4))
```
With the help of my friend grep, I confirmed that these are the only 2 problematic tests.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
