### PR TITLE
Silence NumPy 2.5 deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,8 @@ filterwarnings = [
     'ignore:`torch.jit.script` is not supported in Python 3.14\+ and may break.:DeprecationWarning',
     # https://github.com/kornia/kornia/issues/3727
     'ignore:`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.:DeprecationWarning',
+    # https://github.com/rasterio/rasterio/issues/3592
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -160,16 +160,16 @@ class RCF(Module):
         patchesCovMat = 1.0 / n_patches * patches.T.dot(patches)
 
         (E, V) = np.linalg.eig(patchesCovMat)
+        E_real = np.real(E)
+        V_real = np.real(V)
 
-        E += zca_bias
-        sqrt_zca_eigs = np.sqrt(E)
+        E_real += zca_bias
+        sqrt_zca_eigs = np.sqrt(E_real)
         inv_sqrt_zca_eigs = np.diag(np.power(sqrt_zca_eigs, -1))
-        global_ZCA = V.dot(inv_sqrt_zca_eigs).dot(V.T)
-        patches_normalized: np.typing.NDArray[np.float32] = (
-            (patches).dot(global_ZCA).dot(global_ZCA.T)
-        )
+        global_ZCA = V_real.dot(inv_sqrt_zca_eigs).dot(V_real.T)
+        patches_normalized = (patches).dot(global_ZCA).dot(global_ZCA.T)
 
-        return patches_normalized.reshape(orig_shape).astype('float32')
+        return patches_normalized.reshape(orig_shape)
 
     @torch.inference_mode()
     def forward(self, x: Tensor) -> Tensor:


### PR DESCRIPTION
### Summary

Silences all NumPy 2.5 deprecation warnings.

### Rationale

Future-proofs the code and separates signal from noise in test warnings.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
