### PR TITLE
PASTIS: normalize each timestep independently in plot

### DIFF
--- a/torchgeo/datasets/pastis.py
+++ b/torchgeo/datasets/pastis.py
@@ -388,9 +388,11 @@ class PASTIS(NonGeoDataset):
         Returns:
             a matplotlib Figure with the rendered sample
         """
-        # Keep the RGB bands and quantile-normalize the displayed frames.
+        # Keep the RGB bands and quantile-normalize each frame independently.
         rgb_frames = sample['image'][:, [2, 1, 0], :, :]
-        rgb_frames = quantile_normalization(rgb_frames)
+        rgb_frames = torch.stack(
+            [quantile_normalization(frame) for frame in rgb_frames]
+        )
         images = rgb_frames.numpy().transpose(0, 2, 3, 1)
         mask = sample['mask'].numpy()
 


### PR DESCRIPTION
### Summary
This PR improves quantile normalization in PASTIS's plot function to normalize each timestep independently. The quantiles are computed over the entire TxCxHxW in main, and this PR's quantiles are computed per CxHxW frame. Each frame is stretched to its own contrast range per time step.

### Rationale
Previously, a single quantile range was shared across all time steps. Because some timesteps contain extremely bright imagery (heavy cloud cover or high exposure), the upper quantile becomes too high for typical clear-sky frames, thereby dimming them. Normalizing per frame makes each displayed frame's contrast independent of outliers at other timesteps in the series.

Here are examples of before and after the quantile normalization change:
<img width="1452" height="748" alt="pastis_compare_49" src="https://github.com/user-attachments/assets/2cbfecdf-16b5-4e8a-bb97-360ced2ae4a3" />
<img width="1452" height="748" alt="pastis_compare_96" src="https://github.com/user-attachments/assets/fcb04fdb-9637-4dd3-a34c-2e6c984befb8" />
<img width="1452" height="748" alt="pastis_compare_61" src="https://github.com/user-attachments/assets/777b2177-cba8-448d-ad5e-025aadc88dbe" />


### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution

@adamjstewart @robmarkcole 