### PR TITLE
XarrayDataset: normalize y-axis orientation before merge

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -597,6 +597,12 @@ class TestXarrayDataset:
         ):
             dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
+    def test_getitem_returns_source_data(self) -> None:
+        pytest.importorskip('h5py', minversion='3.10')
+        ds = XarrayDataset(os.path.join('tests', 'data', 'hdf5'))
+        image = ds[ds.bounds]['image']
+        assert (image > 0).any()
+
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             XarrayDataset(tmp_path)

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -597,10 +597,8 @@ class TestXarrayDataset:
         ):
             dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
-    def test_getitem_returns_source_data(self) -> None:
-        pytest.importorskip('h5py', minversion='3.10')
-        ds = XarrayDataset(os.path.join('tests', 'data', 'hdf5'))
-        image = ds[ds.bounds]['image']
+    def test_getitem_returns_source_data(self, dataset: XarrayDataset) -> None:
+        image = dataset[dataset.bounds]['image']
         assert (image > 0).any()
 
     def test_no_data(self, tmp_path: Path) -> None:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -954,15 +954,12 @@ class XarrayDataset(GeoDataset):
                 if src.rio.crs is None:
                     src = src.rio.write_crs(self.crs)
 
-                # Flip to north-up if the y-axis is ascending. merge_datasets cannot
-                # place a source with a positive y-resolution and silently returns an
-                # all-nodata array.
+                # Flip to north-up if the y-axis is ascending or merge_datasets
+                # will silently return an all-nodata array.
                 y_dim = src.rio.y_dim
                 if src[y_dim][0] < src[y_dim][-1]:
                     src = src.isel({y_dim: slice(None, None, -1)})
 
-                # Only reproject for a CRS change; merge_datasets handles resampling
-                # to the requested resolution and bounds.
                 if src.rio.crs != self.crs:
                     src = src.rio.reproject(self.crs)
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -941,7 +941,8 @@ class XarrayDataset(GeoDataset):
 
         x, y, t = self._disambiguate_slice(index)
         bounds = (x.start, y.start, x.stop, y.stop)
-        res = (x.step, y.step)
+        # merge_datasets requires a positive resolution
+        res = (abs(x.step), abs(y.step))
 
         with ExitStack() as stack:
             datasets = []
@@ -953,8 +954,17 @@ class XarrayDataset(GeoDataset):
                 if src.rio.crs is None:
                     src = src.rio.write_crs(self.crs)
 
-                if src.rio.crs != self.crs or res != src.rio.resolution():
-                    src = src.rio.reproject(self.crs, resolution=res)
+                # Flip to north-up if the y-axis is ascending. merge_datasets cannot
+                # place a source with a positive y-resolution and silently returns an
+                # all-nodata array.
+                y_dim = src.rio.y_dim
+                if src[y_dim][0] < src[y_dim][-1]:
+                    src = src.isel({y_dim: slice(None, None, -1)})
+
+                # Only reproject for a CRS change; merge_datasets handles resampling
+                # to the requested resolution and bounds.
+                if src.rio.crs != self.crs:
+                    src = src.rio.reproject(self.crs)
 
                 datasets.append(src)
 


### PR DESCRIPTION
### Summary

XarrayDataset returned all-nodata for ascending-latitude data (and crashed on north-up) because _merge_files passed the source's signed resolution to merge_datasets.
Fixed by flipping sources to north-up and passing a positive resolution.

### Rationale

I have never used XarrayDataset myself, but I found this while implementing a feature for RasterDataset which I wanted to harmonise in XarrayDataset. Seems like the tests for XarrayDataset use a dataset that it does not support reading.

The added test confirms the problem when run on the main branch.

### Checklist

- [X] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [X] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [X] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
