### PR TITLE
OlmoEarth: force model to use v1

### DIFF
--- a/torchgeo/models/olmoearth.py
+++ b/torchgeo/models/olmoearth.py
@@ -90,7 +90,9 @@ def olmoearth_v1(
     model_size = kwargs.pop('model_size', 'nano')
     if weights is not None:
         model_size = weights.meta.get('model_size', model_size)
-    model: nn.Module = olmoearth.OlmoEarthPretrain_v1(model_size=model_size, **kwargs)
+    model: nn.Module = olmoearth.OlmoEarthPretrain_v1(
+        model_size=model_size, model_version='v1', **kwargs
+    )
     if weights is not None:
         state_dict = weights.get_state_dict(progress=True)
         model.load_state_dict(state_dict, strict=False)


### PR DESCRIPTION
### Summary

Previously, the model would use whatever the latest version is. Now, we force the model to use version 1.0.

### Rationale

The weights themselves are for v1.0, so the model architecture silently changing underneath is not a good idea. I also hit the following test failure:
```console
> pytest -m slow --force-enable-socket tests/models/test_olmoearth.py::TestOlmoEarthV1::test_olmoearth_v1_download[OlmoEarthV1_Weights.LARGE]
...
ValueError: model_size 'large' is not available for v1.2. Must be one of ['nano', 'small', 'tiny', 'base']
```

@piperwolters @favyen2 

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
