### PR TITLE
README: fix sponsorship logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The goal of this library is to make it simple:
 Community:
 [![slack](https://img.shields.io/badge/Slack-join-4A154B?logo=slack)](https://torchgeo.slack.com/join/shared_invite/zt-22rse667m-eqtCeNW0yI000Tl4B~2PIw)
 [![osgeo](https://img.shields.io/badge/OSGeo-join-4CB05B?logo=osgeo)](https://www.osgeo.org/community/getting-started-osgeo/)
-[![radiant earth](https://img.shields.io/badge/Radiant_Earth-sponsor-469695?logo=radiant-earth)](https://github.com/sponsors/torchgeo)
+[![radiant earth](https://img.shields.io/badge/Radiant_Earth-sponsor-469695?logo=radiantearth)](https://github.com/sponsors/torchgeo)
 [![huggingface](https://img.shields.io/badge/Hugging_Face-join-FFD21E?logo=huggingface)](https://huggingface.co/torchgeo)
 [![zenodo](https://img.shields.io/badge/Zenodo-join-1682D4?logo=zenodo)](https://zenodo.org/communities/torchgeo)
 [![pytorch](https://img.shields.io/badge/PyTorch-join-DE3412?logo=pytorch)](https://pytorch.org/join-ecosystem/)


### PR DESCRIPTION
https://github.com/simple-icons/simple-icons/pull/14800 is now merged and released. https://simpleicons.org/?q=radiant+earth shows what the logo looks like. Turns out that spaces are removed instead of replaced with a dash. So far it still doesn't seem to load, so we may have to wait for img.shields.io to update their own simple icons version.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
