### PR TITLE
trainers: add support for Presto model in TemporalRegressionTask

### DIFF
--- a/tests/conf/air_quality_presto.yaml
+++ b/tests/conf/air_quality_presto.yaml
@@ -1,0 +1,29 @@
+model:
+  class_path: TemporalRegressionTask
+  init_args:
+    model: 'presto'
+    in_channels: 17
+    num_outputs: 17
+    out_steps: 2
+    loss: 'mse'
+  dict_kwargs:
+    encoder_embedding_size: 16
+    channel_embed_ratio: 0.25
+    month_embed_ratio: 0.25
+    encoder_depth: 1
+    mlp_ratio: 2
+    encoder_num_heads: 2
+    decoder_embedding_size: 16
+    decoder_depth: 1
+    decoder_num_heads: 2
+    max_sequence_length: 3
+data:
+  class_path: AirQualityDataModule
+  init_args:
+    batch_size: 2
+    val_split_pct: 0.3
+    test_split_pct: 0.3
+  dict_kwargs:
+    root: 'tests/data/air_quality'
+    input_steps: 3
+    target_steps: 2

--- a/tests/conf/air_quality_presto.yaml
+++ b/tests/conf/air_quality_presto.yaml
@@ -1,5 +1,5 @@
 model:
-  class_path: TemporalRegressionTask
+  class_path: TemporalRegression
   init_args:
     model: 'presto'
     in_channels: 17

--- a/tests/tasks/test_temporal_regression.py
+++ b/tests/tasks/test_temporal_regression.py
@@ -51,28 +51,6 @@ class TestTemporalRegression:
         trainer = Trainer(accelerator='cpu')
         trainer.predict(model=model, datamodule=datamodule)
 
-    def test_predict_presto(self) -> None:
-        root = os.path.join('tests', 'data', 'air_quality')
-        model = TemporalRegression(
-            model='presto',
-            in_channels=17,
-            num_outputs=17,
-            encoder_embedding_size=16,
-            channel_embed_ratio=0.25,
-            month_embed_ratio=0.25,
-            encoder_depth=1,
-            mlp_ratio=2,
-            encoder_num_heads=2,
-            decoder_embedding_size=16,
-            decoder_depth=1,
-            decoder_num_heads=2,
-            max_sequence_length=3,
-        )
-        datamodule = AirQualityDataModule(root=root)
-        datamodule.predict_dataset = AirQuality(root)
-        trainer = Trainer(accelerator='cpu')
-        trainer.predict(model=model, datamodule=datamodule)
-
     def test_presto_channel_validation(self) -> None:
         match = 'Presto expected 17 input channels, got 3.'
         with pytest.raises(ValueError, match=match):

--- a/tests/tasks/test_temporal_regression.py
+++ b/tests/tasks/test_temporal_regression.py
@@ -71,3 +71,8 @@ class TestTemporalRegression:
         datamodule.predict_dataset = AirQuality(root)
         trainer = Trainer(accelerator='cpu')
         trainer.predict(model=model, datamodule=datamodule)
+
+    def test_presto_channel_validation(self) -> None:
+        match = 'Presto expected 17 input channels, got 3.'
+        with pytest.raises(ValueError, match=match):
+            TemporalRegressionTask(model='presto', in_channels=3)

--- a/tests/tasks/test_temporal_regression.py
+++ b/tests/tasks/test_temporal_regression.py
@@ -76,10 +76,10 @@ class TestTemporalRegression:
     def test_presto_channel_validation(self) -> None:
         match = 'Presto expected 17 input channels, got 3.'
         with pytest.raises(ValueError, match=match):
-            TemporalRegressionTask(model='presto', in_channels=3)
+            TemporalRegression(model='presto', in_channels=3)
 
     def test_presto_optional_batch_fields(self) -> None:
