### PR TITLE
TRY: ruff 0.16 fixes for tryceratops

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -199,7 +199,7 @@ class TestGeoDataset:
     def test_and_nongeo(self, dataset: GeoDataset) -> None:
         ds2 = CustomNonGeoDataset()
         with pytest.raises(
-            ValueError, match='IntersectionDataset only supports GeoDatasets'
+            TypeError, match='IntersectionDataset only supports GeoDatasets'
         ):
             dataset & ds2  # ty: ignore[unsupported-operator]
 
@@ -891,7 +891,7 @@ class TestIntersectionDataset:
         ds1 = CustomNonGeoDataset()
         ds2 = CustomNonGeoDataset()
         with pytest.raises(
-            ValueError, match='IntersectionDataset only supports GeoDatasets'
+            TypeError, match='IntersectionDataset only supports GeoDatasets'
         ):
             IntersectionDataset(ds1, ds2)  # ty: ignore[invalid-argument-type]
 
@@ -1289,11 +1289,11 @@ class TestUnionDataset:
         ds2 = CustomNonGeoDataset()
         ds3 = CustomGeoDataset()
         msg = 'UnionDataset only supports GeoDatasets'
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(TypeError, match=msg):
             UnionDataset(ds1, ds2)  # ty: ignore[invalid-argument-type]
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(TypeError, match=msg):
             UnionDataset(ds1, ds3)  # ty: ignore[invalid-argument-type]
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(TypeError, match=msg):
             UnionDataset(ds3, ds1)  # ty: ignore[invalid-argument-type]
 
     def test_invalid_index(self, dataset: UnionDataset) -> None:

--- a/tests/datasets/test_openstreetmap.py
+++ b/tests/datasets/test_openstreetmap.py
@@ -534,7 +534,7 @@ class TestOpenStreetMap:
 
         # Make all requests fail
         def mock_post_fail(*_: Any, **__: Any) -> NoReturn:
-            raise Exception('Connection failed')
+            raise RuntimeError('Connection failed')
 
         monkeypatch.setattr(
             'torchgeo.datasets.openstreetmap.requests.post', mock_post_fail
@@ -576,9 +576,9 @@ class TestOpenStreetMap:
             # Valid case - should not raise
             ([{'name': 'building', 'selector': [{'building': '*'}]}], None, None),
             # Invalid cases
-            ([], ValueError, 'classes must be a non-empty list'),
-            ('invalid', ValueError, 'classes must be a non-empty list'),
-            (['invalid'], ValueError, 'Class 0 must be a dictionary'),
+            ([], TypeError, 'classes must be a non-empty list'),
+            ('invalid', TypeError, 'classes must be a non-empty list'),
+            (['invalid'], TypeError, 'Class 0 must be a dictionary'),
             (
                 [{'name': 'test'}],
                 ValueError,
@@ -586,12 +586,12 @@ class TestOpenStreetMap:
             ),
             (
                 [{'name': 'test', 'selector': 'invalid'}],
-                ValueError,
+                TypeError,
                 'Class 0 selector must be a list',
             ),
             (
                 [{'name': 'test', 'selector': ['invalid']}],
-                ValueError,
+                TypeError,
                 'Class 0 selector 0 must be a dictionary',
             ),
         ],

--- a/tests/trainers/test_mae.py
+++ b/tests/trainers/test_mae.py
@@ -97,7 +97,7 @@ class TestMAETask:
         return weights
 
     def test_wrong_model_type(self) -> None:
-        with pytest.raises(ValueError, match='is not a ViT architecture'):
+        with pytest.raises(TypeError, match='is not a ViT architecture'):
             MAETask(model='resnet18', weights=None)
 
     def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -195,7 +195,7 @@ class GeoDataset(Dataset[Sample], abc.ABC, PlottingMixin):
             a single dataset
 
         Raises:
-            ValueError: if other is not a :class:`GeoDataset`
+            TypeError: if other is not a :class:`GeoDataset`
 
         .. versionadded:: 0.2
         """
@@ -211,7 +211,7 @@ class GeoDataset(Dataset[Sample], abc.ABC, PlottingMixin):
             a single dataset
 
         Raises:
-            ValueError: if other is not a :class:`GeoDataset`
+            TypeError: if other is not a :class:`GeoDataset`
 
         .. versionadded:: 0.2
         """
