### PR TITLE
Fix support for pytest 10

### DIFF
--- a/tests/datasets/test_eddmaps.py
+++ b/tests/datasets/test_eddmaps.py
@@ -20,7 +20,8 @@ from torchgeo.datasets import (
 
 class TestEDDMapS:
     @pytest.fixture(scope='class')
-    def dataset(self) -> EDDMapS:
+    @classmethod
+    def dataset(cls) -> EDDMapS:
         root = os.path.join('tests', 'data', 'eddmaps')
         return EDDMapS(root)
 

--- a/tests/datasets/test_gbif.py
+++ b/tests/datasets/test_gbif.py
@@ -20,7 +20,8 @@ from torchgeo.datasets import (
 
 class TestGBIF:
     @pytest.fixture(scope='class')
-    def dataset(self) -> GBIF:
+    @classmethod
+    def dataset(cls) -> GBIF:
         root = os.path.join('tests', 'data', 'gbif')
         return GBIF(root)
 

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -557,7 +557,8 @@ class TestXarrayDataset:
         scope='class',
         params=itertools.product(['hdf5', 'netcdf'], [None, CRS.from_epsg(4979)]),
     )
-    def dataset(self, request: SubRequest) -> XarrayDataset:
+    @classmethod
+    def dataset(cls, request: SubRequest) -> XarrayDataset:
         root = os.path.join('tests', 'data', request.param[0])
         transforms = nn.Identity()
         match request.param[0]:
@@ -597,19 +598,22 @@ class TestXarrayDataset:
 
 class TestVectorDataset:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomVectorDataset:
+    @classmethod
+    def dataset(cls) -> CustomVectorDataset:
         root = os.path.join('tests', 'data', 'vector')
         transforms = nn.Identity()
         return CustomVectorDataset(root, res=(0.1, 0.1), transforms=transforms)
 
     @pytest.fixture(scope='class')
-    def dataset_parquet(self) -> CustomVectorParquetDataset:
+    @classmethod
+    def dataset_parquet(cls) -> CustomVectorParquetDataset:
         root = os.path.join('tests', 'data', 'vector')
         transforms = nn.Identity()
         return CustomVectorParquetDataset(root, res=(0.1, 0.1), transforms=transforms)
 
     @pytest.fixture(scope='class')
-    def multilabel(self) -> CustomVectorDataset:
+    @classmethod
+    def multilabel(cls) -> CustomVectorDataset:
         root = os.path.join('tests', 'data', 'vector')
         transforms = nn.Identity()
         return CustomVectorDataset(
@@ -757,7 +761,8 @@ class TestVectorDataset:
 
 class TestNonGeoDataset:
     @pytest.fixture(scope='class')
-    def dataset(self) -> NonGeoDataset:
+    @classmethod
+    def dataset(cls) -> NonGeoDataset:
         return CustomNonGeoDataset()
 
     def test_getitem(self, dataset: NonGeoDataset) -> None:
@@ -801,12 +806,14 @@ class TestNonGeoDataset:
 
 class TestNonGeoClassificationDataset:
     @pytest.fixture(scope='class')
-    def dataset(self, root: str) -> NonGeoClassificationDataset:
+    @classmethod
+    def dataset(cls, root: str) -> NonGeoClassificationDataset:
         transforms = nn.Identity()
         return NonGeoClassificationDataset(root, transforms=transforms)
 
     @pytest.fixture(scope='class')
-    def root(self) -> str:
+    @classmethod
+    def root(cls) -> str:
         root = os.path.join('tests', 'data', 'nongeoclassification')
         return root
 
@@ -851,7 +858,8 @@ class TestNonGeoClassificationDataset:
 
 class TestIntersectionDataset:
     @pytest.fixture(scope='class')
-    def dataset(self) -> IntersectionDataset:
+    @classmethod
+    def dataset(cls) -> IntersectionDataset:
         ds1 = RasterDataset(
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_4087')
         )
@@ -1127,7 +1135,8 @@ class TestIntersectionDataset:
 
 class TestUnionDataset:
     @pytest.fixture(scope='class')
-    def dataset(self) -> UnionDataset:
+    @classmethod
+    def dataset(cls) -> UnionDataset:
         ds1 = RasterDataset(
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_4087')
         )

--- a/tests/datasets/test_inaturalist.py
+++ b/tests/datasets/test_inaturalist.py
@@ -20,7 +20,8 @@ from torchgeo.datasets import (
 
 class TestINaturalist:
     @pytest.fixture(scope='class')
-    def dataset(self) -> INaturalist:
+    @classmethod
+    def dataset(cls) -> INaturalist:
         root = os.path.join('tests', 'data', 'inaturalist')
         return INaturalist(root)
 

--- a/tests/datasets/test_millionaid.py
+++ b/tests/datasets/test_millionaid.py
@@ -18,7 +18,8 @@ class TestMillionAID:
     @pytest.fixture(
         scope='class', params=zip(['train', 'test'], ['multi-class', 'multi-label'])
     )
-    def dataset(self, request: SubRequest) -> MillionAID:
+    @classmethod
+    def dataset(cls, request: SubRequest) -> MillionAID:
         root = os.path.join('tests', 'data', 'millionaid')
         split, task = request.param
         transforms = nn.Identity()

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -488,7 +488,8 @@ def test_disambiguate_timestamp(
 
 class TestCollateFunctionsMatchingKeys:
     @pytest.fixture(scope='class')
-    def samples(self) -> list[Sample]:
+    @classmethod
+    def samples(cls) -> list[Sample]:
         return [{'image': torch.tensor([1, 2, 0])}, {'image': torch.tensor([0, 0, 3])}]
 
     def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
@@ -513,7 +514,8 @@ class TestCollateFunctionsMatchingKeys:
 
 class TestCollateFunctionsDifferingKeys:
     @pytest.fixture(scope='class')
-    def samples(self) -> list[Sample]:
+    @classmethod
+    def samples(cls) -> list[Sample]:
         return [
             {'image': torch.tensor([1, 2, 0])},
             {'mask': torch.tensor([0, 0, 3]), 'other': 5},

--- a/tests/samplers/test_base.py
+++ b/tests/samplers/test_base.py
@@ -61,7 +61,8 @@ class CustomTemporalSampler(TemporalSampler):
 
 class TestGeoSampler:
     @pytest.fixture(scope='class', params=[None, 5])
-    def sampler(self, dataset: GeoDataset, request: SubRequest) -> CustomGeoSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset, request: SubRequest) -> CustomGeoSampler:
         return CustomGeoSampler(dataset, length=request.param)
 
     def test_iter(self, sampler: CustomGeoSampler) -> None:
@@ -86,7 +87,8 @@ class TestGeoSampler:
 
 class TestSpatialSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> CustomSpatialSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> CustomSpatialSampler:
         return CustomSpatialSampler(dataset)
 
     def test_iter(self, sampler: CustomSpatialSampler) -> None:
@@ -131,7 +133,8 @@ class TestSpatialSampler:
 
 class TestTemporalSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> CustomTemporalSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> CustomTemporalSampler:
         return CustomTemporalSampler(dataset)
 
     def test_iter(self, sampler: CustomTemporalSampler) -> None:
@@ -175,24 +178,27 @@ class TestTemporalSampler:
 
 class TestSpatioTemporalSampler:
     @pytest.fixture(scope='class', params=['random', 'sequential'])
+    @classmethod
     def spatial_sampler(
-        self, dataset: GeoDataset, request: SubRequest
+        cls, dataset: GeoDataset, request: SubRequest
     ) -> CustomSpatialSampler:
         sampler = CustomSpatialSampler(dataset)
         sampler.strategy = request.param
         return sampler
 
     @pytest.fixture(scope='class', params=['random', 'sequential'])
+    @classmethod
     def temporal_sampler(
-        self, dataset: GeoDataset, request: SubRequest
+        cls, dataset: GeoDataset, request: SubRequest
     ) -> CustomTemporalSampler:
         sampler = CustomTemporalSampler(dataset)
         sampler.strategy = request.param
         return sampler
 
     @pytest.fixture(scope='class')
+    @classmethod
     def sampler(
-        self,
+        cls,
         spatial_sampler: CustomSpatialSampler,
         temporal_sampler: CustomTemporalSampler,
     ) -> SpatioTemporalSampler:

--- a/tests/samplers/test_batch.py
+++ b/tests/samplers/test_batch.py
@@ -47,7 +47,8 @@ class CustomGeoDataset(GeoDataset):
 
 class TestBatchGeoSampler:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomGeoDataset:
+    @classmethod
+    def dataset(cls) -> CustomGeoDataset:
         geometry = [shapely.box(0, 0, 100, 100)]
         return CustomGeoDataset(geometry)
 
@@ -86,7 +87,8 @@ class TestBatchGeoSampler:
 
 class TestRandomBatchGeoSampler:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomGeoDataset:
+    @classmethod
+    def dataset(cls) -> CustomGeoDataset:
         geometry = [shapely.box(0, 0, 100, 100), shapely.box(0, 0, 100, 100)]
         return CustomGeoDataset(geometry)
 

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -54,7 +54,8 @@ class CustomGeoDataset(GeoDataset):
 
 class TestGeoSampler:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomGeoDataset:
+    @classmethod
+    def dataset(cls) -> CustomGeoDataset:
         geometry = [shapely.box(0, 0, 100, 100)]
         return CustomGeoDataset(geometry)
 
@@ -83,7 +84,8 @@ class TestGeoSampler:
 
 class TestRandomGeoSampler:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomGeoDataset:
+    @classmethod
+    def dataset(cls) -> CustomGeoDataset:
         geometry = [shapely.box(0, 0, 100, 100), shapely.box(0, 0, 100, 100)]
         return CustomGeoDataset(geometry)
 
@@ -168,7 +170,8 @@ class TestRandomGeoSampler:
 
 class TestGridGeoSampler:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomGeoDataset:
+    @classmethod
+    def dataset(cls) -> CustomGeoDataset:
         geometry = [shapely.box(0, 0, 100, 100), shapely.box(0, 0, 100, 100)]
         return CustomGeoDataset(geometry)
 
@@ -266,7 +269,8 @@ class TestGridGeoSampler:
 
 class TestPreChippedGeoSampler:
     @pytest.fixture(scope='class')
-    def dataset(self) -> CustomGeoDataset:
+    @classmethod
+    def dataset(cls) -> CustomGeoDataset:
         geometry = [shapely.box(0, 0, 20, 20), shapely.box(0, 0, 30, 30)]
         return CustomGeoDataset(geometry)
 

--- a/tests/samplers/test_spatial.py
+++ b/tests/samplers/test_spatial.py
@@ -15,7 +15,8 @@ from torchgeo.samplers import GriddedPatchSampler, RandomPatchSampler, Units
 
 class TestRandomPatchSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> RandomPatchSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> RandomPatchSampler:
         return RandomPatchSampler(dataset, size=5)
 
     def test_iter(self, sampler: RandomPatchSampler) -> None:
@@ -60,7 +61,8 @@ class TestRandomPatchSampler:
 
 class TestGriddedPatchSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> GriddedPatchSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> GriddedPatchSampler:
         return GriddedPatchSampler(dataset, size=5)
 
     def test_iter(self, sampler: GriddedPatchSampler) -> None:

--- a/tests/samplers/test_temporal.py
+++ b/tests/samplers/test_temporal.py
@@ -24,7 +24,8 @@ TMAX = Timestamp(2025, 4, 30)
 
 class TestRandomTimestampSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> RandomTimestampSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> RandomTimestampSampler:
         return RandomTimestampSampler(dataset)
 
     def test_iter(self, sampler: RandomTimestampSampler) -> None:
@@ -52,7 +53,8 @@ class TestRandomTimestampSampler:
 
 class TestSequentialTimestampSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> SequentialTimestampSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> SequentialTimestampSampler:
         return SequentialTimestampSampler(dataset)
 
     def test_iter(self, sampler: SequentialTimestampSampler) -> None:
@@ -80,7 +82,8 @@ class TestSequentialTimestampSampler:
 
 class TestRandomTimedeltaSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> RandomTimedeltaSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> RandomTimedeltaSampler:
         delta = Timedelta('1W')
         return RandomTimedeltaSampler(dataset, delta=delta)
 
@@ -109,7 +112,8 @@ class TestRandomTimedeltaSampler:
 
 class TestSequentialTimedeltaSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> SequentialTimedeltaSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> SequentialTimedeltaSampler:
         delta = Timedelta('1W')
         return SequentialTimedeltaSampler(dataset, delta=delta)
 
@@ -138,7 +142,8 @@ class TestSequentialTimedeltaSampler:
 
 class TestRandomPeriodSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> RandomPeriodSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> RandomPeriodSampler:
         return RandomPeriodSampler(dataset, freq='M', length=1)
 
     def test_iter(self, sampler: RandomPeriodSampler) -> None:
@@ -166,7 +171,8 @@ class TestRandomPeriodSampler:
 
 class TestSequentialPeriodSampler:
     @pytest.fixture(scope='class')
-    def sampler(self, dataset: GeoDataset) -> SequentialPeriodSampler:
+    @classmethod
+    def sampler(cls, dataset: GeoDataset) -> SequentialPeriodSampler:
         return SequentialPeriodSampler(dataset, freq='M')
 
     def test_iter(self, sampler: SequentialPeriodSampler) -> None:


### PR DESCRIPTION
Fixes the following warning in CI:
```
tests/datasets/test_eddmaps.py: 1 warning
tests/datasets/test_gbif.py: 1 warning
tests/datasets/test_geo.py: 12 warnings
tests/datasets/test_inaturalist.py: 1 warning
tests/datasets/test_millionaid.py: 2 warnings
tests/datasets/test_utils.py: 2 warnings
tests/samplers/test_base.py: 13 warnings
tests/samplers/test_batch.py: 2 warnings
tests/samplers/test_single.py: 4 warnings
tests/samplers/test_spatial.py: 2 warnings
tests/samplers/test_temporal.py: 6 warnings
  /home/runner/work/torchgeo/torchgeo/.venv/lib/python3.14/site-packages/_pytest/fixtures.py:1313: PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated.
  Instance attributes set in this fixture will NOT be visible to test methods,
  as each test gets a new instance while the fixture runs only once per class.
  Use @classmethod decorator and set attributes on cls instead.
  See https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method
    fixturefunc = resolve_fixture_function(fixturedef, request)
```
See https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method for details.

## AI Usage Disclosure

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