-        model = TemporalRegressionTask(
+        model = TemporalRegression(
             model='presto',
             in_channels=17,
             num_outputs=17,

--- a/tests/tasks/test_temporal_regression.py
+++ b/tests/tasks/test_temporal_regression.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+import torch
 from lightning.pytorch import Trainer
 
 from torchgeo.datamodules import AirQualityDataModule, MisconfigurationException
@@ -76,3 +77,31 @@ class TestTemporalRegression:
         match = 'Presto expected 17 input channels, got 3.'
         with pytest.raises(ValueError, match=match):
             TemporalRegressionTask(model='presto', in_channels=3)
+
+    def test_presto_optional_batch_fields(self) -> None:
+        model = TemporalRegressionTask(
+            model='presto',
+            in_channels=17,
+            num_outputs=17,
+            encoder_embedding_size=16,
+            channel_embed_ratio=0.25,
+            month_embed_ratio=0.25,
+            encoder_depth=1,
+            mlp_ratio=2,
+            encoder_num_heads=2,
+            decoder_embedding_size=16,
+            decoder_depth=1,
+            decoder_num_heads=2,
+            max_sequence_length=3,
+        )
+        batch = {
+            'input': torch.randn(2, 3, 17),
+            'dynamic_world': torch.zeros(2, 3, dtype=torch.long),
+            'latlons': torch.zeros(2, 2),
+            'mask': torch.zeros(2, 3, 17),
+            'month': torch.zeros(2, dtype=torch.long),
+        }
+
+        y_hat = model._forward_model(batch)
+
+        assert y_hat.shape == torch.Size([2, 17])

--- a/tests/tasks/test_temporal_regression.py
+++ b/tests/tasks/test_temporal_regression.py
@@ -13,7 +13,9 @@ from torchgeo.tasks import TemporalRegression
 
 
 class TestTemporalRegression:
-    @pytest.mark.parametrize('name', ['air_quality_mse', 'air_quality_mae'])
+    @pytest.mark.parametrize(
+        'name', ['air_quality_mse', 'air_quality_mae', 'air_quality_presto']
+    )
     def test_trainer(self, name: str, fast_dev_run: bool) -> None:
         config = os.path.join('tests', 'conf', name + '.yaml')
 
@@ -40,9 +42,31 @@ class TestTemporalRegression:
         except MisconfigurationException:
             pass
 
-    def test_predict(self) -> None:
+    def test_predict_ltae(self) -> None:
         root = os.path.join('tests', 'data', 'air_quality')
         model = TemporalRegression(in_channels=17, num_outputs=17, len_max_seq=3)
+        datamodule = AirQualityDataModule(root=root)
+        datamodule.predict_dataset = AirQuality(root)
+        trainer = Trainer(accelerator='cpu')
+        trainer.predict(model=model, datamodule=datamodule)
+
+    def test_predict_presto(self) -> None:
+        root = os.path.join('tests', 'data', 'air_quality')
+        model = TemporalRegression(
+            model='presto',
+            in_channels=17,
+            num_outputs=17,
+            encoder_embedding_size=16,
+            channel_embed_ratio=0.25,
+            month_embed_ratio=0.25,
+            encoder_depth=1,
+            mlp_ratio=2,
+            encoder_num_heads=2,
+            decoder_embedding_size=16,
+            decoder_depth=1,
+            decoder_num_heads=2,
+            max_sequence_length=3,
+        )
         datamodule = AirQualityDataModule(root=root)
         datamodule.predict_dataset = AirQuality(root)
         trainer = Trainer(accelerator='cpu')

--- a/torchgeo/tasks/temporal_regression.py
+++ b/torchgeo/tasks/temporal_regression.py
@@ -6,12 +6,59 @@
 from typing import Any, Literal
 
 import einops
+import torch
 from torch import Tensor, nn
 
 from ..datasets.utils import Sample
-from ..models import LTAE
+from ..models import LTAE, Presto, presto
 from .base import BaseTask
 from .mixins import RegressionMixin
+
+
+class _PrestoTemporalRegressionModel(nn.Module):
+    """Presto encoder with a regression head."""
+
+    def __init__(self, model: Presto, out_features: int) -> None:
+        """Initialize a new Presto regression model.
+
+        Args:
+            model: Presto model.
+            out_features: Number of output features.
+        """
+        super().__init__()
+        self.model = model
+        self.head = nn.Linear(model.encoder.embedding_size, out_features)
+
+    def forward(
+        self,
+        x: Tensor,
+        dynamic_world: Tensor | None = None,
+        latlons: Tensor | None = None,
+        mask: Tensor | None = None,
+        month: Tensor | int = 0,
+    ) -> Tensor:
+        """Forward pass of the model.
+
+        Args:
+            x: Input tensor of shape (B, T, C).
+            dynamic_world: Dynamic world tensor of shape (B, T).
+            latlons: Latitude and longitude tensor of shape (B, 2).
+            mask: Mask tensor of shape (B, T, C).
+            month: Month tensor or integer representing the month.
+
+        Returns:
+            Output tensor of shape (B, out_features).
+        """
+        b, t, _ = x.shape
+        if dynamic_world is None:
+            dynamic_world = torch.zeros(b, t, dtype=torch.long, device=x.device)
+        if latlons is None:
+            latlons = torch.zeros(b, 2, dtype=x.dtype, device=x.device)
+
+        features, _, _ = self.model.encoder(
+            x=x, dynamic_world=dynamic_world, latlons=latlons, mask=mask, month=month
+        )
+        return self.head(features.mean(dim=1))
 
 
 class TemporalRegression(RegressionMixin, BaseTask):
@@ -22,7 +69,7 @@ class TemporalRegression(RegressionMixin, BaseTask):
 
     def __init__(
         self,
-        model: Literal['ltae'] = 'ltae',
+        model: Literal['ltae', 'presto'] = 'ltae',
         in_channels: int = 1,
         num_outputs: int = 1,
         labels: list[str] | None = None,
@@ -35,7 +82,8 @@ class TemporalRegression(RegressionMixin, BaseTask):
         """Initialize a new TemporalRegression instance.
 
         Args:
-            model: Name of the model architecture.
+            model: Name of the model architecture. Supported values are ``'ltae'``
+                and ``'presto'``.
             in_channels: Number of input features per time step
                 (the *C* dimension of the *(B, T, C)* input tensor).
             num_outputs: Number of output features per time step
@@ -59,6 +107,40 @@ class TemporalRegression(RegressionMixin, BaseTask):
                 ltae = LTAE(in_channels=self.hparams['in_channels'], **self.kwargs)
                 linear = nn.Linear(ltae.n_neurons[-1], out)
                 self.model = nn.Sequential(ltae, linear)
+            case 'presto':
+                out = self.hparams['num_outputs'] * self.hparams['out_steps']
+                model = presto(**self.kwargs)
+                channels = sum(
+                    len(group) for group in model.encoder.band_groups.values()
+                )
+                if self.hparams['in_channels'] != channels:
+                    raise ValueError(
+                        f'Presto expected {channels} input channels, got '
+                        f'{self.hparams["in_channels"]}.'
+                    )
+                self.model = _PrestoTemporalRegressionModel(model, out)
+
+    def _forward_model(self, batch: Sample) -> Tensor:
+        """Forward batch inputs through the configured model.
+
+        Args:
+            batch: The output of the DataLoader.
+
+        Returns:
+            Predicted values of shape *(B, T * C)*.
+        """
+        x = batch['input']
+        match self.hparams['model']:
+            case 'ltae':
+                y_hat: Tensor = self.model(x)
+            case 'presto':
+                kwargs: dict[str, Tensor] = {}
+                for key in ['dynamic_world', 'latlons', 'mask', 'month']:
+                    if key in batch:
+                        kwargs[key] = batch[key]
+                y_hat = self.model(x, **kwargs)
+
+        return y_hat
 
     def _shared_step(self, batch: Sample, batch_idx: int, stage: str) -> Tensor:
         """Forward pass, loss computation, and metric update for all splits.
@@ -71,12 +153,11 @@ class TemporalRegression(RegressionMixin, BaseTask):
         Returns:
             Scalar loss tensor.
         """
-        x = batch['input']
         y = batch['target']
         t = self.hparams['out_steps']
-        batch_size = x.shape[0]
+        batch_size = batch['input'].shape[0]
 
-        y_hat = self.model(x)
+        y_hat = self._forward_model(batch)
         y_hat = einops.rearrange(y_hat, 'b (t c) -> b t c', t=t)
 
         loss = self.criterion(y_hat, y)
@@ -145,10 +226,9 @@ class TemporalRegression(RegressionMixin, BaseTask):
         Returns:
             Predicted values of shape *(B, T, C)*.
         """
-        x = batch['input']
         t = self.hparams['out_steps']
 
-        y_hat = self.model(x)
+        y_hat = self._forward_model(batch)
         y_hat = einops.rearrange(y_hat, 'b (t c) -> b t c', t=t)
 
         # Denormalize before returning predictions

--- a/torchgeo/tasks/temporal_regression.py
+++ b/torchgeo/tasks/temporal_regression.py
@@ -95,6 +95,12 @@ class TemporalRegression(RegressionMixin, BaseTask):
             lr: Learning rate for optimizer.
             patience: Patience for learning rate scheduler.
             **kwargs: Additional keyword arguments passed to the model constructor.
+
+        .. note::
+           When using ``model='presto'``, ``in_channels`` must match the number of
+           channels defined by the model's band groups. Batches may also include
+           ``dynamic_world``, ``latlons``, ``mask``, and ``month`` entries, which
+           are forwarded to the Presto encoder when present.
         """
         self.kwargs = kwargs
         super().__init__()


### PR DESCRIPTION
Adds Presto support to TemporalRegressionTask alongside the existing LTAE path.
Changes

- Added a private _PrestoTemporalRegressionModel wrapper that uses the Presto encoder, mean-pools encoded tokens, and applies a linear regression head.
- Extended TemporalRegressionTask(model=...) to accept 'presto'.
- Added input channel validation for Presto based on its configured band groups.
- Added _forward_model dispatch so LTAE and Presto can handle their required batch inputs explicitly.
- Presto forwarding supports optional batch fields: dynamic_world, latlons, mask, and month; defaults are provided in the wrapper when dynamic_world or latlons are absent.
- Added tests/conf/air_quality_presto.yaml for end-to-end trainer coverage.
- Extended temporal regression trainer tests to include the Presto config.
- Renamed test_predict to test_predict_ltae and added test_predict_presto.

CC @isaaccorley 

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