@@ -1427,7 +1427,7 @@ class IntersectionDataset(GeoDataset):
 
         Raises:
             RuntimeError: if datasets have no spatiotemporal intersection
-            ValueError: if either dataset is not a :class:`GeoDataset`
+            TypeError: if either dataset is not a :class:`GeoDataset`
 
         .. versionadded:: 0.8
            The *spatial_only* parameter.
@@ -1441,7 +1441,7 @@ class IntersectionDataset(GeoDataset):
 
         for ds in self.datasets:
             if not isinstance(ds, GeoDataset):
-                raise ValueError('IntersectionDataset only supports GeoDatasets')
+                raise TypeError('IntersectionDataset only supports GeoDatasets')
 
         dataset2.crs = dataset1.crs
         dataset2.res = dataset1.res
@@ -1599,7 +1599,7 @@ class UnionDataset(GeoDataset):
                 entry and returns a transformed version
 
         Raises:
-            ValueError: if either dataset is not a :class:`GeoDataset`
+            TypeError: if either dataset is not a :class:`GeoDataset`
 
         .. versionadded:: 0.4
             The *transforms* parameter.
@@ -1610,7 +1610,7 @@ class UnionDataset(GeoDataset):
 
         for ds in self.datasets:
             if not isinstance(ds, GeoDataset):
-                raise ValueError('UnionDataset only supports GeoDatasets')
+                raise TypeError('UnionDataset only supports GeoDatasets')
 
         dataset2.crs = dataset1.crs
         dataset2.res = dataset1.res

--- a/torchgeo/datasets/openstreetmap.py
+++ b/torchgeo/datasets/openstreetmap.py
@@ -116,6 +116,7 @@ class OpenStreetMap(VectorDataset):
 
         Raises:
             DatasetNotFoundError: if dataset is not found and download is False
+            TypeError: if invalid class configuration
             ValueError: if invalid class configuration
         """
         self._validate_classes(classes)
@@ -152,21 +153,22 @@ class OpenStreetMap(VectorDataset):
                 with 'name' (str) and 'selector' (list[dict[str, str | list[str]]]) keys.
 
         Raises:
+            TypeError: if classes configuration is invalid
             ValueError: if classes configuration is invalid
         """
         if not isinstance(classes, list) or not classes:
-            raise ValueError('classes must be a non-empty list')
+            raise TypeError('classes must be a non-empty list')
 
         for i, class_def in enumerate(classes):
             if not isinstance(class_def, dict):
-                raise ValueError(f'Class {i} must be a dictionary')
+                raise TypeError(f'Class {i} must be a dictionary')
             if 'name' not in class_def or 'selector' not in class_def:
                 raise ValueError(f'Class {i} must have "name" and "selector" keys')
             if not isinstance(class_def['selector'], list):
-                raise ValueError(f'Class {i} selector must be a list')
+                raise TypeError(f'Class {i} selector must be a list')
             for j, selector in enumerate(class_def['selector']):
                 if not isinstance(selector, dict):
-                    raise ValueError(f'Class {i} selector {j} must be a dictionary')
+                    raise TypeError(f'Class {i} selector {j} must be a dictionary')
 
     def _get_data_filename(self) -> pathlib.Path:
         """Get the filename for the cached data file.

--- a/torchgeo/trainers/mae.py
+++ b/torchgeo/trainers/mae.py
@@ -92,6 +92,9 @@ class MAETask(BaseTask):
             norm_pix_loss: If True, normalize each target patch to zero mean and unit
                 variance before computing MSE. Recommended by the original MAE paper.
             warmup_epochs: Number of linear warmup epochs before cosine annealing.
+
+        Raises:
+            TypeError: If *model* is not a ViT architecture.
         """
         self.weights = weights
         super().__init__()
@@ -112,7 +115,7 @@ class MAETask(BaseTask):
             model, in_chans=in_channels, num_classes=0, pretrained=weights is True
         )
         if not isinstance(vit, VisionTransformer):
-            raise ValueError(
+            raise TypeError(
                 f'Model {model} is not a ViT architecture, which is required for MAE training.'
             )
 


### PR DESCRIPTION
### Summary

Fixes all TRY002 and TRY004 errors in TorchGeo.

### Rationale

Ruff 0.16 now enables these rules by default. Since these are backwards-incompatible, I figured it's worth separating them out from the larger ruff PR for detailed review.

@ashnair1 some of the code in OSM is the definition of defensive coding/AI slop. Would love to improve this and simplify the class.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
