### PR TITLE
Security hardening: torch.load(weights_only=True)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ from torchgeo.models import ResNet18_Weights
 
 weights = ResNet18_Weights.SENTINEL2_ALL_MOCO
 model = timm.create_model("resnet18", in_chans=weights.meta["in_chans"], num_classes=10)
-model.load_state_dict(weights.get_state_dict(progress=True), strict=False)
+model.load_state_dict(weights.get_state_dict(progress=True, weights_only=True), strict=False)
 ```
 
 These weights can also directly be used in TorchGeo Lightning modules that are shown in the following section via the `weights` argument. For a notebook example, see this [tutorial](https://torchgeo.readthedocs.io/en/stable/tutorials/pretrained_weights.html).

--- a/docs/tutorials/earth_surface_water.ipynb
+++ b/docs/tutorials/earth_surface_water.ipynb
@@ -595,7 +595,7 @@
     "    backbone.register_module('conv1', conv)\n",
     "\n",
     "    if weights_fn is not None:\n",
-    "        state_dict = torch.load(weights_fn, map_location='cpu')\n",
+    "        state_dict = torch.load(weights_fn, map_location='cpu', weights_only=True)\n",
     "        model.load_state_dict(state_dict, strict=True)\n",
     "        print('Loaded weights from', weights_fn)\n",
     "\n",

--- a/docs/tutorials/pretrained_weights.ipynb
+++ b/docs/tutorials/pretrained_weights.ipynb
@@ -180,7 +180,9 @@
    "source": [
     "in_chans = all_weights.meta['in_chans']\n",
     "model = timm.create_model('resnet18', in_chans=in_chans, num_classes=10)\n",
-    "model.load_state_dict(all_weights.get_state_dict(progress=True), strict=False)"
+    "model.load_state_dict(\n",
+    "    all_weights.get_state_dict(progress=True, weights_only=True), strict=False\n",
+    ")"
    ]
   },
   {

--- a/torchgeo/models/btc.py
+++ b/torchgeo/models/btc.py
@@ -142,7 +142,9 @@ class SwinBackbone(Module):
 
         if backbone_pretrained:
             # load pretrained feature norm weights
-            state_dict = weights.get_state_dict(include_norms=True, progress=True)
+            state_dict = weights.get_state_dict(
+                include_norms=True, progress=True, weights_only=True
+            )
             self.norms.load_state_dict(state_dict['feat_norms_state_dict'])
 
     def forward(self, x: Tensor) -> list[Tensor]:

--- a/torchgeo/models/copernicusfm.py
+++ b/torchgeo/models/copernicusfm.py
@@ -760,7 +760,7 @@ def copernicusfm_base(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
 
         # Both fc_norm and head are generated dynamically

--- a/torchgeo/models/croma.py
+++ b/torchgeo/models/croma.py
@@ -545,7 +545,7 @@ def load_weights(model: CROMA, weights: WeightsEnum) -> None:
     Raises:
         AssertionError: If there are missing or unexpected keys.
     """
-    state_dict = weights.get_state_dict(progress=True)
+    state_dict = weights.get_state_dict(progress=True, weights_only=True)
     missing_keys, unexpected_keys = [], []
 
     if 'sar' in model.modalities:

--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -473,7 +473,7 @@ def dofa_base_patch16_224(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         # Both fc_norm and head are generated dynamically
         assert set(missing_keys) <= {
@@ -511,7 +511,7 @@ def dofa_large_patch16_224(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         # Both fc_norm and head are generated dynamically
         assert set(missing_keys) <= {

--- a/torchgeo/models/earthloc.py
+++ b/torchgeo/models/earthloc.py
@@ -256,7 +256,9 @@ def earthloc(
             'pretrained': False,
         }
         model = EarthLoc(*args, **kwargs)
-        model.load_state_dict(weights.get_state_dict(progress=True), strict=True)
+        model.load_state_dict(
+            weights.get_state_dict(progress=True, weights_only=True), strict=True
+        )
     else:
         model = EarthLoc(*args, **kwargs)
 

--- a/torchgeo/models/olmoearth.py
+++ b/torchgeo/models/olmoearth.py
@@ -92,6 +92,6 @@ def olmoearth_v1(
         model_size = weights.meta.get('model_size', model_size)
     model: nn.Module = olmoearth.OlmoEarthPretrain_v1(model_size=model_size, **kwargs)
     if weights is not None:
-        state_dict = weights.get_state_dict(progress=True)
+        state_dict = weights.get_state_dict(progress=True, weights_only=True)
         model.load_state_dict(state_dict, strict=False)
     return model

--- a/torchgeo/models/panopticon.py
+++ b/torchgeo/models/panopticon.py
@@ -509,7 +509,7 @@ def panopticon_vitb14(
     patch_size = 14  # fixed
 
     if weights:
-        state_dict = weights.get_state_dict(progress=True)
+        state_dict = weights.get_state_dict(progress=True, weights_only=True)
         state_dict.pop('mask_token')
 
         # interpolate positional embeddings (timm==0.9.2) does not support this yet

--- a/torchgeo/models/presto.py
+++ b/torchgeo/models/presto.py
@@ -834,7 +834,10 @@ def presto(weights: Presto_Weights | None = None, *args: Any, **kwargs: Any) -> 
 
     if weights:
         model.load_state_dict(
-            weights.get_state_dict(progress=True, map_location='cpu'), strict=True
+            weights.get_state_dict(
+                progress=True, map_location='cpu', weights_only=True
+            ),
+            strict=True,
         )
 
     return model

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -889,7 +889,7 @@ def resnet18(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
         assert set(unexpected_keys) <= {'fc.weight', 'fc.bias'}
@@ -924,7 +924,7 @@ def resnet50(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
         # used when features_only = True
@@ -959,7 +959,7 @@ def resnet152(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
         # used when features_only = True

--- a/torchgeo/models/scale_mae.py
+++ b/torchgeo/models/scale_mae.py
@@ -237,7 +237,7 @@ def scalemae_large_patch16(
     )
 
     if weights:
-        state_dict = weights.get_state_dict(progress=True)
+        state_dict = weights.get_state_dict(progress=True, weights_only=True)
 
         if 'img_size' in kwargs and weights.meta['img_size'] != kwargs['img_size']:
             state_dict = interpolate_pos_embed(model, state_dict)

--- a/torchgeo/models/swin.py
+++ b/torchgeo/models/swin.py
@@ -378,7 +378,7 @@ def swin_t(
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         # some weights do not contain final norm and cls head weights
         assert set(missing_keys) <= {
@@ -423,7 +423,7 @@ def swin_s(
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         # some weights do not contain final norm and cls head weights
         assert set(missing_keys) <= {
@@ -478,7 +478,7 @@ def swin_b(
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         # some weights do not contain final norm and cls head weights
         assert set(missing_keys) <= {
@@ -525,7 +525,7 @@ def swin_v2_t(
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= set()
         assert not unexpected_keys
@@ -564,7 +564,7 @@ def swin_v2_b(
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= set()
         assert not unexpected_keys

--- a/torchgeo/models/tessera.py
+++ b/torchgeo/models/tessera.py
@@ -405,16 +405,18 @@ def tessera(
         return model
 
     if weights == Tessera_Weights.TESSERA:
-        model.load_state_dict(weights.get_state_dict(progress=True), strict=True)
+        model.load_state_dict(
+            weights.get_state_dict(progress=True, weights_only=True), strict=True
+        )
         return model
     elif weights == Tessera_Weights.TESSERA_SENTINEL2_ENCODER:
         model.s2_backbone.load_state_dict(
-            weights.get_state_dict(progress=True), strict=True
+            weights.get_state_dict(progress=True, weights_only=True), strict=True
         )
         return model.s2_backbone
     elif weights == Tessera_Weights.TESSERA_SENTINEL1_ENCODER:
         model.s1_backbone.load_state_dict(
-            weights.get_state_dict(progress=True), strict=True
+            weights.get_state_dict(progress=True, weights_only=True), strict=True
         )
         return model.s1_backbone
     else:

--- a/torchgeo/models/tilenet.py
+++ b/torchgeo/models/tilenet.py
@@ -177,7 +177,7 @@ def tilenet(
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=True
+            weights.get_state_dict(progress=True, weights_only=True), strict=True
         )
         assert missing_keys == []
         assert unexpected_keys == []

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -275,7 +275,7 @@ def unet(
     model: nn.Module = smp.create_model(*args, **kwargs)
 
     if weights:
-        state_dict = weights.get_state_dict(progress=True)
+        state_dict = weights.get_state_dict(progress=True, weights_only=True)
 
         # Load full pretrained model
         if kwargs['classes'] == weights.meta['num_classes']:

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -638,7 +638,7 @@ def vit_small_patch16_224(
 
     if weights:
         missing_keys, unexpected_keys = target_model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= KEYS
         # used when features_only = True
@@ -678,7 +678,7 @@ def vit_base_patch16_224(
 
     if weights:
         missing_keys, unexpected_keys = target_model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= KEYS
         assert set(unexpected_keys) <= KEYS
@@ -717,7 +717,7 @@ def vit_large_patch16_224(
 
     if weights:
         missing_keys, unexpected_keys = target_model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= KEYS
         assert set(unexpected_keys) <= KEYS
@@ -756,7 +756,7 @@ def vit_huge_patch14_224(
 
     if weights:
         missing_keys, unexpected_keys = target_model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= KEYS
         assert set(unexpected_keys) <= KEYS
@@ -796,7 +796,7 @@ def vit_small_patch14_dinov2(
 
     if weights:
         missing_keys, unexpected_keys = target_model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= KEYS
         assert set(unexpected_keys) <= KEYS
@@ -836,7 +836,7 @@ def vit_base_patch14_dinov2(
 
     if weights:
         missing_keys, unexpected_keys = target_model.load_state_dict(
-            weights.get_state_dict(progress=True), strict=False
+            weights.get_state_dict(progress=True, weights_only=True), strict=False
         )
         assert set(missing_keys) <= KEYS
         assert set(unexpected_keys) <= KEYS

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -340,11 +340,13 @@ class BYOLTask(BaseTask):
         # Load weights
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             elif os.path.exists(weights):
                 _, state_dict = utils.extract_backbone(weights)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
             utils.load_state_dict(backbone, state_dict)
 
         self.model = BYOL(backbone, in_channels=in_channels, image_size=(224, 224))

--- a/torchgeo/trainers/change.py
+++ b/torchgeo/trainers/change.py
@@ -181,11 +181,13 @@ class ChangeDetectionTask(ClassificationMixin, BaseTask):
 
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             elif os.path.exists(weights):
                 _, state_dict = utils.extract_backbone(weights)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
 
             self.model.encoder.load_state_dict(state_dict)
 

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -103,11 +103,13 @@ class ClassificationTask(ClassificationMixin, BaseTask):
         # Load weights
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             elif os.path.exists(weights):
                 _, state_dict = utils.extract_backbone(weights)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
             utils.load_state_dict(self.model, state_dict)
 
         # Freeze backbone and unfreeze classifier head

--- a/torchgeo/trainers/mae.py
+++ b/torchgeo/trainers/mae.py
@@ -119,9 +119,11 @@ class MAETask(BaseTask):
         # Load weights
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
             load_state_dict(vit, state_dict)  # type: ignore[invalid-argument-type]
 
         self.patch_size = vit.patch_embed.patch_size[0]

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -246,11 +246,13 @@ class MoCoTask(BaseTask):
         # Load weights
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             elif os.path.exists(weights):
                 _, state_dict = utils.extract_backbone(weights)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
             utils.load_state_dict(self.backbone, state_dict)
 
         # Create projection (and prediction) head

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -100,11 +100,13 @@ class RegressionTask(RegressionMixin, BaseTask):
         # Load weights
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             elif os.path.exists(weights):
                 _, state_dict = utils.extract_backbone(weights)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
             utils.load_state_dict(self.model, state_dict)
 
         # Freeze backbone and unfreeze classifier head
@@ -296,11 +298,15 @@ class PixelwiseRegressionTask(RegressionTask):
         if model != 'fcn':
             if weights and weights is not True:
                 if isinstance(weights, WeightsEnum):
-                    state_dict = weights.get_state_dict(progress=True)
+                    state_dict = weights.get_state_dict(
+                        progress=True, weights_only=True
+                    )
                 elif os.path.exists(weights):
                     _, state_dict = utils.extract_backbone(weights)
                 else:
-                    state_dict = get_weight(weights).get_state_dict(progress=True)
+                    state_dict = get_weight(weights).get_state_dict(
+                        progress=True, weights_only=True
+                    )
                 self.model.encoder.load_state_dict(state_dict)
 
         # Freeze backbone

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -190,11 +190,15 @@ class SemanticSegmentationTask(ClassificationMixin, BaseTask):
         if model != 'fcn':
             if weights and weights is not True:
                 if isinstance(weights, WeightsEnum):
-                    state_dict = weights.get_state_dict(progress=True)
+                    state_dict = weights.get_state_dict(
+                        progress=True, weights_only=True
+                    )
                 elif os.path.exists(weights):
                     _, state_dict = utils.extract_backbone(weights)
                 else:
-                    state_dict = get_weight(weights).get_state_dict(progress=True)
+                    state_dict = get_weight(weights).get_state_dict(
+                        progress=True, weights_only=True
+                    )
                 self.model.encoder.load_state_dict(state_dict)
 
         # Freeze backbone

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -164,11 +164,13 @@ class SimCLRTask(BaseTask):
         # Load weights
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
+                state_dict = weights.get_state_dict(progress=True, weights_only=True)
             elif os.path.exists(weights):
                 _, state_dict = utils.extract_backbone(weights)
             else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
+                state_dict = get_weight(weights).get_state_dict(
+                    progress=True, weights_only=True
+                )
             utils.load_state_dict(self.backbone, state_dict)
 
         # Create projection head

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -46,7 +46,7 @@ def extract_backbone(path: str) -> tuple[str, dict[str, Tensor]]:
     .. versionchanged:: 0.4
         Renamed from *extract_encoder* to *extract_backbone*
     """
-    checkpoint = torch.load(path, map_location=torch.device('cpu'))
+    checkpoint = torch.load(path, map_location=torch.device('cpu'), weights_only=True)
     if 'model' in checkpoint['hyper_parameters']:
         name = checkpoint['hyper_parameters']['model']
         state_dict = checkpoint['state_dict']


### PR DESCRIPTION
### Summary

Use `weights_only=True` for all uses of `torch.load()` or `torchvision.models.WeightsEnum.get_state_dict()`, which calls `torch.hub.load_state_dict_from_url()`, which calls `torch.load()`.

### Rationale

Security vulnerability reported by @tinyb0y

Also suggested in #2839

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
