### PR TITLE
DTZ: ruff 0.16 fixes for flake8-datetimez

### DIFF
--- a/tests/data/mmearth/data.py
+++ b/tests/data/mmearth/data.py
@@ -156,7 +156,7 @@ def create_hd5f(dataset_name: str, px_dim: tuple[int]) -> list[dict[str, str]]:
             tile_meta['S2_type'] = S2_type.decode('utf-8')
             # in all_Modality_bands era5 contains the data instead `prev` and `curr` prefixes
             date_str = tile_meta['S2_DATE']
-            date_obj = pd.Timestamp.strptime(date_str, '%Y-%m-%d')
+            date_obj = pd.to_datetime(date_str, format='%Y-%m-%d')
             curr_month_str = date_obj.strftime('%Y%m')
             prev_month_obj = date_obj.replace(day=1) - pd.Timedelta(days=1)
             prev_month_str = prev_month_obj.strftime('%Y%m')

--- a/tests/data/mmearth/data.py
+++ b/tests/data/mmearth/data.py
@@ -7,10 +7,10 @@ import json
 import os
 import shutil
 from copy import deepcopy
-from datetime import datetime, timedelta
 
 import h5py
 import numpy as np
+import pandas as pd
 
 meta_dummy_dict = {
     'S2_DATE': '2018-07-16',
@@ -156,9 +156,9 @@ def create_hd5f(dataset_name: str, px_dim: tuple[int]) -> list[dict[str, str]]:
             tile_meta['S2_type'] = S2_type.decode('utf-8')
             # in all_Modality_bands era5 contains the data instead `prev` and `curr` prefixes
             date_str = tile_meta['S2_DATE']
-            date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+            date_obj = pd.Timestamp.strptime(date_str, '%Y-%m-%d')
             curr_month_str = date_obj.strftime('%Y%m')
-            prev_month_obj = date_obj.replace(day=1) - timedelta(days=1)
+            prev_month_obj = date_obj.replace(day=1) - pd.Timedelta(days=1)
             prev_month_str = prev_month_obj.strftime('%Y%m')
             curr_sample_bands = deepcopy(all_modality_bands)
             curr_sample_bands['era5'] = [

--- a/tests/data/skippd/data.py
+++ b/tests/data/skippd/data.py
@@ -4,10 +4,10 @@
 # Licensed under the MIT License.
 
 import zipfile
-from datetime import datetime, timedelta
 
 import h5py
 import numpy as np
+import pandas as pd
 
 # max rgb image
 RGB_MAX = 255
@@ -55,7 +55,7 @@ if __name__ == '__main__':
         # create time stamps
         for split in splits:
             time_stamps = np.array(
-                [datetime.now() - timedelta(days=i) for i in range(NUM_SAMPLES)]
+                [pd.Timestamp.now() - pd.Timedelta(days=i) for i in range(NUM_SAMPLES)]
             )
             np.save(f'times_{split}_{task}.npy', time_stamps)
 

--- a/tests/datasets/test_splits.py
+++ b/tests/datasets/test_splits.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from collections.abc import Sequence
-from datetime import datetime
 from math import floor, isclose
 
 import pandas as pd
@@ -23,8 +22,8 @@ from torchgeo.datasets import (
 )
 from torchgeo.datasets.utils import GeoSlice, Sample
 
-MINT = datetime(2025, 4, 24)
-MAXT = datetime(2025, 4, 25)
+MINT = pd.Timestamp(2025, 4, 24)
+MAXT = pd.Timestamp(2025, 4, 25)
 
 
 def total_area(dataset: GeoDataset) -> float:
@@ -272,10 +271,10 @@ def test_time_series_split(
     ]
     index = pd.IntervalIndex.from_tuples(
         [
-            (datetime(2025, 4, 25), datetime(2025, 4, 26)),
-            (datetime(2025, 4, 26), datetime(2025, 4, 27)),
-            (datetime(2025, 4, 27), datetime(2025, 4, 28)),
-            (datetime(2025, 4, 28), datetime(2025, 4, 29)),
+            (pd.Timestamp(2025, 4, 25), pd.Timestamp(2025, 4, 26)),
+            (pd.Timestamp(2025, 4, 26), pd.Timestamp(2025, 4, 27)),
+            (pd.Timestamp(2025, 4, 27), pd.Timestamp(2025, 4, 28)),
+            (pd.Timestamp(2025, 4, 28), pd.Timestamp(2025, 4, 29)),
         ],
         closed='neither',
         name='datetime',

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -50,7 +50,7 @@ MAXT = pd.Timestamp(2025, 4, 25)
 class TestBoundingBox:
     def test_repr_str(self) -> None:
         bbox = BoundingBox(0, 1, 2.0, 3.0, MINT, MAXT)
-        expected = 'BoundingBox(minx=0, maxx=1, miny=2.0, maxy=3.0, mint=datetime.datetime(2025, 4, 24, 0, 0), maxt=datetime.datetime(2025, 4, 25, 0, 0))'
+        expected = "BoundingBox(minx=0, maxx=1, miny=2.0, maxy=3.0, mint=Timestamp('2025-04-24 00:00:00'), maxt=Timestamp('2025-04-25 00:00:00'))"
         assert repr(bbox) == expected
         assert str(bbox) == expected
 

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -40,8 +40,8 @@ from torchgeo.datasets.utils import (
     working_dir,
 )
 
-MINT = datetime(2025, 4, 24)
-MAXT = datetime(2025, 4, 25)
+MINT = pd.Timestamp(2025, 4, 24)
+MAXT = pd.Timestamp(2025, 4, 25)
 
 
 @pytest.mark.filterwarnings(
@@ -187,7 +187,7 @@ class TestBoundingBox:
         'test_input',
         [
             # No overlap
-            (0.5, 1.5, 0.5, 1.5, datetime(2025, 4, 26), datetime(2025, 4, 27)),
+            (0.5, 1.5, 0.5, 1.5, pd.Timestamp(2025, 4, 26), pd.Timestamp(2025, 4, 27)),
             (0.5, 1.5, 2, 3, MINT, MAXT),
             (2, 3, 0.5, 1.5, MINT, MAXT),
             (2, 3, 2, 3, MINT, MAXT),
@@ -268,7 +268,7 @@ class TestBoundingBox:
             ((-0.5, 0.5, 0.5, 1.5, MINT, MAXT), True),
             ((-0.5, 0.5, -0.5, 0.5, MINT, MAXT), True),
             # No overlap
-            ((0.5, 1.5, 0.5, 1.5, datetime(2025, 4, 26), datetime(2025, 4, 27)), False),
+            ((0.5, 1.5, 0.5, 1.5, pd.Timestamp(2025, 4, 26), pd.Timestamp(2025, 4, 27)), False),
             ((0.5, 1.5, 2, 3, MINT, MAXT), False),
             ((2, 3, 0.5, 1.5, MINT, MAXT), False),
             ((2, 3, 2, 3, MINT, MAXT), False),
@@ -419,62 +419,62 @@ def test_download_and_extract_archive(tmp_path: Path) -> None:
         (
             '2021',
             '%Y',
-            datetime(2021, 1, 1, 0, 0, 0, 0),
-            datetime(2021, 12, 31, 23, 59, 59, 999999),
+            pd.Timestamp(2021, 1, 1, 0, 0, 0, 0),
+            pd.Timestamp(2021, 12, 31, 23, 59, 59, 999999),
         ),
         (
             '2021-09',
             '%Y-%m',
-            datetime(2021, 9, 1, 0, 0, 0, 0),
-            datetime(2021, 9, 30, 23, 59, 59, 999999),
+            pd.Timestamp(2021, 9, 1, 0, 0, 0, 0),
+            pd.Timestamp(2021, 9, 30, 23, 59, 59, 999999),
         ),
         (
             'Dec 21',
             '%b %y',
-            datetime(2021, 12, 1, 0, 0, 0, 0),
-            datetime(2021, 12, 31, 23, 59, 59, 999999),
+            pd.Timestamp(2021, 12, 1, 0, 0, 0, 0),
+            pd.Timestamp(2021, 12, 31, 23, 59, 59, 999999),
         ),
         (
             '2021-09-13',
             '%Y-%m-%d',
-            datetime(2021, 9, 13, 0, 0, 0, 0),
-            datetime(2021, 9, 13, 23, 59, 59, 999999),
+            pd.Timestamp(2021, 9, 13, 0, 0, 0, 0),
+            pd.Timestamp(2021, 9, 13, 23, 59, 59, 999999),
         ),
         (
             '2021-09-13 17',
             '%Y-%m-%d %H',
-            datetime(2021, 9, 13, 17, 0, 0, 0),
-            datetime(2021, 9, 13, 17, 59, 59, 999999),
+            pd.Timestamp(2021, 9, 13, 17, 0, 0, 0),
+            pd.Timestamp(2021, 9, 13, 17, 59, 59, 999999),
         ),
         (
             '2021-09-13 17:21',
             '%Y-%m-%d %H:%M',
-            datetime(2021, 9, 13, 17, 21, 0, 0),
-            datetime(2021, 9, 13, 17, 21, 59, 999999),
+            pd.Timestamp(2021, 9, 13, 17, 21, 0, 0),
+            pd.Timestamp(2021, 9, 13, 17, 21, 59, 999999),
         ),
         (
             '2021-09-13 17:21:53',
             '%Y-%m-%d %H:%M:%S',
-            datetime(2021, 9, 13, 17, 21, 53, 0),
-            datetime(2021, 9, 13, 17, 21, 53, 999999),
+            pd.Timestamp(2021, 9, 13, 17, 21, 53, 0),
+            pd.Timestamp(2021, 9, 13, 17, 21, 53, 999999),
         ),
         (
             '2021-09-13 17:21:53:000123',
             '%Y-%m-%d %H:%M:%S:%f',
-            datetime(2021, 9, 13, 17, 21, 53, 123),
-            datetime(2021, 9, 13, 17, 21, 53, 123),
+            pd.Timestamp(2021, 9, 13, 17, 21, 53, 123),
+            pd.Timestamp(2021, 9, 13, 17, 21, 53, 123),
         ),
         (
             '2021-09-13%2017:21:53',
             '%Y-%m-%d%%20%H:%M:%S',
-            datetime(2021, 9, 13, 17, 21, 53, 0),
-            datetime(2021, 9, 13, 17, 21, 53, 999999),
+            pd.Timestamp(2021, 9, 13, 17, 21, 53, 0),
+            pd.Timestamp(2021, 9, 13, 17, 21, 53, 999999),
         ),
         (
             '2021%m',
             '%Y%%m',
-            datetime(2021, 1, 1, 0, 0, 0, 0),
-            datetime(2021, 12, 31, 23, 59, 59, 999999),
+            pd.Timestamp(2021, 1, 1, 0, 0, 0, 0),
+            pd.Timestamp(2021, 12, 31, 23, 59, 59, 999999),
         ),
     ],
 )

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -268,7 +268,17 @@ class TestBoundingBox:
             ((-0.5, 0.5, 0.5, 1.5, MINT, MAXT), True),
             ((-0.5, 0.5, -0.5, 0.5, MINT, MAXT), True),
             # No overlap
-            ((0.5, 1.5, 0.5, 1.5, pd.Timestamp(2025, 4, 26), pd.Timestamp(2025, 4, 27)), False),
+            (
+                (
+                    0.5,
+                    1.5,
+                    0.5,
+                    1.5,
+                    pd.Timestamp(2025, 4, 26),
+                    pd.Timestamp(2025, 4, 27),
+                ),
+                False,
+            ),
             ((0.5, 1.5, 2, 3, MINT, MAXT), False),
             ((2, 3, 0.5, 1.5, MINT, MAXT), False),
             ((2, 3, 2, 3, MINT, MAXT), False),

--- a/tests/models/test_aurora.py
+++ b/tests/models/test_aurora.py
@@ -1,9 +1,9 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
-from datetime import datetime
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import torch
 from _pytest.fixtures import SubRequest
@@ -82,7 +82,7 @@ class TestAurora:
             metadata=Metadata(
                 lat=torch.linspace(90, -90, h),
                 lon=torch.linspace(0, 360, w + 1)[:-1],
-                time=(datetime(2020, 6, 1, 12, 0),),
+                time=(pd.Timestamp(2020, 6, 1, 12, 0),),
                 atmos_levels=(100, 250, 500, 850),
             ),
         )

--- a/torchgeo/datasets/mmearth.py
+++ b/torchgeo/datasets/mmearth.py
@@ -6,7 +6,6 @@
 import json
 import os
 from collections.abc import Callable, Sequence
-from datetime import datetime, timedelta
 from typing import ClassVar, TypedDict
 
 import matplotlib.pyplot as plt
@@ -391,10 +390,10 @@ class MMEarth(NonGeoDataset):
             dictionary containing the specific band names for each modality
         """
         date_str = tile_info['S2_DATE']
-        date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+        date_obj = pd.Timestamp.strptime(date_str, '%Y-%m-%d')
         curr_month_str = date_obj.strftime('%Y%m')
         # set to first day of month and subtract one day to get previous month
-        prev_month_obj = date_obj.replace(day=1) - timedelta(days=1)
+        prev_month_obj = date_obj.replace(day=1) - pd.Timedelta(days=1)
         prev_month_str = prev_month_obj.strftime('%Y%m')
 
         specific_modality_bands = {}

--- a/torchgeo/datasets/mmearth.py
+++ b/torchgeo/datasets/mmearth.py
@@ -390,7 +390,7 @@ class MMEarth(NonGeoDataset):
             dictionary containing the specific band names for each modality
         """
         date_str = tile_info['S2_DATE']
-        date_obj = pd.Timestamp.strptime(date_str, '%Y-%m-%d')
+        date_obj = pd.to_datetime(date_str, format='%Y-%m-%d')
         curr_month_str = date_obj.strftime('%Y%m')
         # set to first day of month and subtract one day to get previous month
         prev_month_obj = date_obj.replace(day=1) - pd.Timedelta(days=1)

--- a/torchgeo/datasets/presto.py
+++ b/torchgeo/datasets/presto.py
@@ -3,9 +3,9 @@
 
 """Presto Embeddings dataset."""
 
-from datetime import datetime
 
 import einops
+import pandas as pd
 import torch
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
@@ -46,8 +46,8 @@ class PrestoEmbeddings(RasterDataset):
 
     # Timestamp in filename is when embeddings were released, not the dates they cover
     # TODO: source code shows ±31 days being added to this range?
-    mint = datetime(2019, 3, 1)
-    maxt = datetime(2020, 3, 1)
+    mint = pd.Timestamp(2019, 3, 1)
+    maxt = pd.Timestamp(2020, 3, 1)
 
     all_bands = tuple(map(str, range(128)))
 

--- a/torchgeo/datasets/presto.py
+++ b/torchgeo/datasets/presto.py
@@ -3,7 +3,6 @@
 
 """Presto Embeddings dataset."""
 
-
 import einops
 import pandas as pd
 import torch


### PR DESCRIPTION
### Summary

Fixes all DTZ errors by converting from datetime to pandas (admittedly ignoring the underlying issue).

### Rationale

Ruff 0.16 enables these rules by default. We either need to ignore or make changes. While making all datetimes time-zone-aware would be nice, we would admittedly be guessing 99% of the time. Note that time-zone-aware and non-time-zone-aware cannot directly be compared, thus datasets may not be compatible.

We could go a step farther and always use pd.Timestamp throughout the library. datetime.datetime and pd.Timestamp are typically compatible (the latter is a subclass of the former) but have different default resolutions (ms vs. ns) and may have other hard-to-debug differences.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
