### PR TITLE
Silence warning about number of workers in data loaders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,7 @@ filterwarnings = [
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS
-    "ignore:The .*dataloader.* does not have many workers which may be a bottleneck:UserWarning:lightning",
+    "ignore:The .*dataloader.* does not have many workers which may be a bottleneck:UserWarning",
     # Lightning warns us about using the CPU when GPU/MPS is available
     "ignore:GPU available but not used.:UserWarning",
     # Lightning warns us if TensorBoard is not installed


### PR DESCRIPTION
### Summary

Silences the following warning in CI:
```
tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_forward_deprecates_spatiotemporal_input
  /home/runner/work/torchgeo/torchgeo/.venv/lib/python3.14t/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:434: The 'val_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=3` in the `DataLoader` to improve performance.
```

### Rationale

Not sure why previous ignore didn't work, something to do with nested pytest.warns. The fewer warnings we have in CI, the easier it is to see important warnings.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
