### PR TITLE
CPY: add flake8-copyright to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,12 +250,16 @@ quote-style = "single"
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-extend-select = ["ANN"]
+extend-select = ["ANN", "CPY"]
 ignore = ["ANN401"]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/**" = ["ANN", "D"]
 "tests/**" = ["D"]
+
+[tool.ruff.lint.flake8-copyright]
+author = "TorchGeo Contributors"
+notice-rgx = 'Copyright \(c\)'
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false

--- a/tests/data/air_quality/data.py
+++ b/tests/data/air_quality/data.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
 import numpy as np


### PR DESCRIPTION
### Summary

Adds CPY to our ruff rule list.

### Rationale

Helps test for consistent copyright across all files, something required by OSGeo.

Depends on #3898

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
