### PR TITLE
Security hardening: checksum datasets by default

### DIFF
--- a/tests/conf/bright.yaml
+++ b/tests/conf/bright.yaml
@@ -13,3 +13,4 @@ data:
     batch_size: 1
   dict_kwargs:
     root: 'tests/data/bright'
+    checksum: false

--- a/tests/conf/cowc_counting.yaml
+++ b/tests/conf/cowc_counting.yaml
@@ -11,3 +11,4 @@ data:
     batch_size: 1
   dict_kwargs:
     root: 'tests/data/cowc_counting'
+    checksum: false

--- a/tests/conf/sen12ms_all.yaml
+++ b/tests/conf/sen12ms_all.yaml
@@ -14,3 +14,4 @@ data:
     band_set: 'all'
   dict_kwargs:
     root: 'tests/data/sen12ms'
+    checksum: false

--- a/tests/conf/sen12ms_s1.yaml
+++ b/tests/conf/sen12ms_s1.yaml
@@ -15,3 +15,4 @@ data:
     band_set: 's1'
   dict_kwargs:
     root: 'tests/data/sen12ms'
+    checksum: false

--- a/tests/conf/sen12ms_s2_all.yaml
+++ b/tests/conf/sen12ms_s2_all.yaml
@@ -14,3 +14,4 @@ data:
     band_set: 's2-all'
   dict_kwargs:
     root: 'tests/data/sen12ms'
+    checksum: false

--- a/tests/conf/sen12ms_s2_reduced.yaml
+++ b/tests/conf/sen12ms_s2_reduced.yaml
@@ -14,3 +14,4 @@ data:
     band_set: 's2-reduced'
   dict_kwargs:
     root: 'tests/data/sen12ms'
+    checksum: false

--- a/tests/conf/sentinel2_eurocrops.yaml
+++ b/tests/conf/sentinel2_eurocrops.yaml
@@ -28,3 +28,4 @@ data:
       - 'B09'
       - 'B11'
       - 'B12'
+    eurocrops_checksum: false

--- a/tests/conf/so2sat_all.yaml
+++ b/tests/conf/so2sat_all.yaml
@@ -13,3 +13,4 @@ data:
   dict_kwargs:
     root: 'tests/data/so2sat'
     version: '2'
+    checksum: false

--- a/tests/conf/so2sat_rgb.yaml
+++ b/tests/conf/so2sat_rgb.yaml
@@ -14,3 +14,4 @@ data:
   dict_kwargs:
     root: 'tests/data/so2sat'
     version: '3_random'
+    checksum: false

--- a/tests/conf/so2sat_s1.yaml
+++ b/tests/conf/so2sat_s1.yaml
@@ -13,3 +13,4 @@ data:
   dict_kwargs:
     root: 'tests/data/so2sat'
     version: '2'
+    checksum: false

--- a/tests/conf/so2sat_s2.yaml
+++ b/tests/conf/so2sat_s2.yaml
@@ -12,3 +12,4 @@ data:
     band_set: 's2'
   dict_kwargs:
     root: 'tests/data/so2sat'
+    checksum: false

--- a/tests/conf/vhr10_ins_seg.yaml
+++ b/tests/conf/vhr10_ins_seg.yaml
@@ -12,3 +12,4 @@ data:
     patch_size: 256
   dict_kwargs:
     root: 'tests/data/vhr10'
+    checksum: false

--- a/tests/conf/vhr10_obj_det.yaml
+++ b/tests/conf/vhr10_obj_det.yaml
@@ -12,3 +12,4 @@ data:
     patch_size: 4
   dict_kwargs:
     root: 'tests/data/vhr10'
+    checksum: false

--- a/tests/datasets/test_bright.py
+++ b/tests/datasets/test_bright.py
@@ -53,7 +53,7 @@ class TestBRIGHTDFC2025:
         shutil.copyfile(
             os.path.join(dir, filename), os.path.join(str(tmp_path), filename)
         )
-        BRIGHTDFC2025(root=str(tmp_path))
+        BRIGHTDFC2025(root=str(tmp_path), checksum=False)
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -33,7 +33,7 @@ class TestCanadianBuildingFootprints:
         root = tmp_path
         transforms = nn.Identity()
         return CanadianBuildingFootprints(
-            root, res=(0.1, 0.1), transforms=transforms, download=True
+            root, res=(0.1, 0.1), transforms=transforms, download=True, checksum=False
         )
 
     def test_getitem(self, dataset: CanadianBuildingFootprints) -> None:
@@ -53,7 +53,7 @@ class TestCanadianBuildingFootprints:
         assert isinstance(ds, UnionDataset)
 
     def test_already_downloaded(self, dataset: CanadianBuildingFootprints) -> None:
-        CanadianBuildingFootprints(dataset.paths, download=True)
+        CanadianBuildingFootprints(dataset.paths, download=True, checksum=False)
 
     def test_plot(self, dataset: CanadianBuildingFootprints) -> None:
         index = dataset.bounds

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -52,7 +52,7 @@ class TestCMSGlobalMangroveCanopy:
         )
         root = tmp_path
         shutil.copy(pathname, root)
-        CMSGlobalMangroveCanopy(root, country='Angola')
+        CMSGlobalMangroveCanopy(root, country='Angola', checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -31,7 +31,7 @@ class TestCOWCCounting:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return COWCCounting(root, split, transforms, download=True)
+        return COWCCounting(root, split, transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: COWC) -> None:
         x = dataset[0]
@@ -48,7 +48,7 @@ class TestCOWCCounting:
         assert len(ds) in [12, 24]
 
     def test_already_downloaded(self, dataset: COWC) -> None:
-        COWCCounting(root=dataset.root, download=True)
+        COWCCounting(root=dataset.root, download=True, checksum=False)
 
     def test_out_of_bounds(self, dataset: COWC) -> None:
         with pytest.raises(IndexError):
@@ -79,7 +79,7 @@ class TestCOWCDetection:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return COWCDetection(root, split, transforms, download=True)
+        return COWCDetection(root, split, transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: COWC) -> None:
         x = dataset[0]
@@ -96,7 +96,7 @@ class TestCOWCDetection:
         assert len(ds) in [12, 24]
 
     def test_already_downloaded(self, dataset: COWC) -> None:
-        COWCDetection(root=dataset.root, download=True)
+        COWCDetection(root=dataset.root, download=True, checksum=False)
 
     def test_out_of_bounds(self, dataset: COWC) -> None:
         with pytest.raises(IndexError):

--- a/tests/datasets/test_deepglobelandcover.py
+++ b/tests/datasets/test_deepglobelandcover.py
@@ -35,7 +35,7 @@ class TestDeepGlobeLandCover:
         root = os.path.join('tests', 'data', 'deepglobelandcover')
         filename = 'data.zip'
         shutil.copyfile(os.path.join(root, filename), os.path.join(tmp_path, filename))
-        DeepGlobeLandCover(root=tmp_path)
+        DeepGlobeLandCover(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'data.zip'), 'w') as f:

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -49,7 +49,7 @@ class TestDFC2022:
             os.path.join('tests', 'data', 'dfc2022', 'val.zip'),
             os.path.join(tmp_path, 'val.zip'),
         )
-        DFC2022(root=tmp_path)
+        DFC2022(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'labeled_train.zip'), 'w') as f:

--- a/tests/datasets/test_dior.py
+++ b/tests/datasets/test_dior.py
@@ -52,7 +52,7 @@ class TestDIOR:
                 os.path.join(str(tmp_path), path),
             )
 
-        DIOR(root=tmp_path)
+        DIOR(root=tmp_path, checksum=False)
 
     def test_getitem(self, dataset: DIOR) -> None:
         x = dataset[0]

--- a/tests/datasets/test_dlrsd.py
+++ b/tests/datasets/test_dlrsd.py
@@ -52,7 +52,7 @@ class TestDLRSD:
         self, dataset: DLRSDBase, tmp_path: Path
     ) -> None:
         shutil.rmtree(os.path.join(tmp_path, dataset.directory))
-        type(dataset)(tmp_path)
+        type(dataset)(tmp_path, checksum=False)
 
     @pytest.mark.parametrize('base_class', [DLRSD, DLRSDMultilabel])
     def test_corrupted(self, tmp_path: Path, base_class: type[DLRSDBase]) -> None:

--- a/tests/datasets/test_dota.py
+++ b/tests/datasets/test_dota.py
@@ -137,7 +137,7 @@ class TestDOTA:
                 os.path.join(str(tmp_path), path),
             )
 
-        DOTA(root=tmp_path)
+        DOTA(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'dotav1.0_images_train.tar.gz'), 'w') as f:

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -41,7 +41,7 @@ class TestETCI2021:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return ETCI2021(root, split, transforms, download=True)
+        return ETCI2021(root, split, transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: ETCI2021) -> None:
         x = dataset[0]
@@ -60,7 +60,7 @@ class TestETCI2021:
         assert len(dataset) == 3
 
     def test_already_downloaded(self, dataset: ETCI2021) -> None:
-        ETCI2021(root=dataset.root, download=True)
+        ETCI2021(root=dataset.root, download=True, checksum=False)
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -26,7 +26,7 @@ class TestEUDEM:
         shutil.copy(zipfile, tmp_path)
         root = tmp_path
         transforms = nn.Identity()
-        return EUDEM(root, transforms=transforms)
+        return EUDEM(root, transforms=transforms, checksum=False)
 
     def test_getitem(self, dataset: EUDEM) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_everwatch.py
+++ b/tests/datasets/test_everwatch.py
@@ -45,7 +45,7 @@ class TestEverWatch:
     def test_not_extracted(self, tmp_path: Path) -> None:
         url = os.path.join('tests', 'data', 'everwatch', 'everwatch-benchmark.zip')
         shutil.copy(url, tmp_path)
-        EverWatch(root=tmp_path)
+        EverWatch(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'everwatch-benchmark.zip'), 'w') as f:

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -77,7 +77,7 @@ class TestFAIR1M:
             os.makedirs(os.path.dirname(output), exist_ok=True)
             shutil.copy(url, output)
 
-        FAIR1M(root=tmp_path, split=dataset.split)
+        FAIR1M(root=tmp_path, split=dataset.split, checksum=False)
 
     def test_corrupted(self, tmp_path: Path, dataset: FAIR1M) -> None:
         shutil.rmtree(dataset.root)

--- a/tests/datasets/test_forestdamage.py
+++ b/tests/datasets/test_forestdamage.py
@@ -44,7 +44,7 @@ class TestForestDamage:
             'tests', 'data', 'forestdamage', 'Data_Set_Larch_Casebearer.zip'
         )
         shutil.copy(url, tmp_path)
-        ForestDamage(root=tmp_path)
+        ForestDamage(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'Data_Set_Larch_Casebearer.zip'), 'w') as f:

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -30,7 +30,7 @@ class TestGlobBiomass:
         )
         root = tmp_path
         transforms = nn.Identity()
-        return GlobBiomass(root, transforms=transforms)
+        return GlobBiomass(root, transforms=transforms, checksum=False)
 
     def test_getitem(self, dataset: GlobBiomass) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -22,7 +22,7 @@ class TestInriaAerialImageLabeling:
         root = os.path.join('tests', 'data', 'inria')
         transforms = nn.Identity()
         return InriaAerialImageLabeling(
-            root, split=request.param, transforms=transforms
+            root, split=request.param, transforms=transforms, checksum=False
         )
 
     def test_getitem(self, dataset: InriaAerialImageLabeling) -> None:

--- a/tests/datasets/test_iobench.py
+++ b/tests/datasets/test_iobench.py
@@ -29,7 +29,7 @@ class TestIOBench:
         monkeypatch.setattr(IOBench, 'url', url)
         root = tmp_path
         transforms = nn.Identity()
-        return IOBench(root, transforms=transforms, download=True)
+        return IOBench(root, transforms=transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: IOBench) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -35,7 +35,7 @@ class TestLEVIRCD:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return LEVIRCD(root, split, transforms, download=True)
+        return LEVIRCD(root, split, transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: LEVIRCD) -> None:
         x = dataset[0]

--- a/tests/datasets/test_mapinwild.py
+++ b/tests/datasets/test_mapinwild.py
@@ -69,7 +69,7 @@ class TestMapInWild:
         root = tmp_path
         for zipfile in pathname_glob:
             shutil.copy(zipfile, root)
-        MapInWild(root, download=False)
+        MapInWild(root, download=False, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         pathname = os.path.join('tests', 'data', 'mapinwild', '**', '*.zip')

--- a/tests/datasets/test_millionaid.py
+++ b/tests/datasets/test_millionaid.py
@@ -43,7 +43,7 @@ class TestMillionAID:
     def test_not_extracted(self, tmp_path: Path) -> None:
         url = os.path.join('tests', 'data', 'millionaid', 'train.zip')
         shutil.copy(url, tmp_path)
-        MillionAID(tmp_path)
+        MillionAID(tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'train.zip'), 'w') as f:

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -35,7 +35,7 @@ class TestOpenBuildings:
         md5s = {'000_buildings.csv.gz': 'fake'}
         monkeypatch.setattr(OpenBuildings, 'md5s', md5s)
         transforms = nn.Identity()
-        return OpenBuildings(root, transforms=transforms)
+        return OpenBuildings(root, transforms=transforms, checksum=False)
 
     def test_no_shapes_to_rasterize(
         self, dataset: OpenBuildings, tmp_path: Path
@@ -69,7 +69,7 @@ class TestOpenBuildings:
             json.dump(content, f)
 
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
-            OpenBuildings(dataset.paths)
+            OpenBuildings(dataset.paths, checksum=False)
 
     def test_getitem(self, dataset: OpenBuildings) -> None:
         x = dataset[dataset.bounds]
@@ -105,9 +105,12 @@ class TestOpenBuildings:
         plt.close()
 
     def test_float_res(self, dataset: OpenBuildings) -> None:
-        OpenBuildings(dataset.paths, res=0.0001)
+        OpenBuildings(dataset.paths, res=0.0001, checksum=False)
 
     def test_crs_not_none(self, dataset: OpenBuildings) -> None:
         OpenBuildings(
-            dataset.paths, transforms=dataset.transforms, crs=CRS.from_epsg(3857)
+            dataset.paths,
+            transforms=dataset.transforms,
+            crs=CRS.from_epsg(3857),
+            checksum=False,
         )

--- a/tests/datasets/test_pastis.py
+++ b/tests/datasets/test_pastis.py
@@ -88,7 +88,7 @@ class TestPASTIS:
         url = os.path.join('tests', 'data', 'pastis', 'PASTIS-R.zip')
         root = tmp_path
         shutil.copy(url, root)
-        PASTIS(root)
+        PASTIS(root, checksum=False)
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -43,7 +43,7 @@ class TestPotsdam2D:
             shutil.copyfile(
                 os.path.join(root, filename), os.path.join(tmp_path, filename)
             )
-        Potsdam2D(root=tmp_path)
+        Potsdam2D(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, '4_Ortho_RGBIR.zip'), 'w') as f:

--- a/tests/datasets/test_reforestree.py
+++ b/tests/datasets/test_reforestree.py
@@ -44,7 +44,7 @@ class TestReforesTree:
     def test_not_extracted(self, tmp_path: Path) -> None:
         url = os.path.join('tests', 'data', 'reforestree', 'reforesTree.zip')
         shutil.copy(url, tmp_path)
-        ReforesTree(root=tmp_path)
+        ReforesTree(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'reforesTree.zip'), 'w') as f:

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -21,7 +21,7 @@ class TestSo2Sat:
         root = os.path.join('tests', 'data', 'so2sat')
         split = request.param
         transforms = nn.Identity()
-        return So2Sat(root=root, split=split, transforms=transforms)
+        return So2Sat(root=root, split=split, transforms=transforms, checksum=False)
 
     def test_getitem(self, dataset: So2Sat) -> None:
         x = dataset[0]

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -55,7 +55,7 @@ class TestSo2Sat:
         plt.close()
 
     def test_plot_rgb(self, dataset: So2Sat) -> None:
-        dataset = So2Sat(root=dataset.root, bands=('S2_B03',))
+        dataset = So2Sat(root=dataset.root, bands=('S2_B03',), checksum=False)
         with pytest.raises(
             RGBBandsMissingError, match='Dataset does not contain some of the RGB bands'
         ):

--- a/tests/datasets/test_soda.py
+++ b/tests/datasets/test_soda.py
@@ -39,6 +39,7 @@ class TestSODAA:
             bbox_orientation=bbox_orientation,
             transforms=transforms,
             download=True,
+            checksum=False,
         )
 
     def test_already_downloaded(self, dataset: SODAA) -> None:
@@ -66,7 +67,7 @@ class TestSODAA:
         files = ['Images.zip', 'Annotations.zip', 'sample_df.csv']
         for file in files:
             shutil.copy(os.path.join('tests', 'data', 'soda', file), tmp_path)
-        SODAA(root=tmp_path)
+        SODAA(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'Images.zip'), 'w') as f:

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -49,7 +49,7 @@ class TestUCMerced:
     ) -> None:
         shutil.rmtree(dataset.root)
         shutil.copy(dataset.url + dataset.filename, tmp_path)
-        UCMerced(tmp_path)
+        UCMerced(tmp_path, checksum=False)
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -64,7 +64,7 @@ class TestUSAVars:
         split, labels = request.param
         transforms = nn.Identity()
 
-        return USAVars(root, split, labels, transforms=transforms, download=True)
+        return USAVars(root, split, labels, transforms=transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: USAVars) -> None:
         x = dataset[0]

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -64,7 +64,9 @@ class TestUSAVars:
         split, labels = request.param
         transforms = nn.Identity()
 
-        return USAVars(root, split, labels, transforms=transforms, download=True, checksum=False)
+        return USAVars(
+            root, split, labels, transforms=transforms, download=True, checksum=False
+        )
 
     def test_getitem(self, dataset: USAVars) -> None:
         x = dataset[0]

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -49,7 +49,7 @@ class TestVaihingen2D:
             shutil.copyfile(
                 os.path.join(root, filename), os.path.join(tmp_path, filename)
             )
-        Vaihingen2D(root=tmp_path)
+        Vaihingen2D(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         filenames = [

--- a/tests/datasets/test_vhr10.py
+++ b/tests/datasets/test_vhr10.py
@@ -26,7 +26,7 @@ class TestVHR10:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return VHR10(root, split, transforms, download=True)
+        return VHR10(root, split, transforms, download=True, checksum=False)
 
     def test_getitem(self, dataset: VHR10) -> None:
         x = dataset[0]
@@ -44,7 +44,7 @@ class TestVHR10:
             assert len(dataset) == 150
 
     def test_already_downloaded(self, dataset: VHR10) -> None:
-        VHR10(root=dataset.root, download=True)
+        VHR10(root=dataset.root, download=True, checksum=False)
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_xbd.py
+++ b/tests/datasets/test_xbd.py
@@ -55,7 +55,7 @@ class TestxBD:
             os.path.join('tests', 'data', 'xbd', 'test_images_labels_targets.tar.gz'),
             os.path.join(tmp_path, 'test_images_labels_targets.tar.gz'),
         )
-        xBD(root=tmp_path)
+        xBD(root=tmp_path, checksum=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(

--- a/tests/tasks/test_instance_segmentation.py
+++ b/tests/tasks/test_instance_segmentation.py
@@ -78,7 +78,7 @@ class TestInstanceSegmentation:
         monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
         monkeypatch.setattr(VHR10DataModule, 'plot', plot)
         datamodule = VHR10DataModule(
-            root='tests/data/vhr10', batch_size=1, num_workers=0
+            root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
         )
         model = InstanceSegmentation(in_channels=3, num_classes=11)
         trainer = Trainer(
@@ -93,7 +93,7 @@ class TestInstanceSegmentation:
         monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
         monkeypatch.setattr(VHR10DataModule, 'plot', plot_missing_bands)
         datamodule = VHR10DataModule(
-            root='tests/data/vhr10', batch_size=1, num_workers=0
+            root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
         )
         model = InstanceSegmentation(in_channels=3, num_classes=11)
         trainer = Trainer(
@@ -106,7 +106,7 @@ class TestInstanceSegmentation:
 
     def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictInstanceSegmentationDataModule(
-            root='tests/data/vhr10', batch_size=1, num_workers=0
+            root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
         )
         model = InstanceSegmentation(num_classes=11)
         trainer = Trainer(

--- a/tests/tasks/test_segmentation.py
+++ b/tests/tasks/test_segmentation.py
@@ -217,7 +217,7 @@ class TestSemanticSegmentation:
     def test_no_plot_method(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(SEN12MSDataModule, 'plot', plot)
         datamodule = SEN12MSDataModule(
-            root='tests/data/sen12ms', batch_size=1, num_workers=0
+            root='tests/data/sen12ms', batch_size=1, num_workers=0, checksum=False
         )
         model = SemanticSegmentation(backbone='resnet18', in_channels=15, num_classes=6)
         trainer = Trainer(
@@ -231,7 +231,7 @@ class TestSemanticSegmentation:
     def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(SEN12MSDataModule, 'plot', plot_missing_bands)
         datamodule = SEN12MSDataModule(
-            root='tests/data/sen12ms', batch_size=1, num_workers=0
+            root='tests/data/sen12ms', batch_size=1, num_workers=0, checksum=False
         )
         model = SemanticSegmentation(backbone='resnet18', in_channels=15, num_classes=6)
         trainer = Trainer(

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -91,7 +91,7 @@ class ADVANCE(NonGeoDataset):
         root: Path = 'data',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new ADVANCE dataset instance.
 

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -282,7 +282,7 @@ class BigEarthNet(NonGeoDataset):
         num_classes: int = 19,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new BigEarthNet dataset instance.
 
@@ -698,7 +698,7 @@ class BigEarthNetV2(NonGeoDataset):
         bands: Literal['s1', 's2', 'all'] = 'all',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new BigEarthNet V2 dataset instance.
 

--- a/torchgeo/datasets/bright.py
+++ b/torchgeo/datasets/bright.py
@@ -93,7 +93,7 @@ class BRIGHTDFC2025(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new BRIGHT DFC2025 dataset instance.
 

--- a/torchgeo/datasets/cabuar.py
+++ b/torchgeo/datasets/cabuar.py
@@ -89,7 +89,7 @@ class CaBuAr(NonGeoDataset):
         bands: tuple[str, ...] = all_bands,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CaBuAr dataset instance.
 

--- a/torchgeo/datasets/caffe.py
+++ b/torchgeo/datasets/caffe.py
@@ -87,7 +87,7 @@ class CaFFe(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new instance of CaFFe dataset.
 

--- a/torchgeo/datasets/cbf.py
+++ b/torchgeo/datasets/cbf.py
@@ -69,7 +69,7 @@ class CanadianBuildingFootprints(VectorDataset):
         res: float | tuple[float, float] = (0.00001, 0.00001),
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
 

--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -482,7 +482,7 @@ class CDL(RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.

--- a/torchgeo/datasets/chabud.py
+++ b/torchgeo/datasets/chabud.py
@@ -82,7 +82,7 @@ class ChaBuD(NonGeoDataset):
         bands: Sequence[str] = all_bands,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new ChaBuD dataset instance.
 

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -226,7 +226,7 @@ class Chesapeake(RasterDataset, ABC):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Chesapeake instance.
@@ -549,7 +549,7 @@ class ChesapeakeCVPR(GeoDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
 

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -176,7 +176,7 @@ class CMSGlobalMangroveCanopy(RasterDataset):
         country: str = all_countries[0],
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.

--- a/torchgeo/datasets/copernicus/aq_no2_s5p.py
+++ b/torchgeo/datasets/copernicus/aq_no2_s5p.py
@@ -52,7 +52,7 @@ class CopernicusBenchAQNO2S5P(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchAQNO2S5P instance.
 

--- a/torchgeo/datasets/copernicus/aq_o3_s5p.py
+++ b/torchgeo/datasets/copernicus/aq_o3_s5p.py
@@ -52,7 +52,7 @@ class CopernicusBenchAQO3S5P(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchAQO3S5P instance.
 

--- a/torchgeo/datasets/copernicus/base.py
+++ b/torchgeo/datasets/copernicus/base.py
@@ -84,7 +84,7 @@ class CopernicusBenchBase(NonGeoDataset, ABC):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBase instance.
 

--- a/torchgeo/datasets/copernicus/bigearthnet_s1.py
+++ b/torchgeo/datasets/copernicus/bigearthnet_s1.py
@@ -66,7 +66,7 @@ class CopernicusBenchBigEarthNetS1(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBigEarthNetS1 instance.
 

--- a/torchgeo/datasets/copernicus/bigearthnet_s2.py
+++ b/torchgeo/datasets/copernicus/bigearthnet_s2.py
@@ -79,7 +79,7 @@ class CopernicusBenchBigEarthNetS2(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBigEarthNetS2 instance.
 

--- a/torchgeo/datasets/copernicus/biomass_s3.py
+++ b/torchgeo/datasets/copernicus/biomass_s3.py
@@ -75,7 +75,7 @@ class CopernicusBenchBiomassS3(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBiomassS3 instance.
 

--- a/torchgeo/datasets/copernicus/cloud_s3.py
+++ b/torchgeo/datasets/copernicus/cloud_s3.py
@@ -118,7 +118,7 @@ class CopernicusBenchCloudS3(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBase instance.
 

--- a/torchgeo/datasets/copernicus/embed.py
+++ b/torchgeo/datasets/copernicus/embed.py
@@ -52,7 +52,7 @@ class CopernicusEmbed(RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new CopernicusEmbed instance.

--- a/torchgeo/datasets/copernicus/flood_s1.py
+++ b/torchgeo/datasets/copernicus/flood_s1.py
@@ -56,7 +56,7 @@ class CopernicusBenchFloodS1(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBase instance.
 

--- a/torchgeo/datasets/copernicus/lc100cls_s3.py
+++ b/torchgeo/datasets/copernicus/lc100cls_s3.py
@@ -175,7 +175,7 @@ class CopernicusBenchLC100ClsS3(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchLC100ClsS3 instance.
 

--- a/torchgeo/datasets/copernicus/lc100seg_s3.py
+++ b/torchgeo/datasets/copernicus/lc100seg_s3.py
@@ -226,7 +226,7 @@ class CopernicusBenchLC100SegS3(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchLC100SegS3 instance.
 

--- a/torchgeo/datasets/copernicus/lcz_s2.py
+++ b/torchgeo/datasets/copernicus/lcz_s2.py
@@ -71,7 +71,7 @@ class CopernicusBenchLCZS2(CopernicusBenchBase):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CopernicusBenchBase instance.
 

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -69,7 +69,7 @@ class COWC(NonGeoDataset, abc.ABC):
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new COWC dataset instance.
 

--- a/torchgeo/datasets/cropharvest.py
+++ b/torchgeo/datasets/cropharvest.py
@@ -100,7 +100,7 @@ class CropHarvest(NonGeoDataset):
         root: Path = 'data',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new CropHarvest dataset instance.
 

--- a/torchgeo/datasets/deepglobelandcover.py
+++ b/torchgeo/datasets/deepglobelandcover.py
@@ -106,7 +106,7 @@ class DeepGlobeLandCover(NonGeoDataset):
         root: Path = 'data',
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DeepGlobeLandCover dataset instance.
 

--- a/torchgeo/datasets/dfc2022.py
+++ b/torchgeo/datasets/dfc2022.py
@@ -147,7 +147,7 @@ class DFC2022(NonGeoDataset):
         root: Path = 'data',
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DFC2022 dataset instance.
 

--- a/torchgeo/datasets/digital_typhoon.py
+++ b/torchgeo/datasets/digital_typhoon.py
@@ -108,7 +108,7 @@ class DigitalTyphoon(NonGeoDataset):
         max_feature_value: dict[str, float] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Digital Typhoon dataset instance.
 

--- a/torchgeo/datasets/dior.py
+++ b/torchgeo/datasets/dior.py
@@ -161,7 +161,7 @@ class DIOR(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DIOR dataset instance.
 

--- a/torchgeo/datasets/dl4gam.py
+++ b/torchgeo/datasets/dl4gam.py
@@ -150,7 +150,7 @@ class DL4GAMAlps(NonGeoDataset):
         extra_features: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize the dataset.
 

--- a/torchgeo/datasets/dlrsd.py
+++ b/torchgeo/datasets/dlrsd.py
@@ -102,7 +102,7 @@ class DLRSDBase(NonGeoDataset):
         root: Path = 'data',
         transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DLRSD-style dataset instance.
 
@@ -223,7 +223,7 @@ class DLRSD(DLRSDBase):
         root: Path = 'data',
         transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DLRSD dataset instance.
 
@@ -375,7 +375,7 @@ class DLRSDMultilabel(DLRSDBase):
         root: Path = 'data',
         transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DLRSDMultilabel dataset instance.
 

--- a/torchgeo/datasets/dota.py
+++ b/torchgeo/datasets/dota.py
@@ -179,7 +179,7 @@ class DOTA(NonGeoDataset):
         bbox_orientation: Literal['horizontal', 'oriented'] = 'oriented',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new DOTA dataset instance.
 

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -260,7 +260,7 @@ class EnviroAtlas(GeoDataset):
         prior_as_input: bool = False,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
 

--- a/torchgeo/datasets/esri2020.py
+++ b/torchgeo/datasets/esri2020.py
@@ -75,7 +75,7 @@ class Esri2020(RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -86,7 +86,7 @@ class ETCI2021(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new ETCI 2021 dataset instance.
 

--- a/torchgeo/datasets/eudem.py
+++ b/torchgeo/datasets/eudem.py
@@ -80,7 +80,7 @@ class EUDEM(RasterDataset):
         res: float | tuple[float, float] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.

--- a/torchgeo/datasets/eurocrops.py
+++ b/torchgeo/datasets/eurocrops.py
@@ -98,7 +98,7 @@ class EuroCrops(VectorDataset):
         classes: list[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new EuroCrops instance.
 

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -112,7 +112,7 @@ class EuroSAT(NonGeoClassificationDataset):
         bands: Sequence[str] = BAND_SETS['all'],
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new EuroSAT dataset instance.
 

--- a/torchgeo/datasets/everwatch.py
+++ b/torchgeo/datasets/everwatch.py
@@ -90,7 +90,7 @@ class EverWatch(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new EverWatch dataset instance.
 

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -234,7 +234,7 @@ class FAIR1M(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new FAIR1M dataset instance.
 

--- a/torchgeo/datasets/fire_risk.py
+++ b/torchgeo/datasets/fire_risk.py
@@ -71,7 +71,7 @@ class FireRisk(NonGeoClassificationDataset):
         split: Literal['train', 'val'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new FireRisk dataset instance.
 

--- a/torchgeo/datasets/forestdamage.py
+++ b/torchgeo/datasets/forestdamage.py
@@ -112,7 +112,7 @@ class ForestDamage(NonGeoDataset):
         root: Path = 'data',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new ForestDamage dataset instance.
 

--- a/torchgeo/datasets/ftw.py
+++ b/torchgeo/datasets/ftw.py
@@ -130,7 +130,7 @@ class FieldsOfTheWorld(NonGeoDataset):
         countries: str | Sequence[str] = ['austria'],
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Fields Of The World dataset instance.
 

--- a/torchgeo/datasets/geonrw.py
+++ b/torchgeo/datasets/geonrw.py
@@ -167,7 +167,7 @@ class GeoNRW(NonGeoDataset):
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize the GeoNRW dataset.
 

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -93,7 +93,7 @@ class GID15(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new GID-15 dataset instance.
 

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -149,7 +149,7 @@ class GlobBiomass(RasterDataset):
         measurement: str = 'agb',
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new GlobBiomass instance.

--- a/torchgeo/datasets/hyspecnet.py
+++ b/torchgeo/datasets/hyspecnet.py
@@ -92,7 +92,7 @@ class HySpecNet11k(NonGeoDataset):
         bands: Sequence[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new HySpecNet11k instance.
 

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -166,7 +166,7 @@ class IDTReeS(NonGeoDataset):
         task: Literal['task1', 'task2'] = 'task1',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new IDTReeS dataset instance.
 

--- a/torchgeo/datasets/inria.py
+++ b/torchgeo/datasets/inria.py
@@ -69,7 +69,7 @@ class InriaAerialImageLabeling(NonGeoDataset):
         root: Path = 'data',
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new InriaAerialImageLabeling Dataset instance.
 

--- a/torchgeo/datasets/iobench.py
+++ b/torchgeo/datasets/iobench.py
@@ -59,7 +59,7 @@ class IOBench(IntersectionDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new IOBench instance.
 

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -143,7 +143,7 @@ class L7Irish(IntersectionDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new L7Irish instance.

--- a/torchgeo/datasets/l8biome.py
+++ b/torchgeo/datasets/l8biome.py
@@ -147,7 +147,7 @@ class L8Biome(IntersectionDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new L8Biome instance.

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -79,7 +79,7 @@ class LandCoverAIBase(Dataset[Sample], abc.ABC):
     )
 
     def __init__(
-        self, root: Path = 'data', download: bool = False, checksum: bool = False
+        self, root: Path = 'data', download: bool = False, checksum: bool = True
     ) -> None:
         """Initialize a new LandCover.ai dataset instance.
 
@@ -194,7 +194,7 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new LandCover.ai NonGeo dataset instance.
@@ -317,7 +317,7 @@ class LandCoverAI(LandCoverAIBase, NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new LandCover.ai dataset instance.
 

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -37,7 +37,7 @@ class LEVIRCDBase(NonGeoDataset, abc.ABC):
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new LEVIR-CD base dataset instance.
 

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -97,7 +97,7 @@ class LoveDA(NonGeoDataset):
         scene: Sequence[Literal['urban', 'rural']] = ['urban', 'rural'],
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new LoveDA dataset instance.
 

--- a/torchgeo/datasets/mapinwild.py
+++ b/torchgeo/datasets/mapinwild.py
@@ -119,7 +119,7 @@ class MapInWild(NonGeoDataset):
         split: Literal['train', 'validation', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new MapInWild dataset instance.
 

--- a/torchgeo/datasets/mdas.py
+++ b/torchgeo/datasets/mdas.py
@@ -143,7 +143,7 @@ class MDAS(NonGeoDataset):
         modalities: list[str] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new MDAS dataset instance.
 

--- a/torchgeo/datasets/millionaid.py
+++ b/torchgeo/datasets/millionaid.py
@@ -201,7 +201,7 @@ class MillionAID(NonGeoDataset):
         task: Literal['multi-class', 'multi-label'] = 'multi-class',
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new MillionAID dataset instance.
 

--- a/torchgeo/datasets/mmflood.py
+++ b/torchgeo/datasets/mmflood.py
@@ -134,7 +134,7 @@ class MMFlood(IntersectionDataset):
         include_hydro: bool = False,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         cache: bool = False,
         time_series: bool = False,
     ) -> None:

--- a/torchgeo/datasets/nccm.py
+++ b/torchgeo/datasets/nccm.py
@@ -87,7 +87,7 @@ class NCCM(RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new dataset.

--- a/torchgeo/datasets/nlcd.py
+++ b/torchgeo/datasets/nlcd.py
@@ -409,7 +409,7 @@ class NLCD(RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -211,7 +211,7 @@ class OpenBuildings(VectorDataset):
         crs: CRS | None = None,
         res: float | tuple[float, float] = 0.0001,
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
 

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -100,7 +100,7 @@ class OSCD(NonGeoDataset):
         bands: Sequence[str] = all_bands,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new OSCD dataset instance.
 

--- a/torchgeo/datasets/pastis.py
+++ b/torchgeo/datasets/pastis.py
@@ -161,7 +161,7 @@ class PASTIS(NonGeoDataset):
         mode: str = 'semantic',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new PASTIS dataset instance.
 

--- a/torchgeo/datasets/patternnet.py
+++ b/torchgeo/datasets/patternnet.py
@@ -87,7 +87,7 @@ class PatternNet(NonGeoClassificationDataset):
         root: Path = 'data',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new PatternNet dataset instance.
 

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -127,7 +127,7 @@ class Potsdam2D(NonGeoDataset):
         root: Path = 'data',
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Potsdam dataset instance.
 

--- a/torchgeo/datasets/quakeset.py
+++ b/torchgeo/datasets/quakeset.py
@@ -84,7 +84,7 @@ class QuakeSet(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new QuakeSet dataset instance.
 

--- a/torchgeo/datasets/reforestree.py
+++ b/torchgeo/datasets/reforestree.py
@@ -73,7 +73,7 @@ class ReforesTree(NonGeoDataset):
         root: Path = 'data',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new ReforesTree dataset instance.
 

--- a/torchgeo/datasets/resisc45.py
+++ b/torchgeo/datasets/resisc45.py
@@ -115,7 +115,7 @@ class RESISC45(NonGeoClassificationDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new RESISC45 dataset instance.
 

--- a/torchgeo/datasets/s2_100k.py
+++ b/torchgeo/datasets/s2_100k.py
@@ -55,7 +55,7 @@ class S2100k(NonGeoDataset):
         mode: Literal['both', 'points'] = 'both',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new S2100K dataset instance.
 

--- a/torchgeo/datasets/satlas.py
+++ b/torchgeo/datasets/satlas.py
@@ -542,7 +542,7 @@ class SatlasPretrain(NonGeoDataset):
         labels: Iterable[str] = ('land_cover',),
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SatlasPretrain instance.
 

--- a/torchgeo/datasets/seasonet.py
+++ b/torchgeo/datasets/seasonet.py
@@ -226,7 +226,7 @@ class SeasoNet(NonGeoDataset):
         concat_seasons: int = 1,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SeasoNet dataset instance.
 

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -78,7 +78,7 @@ class SeasonalContrastS2(NonGeoDataset):
         bands: Sequence[str] = rgb_bands,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SeasonalContrastS2 instance.
 

--- a/torchgeo/datasets/sen12ms.py
+++ b/torchgeo/datasets/sen12ms.py
@@ -170,7 +170,7 @@ class SEN12MS(NonGeoDataset):
         split: Literal['train', 'test'] = 'train',
         bands: Sequence[str] = BAND_SETS['all'],
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SEN12MS dataset instance.
 

--- a/torchgeo/datasets/skippd.py
+++ b/torchgeo/datasets/skippd.py
@@ -81,7 +81,7 @@ class SKIPPD(NonGeoDataset):
         task: Literal['nowcast', 'forecast'] = 'nowcast',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
 

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -81,7 +81,7 @@ class SkyScript(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         tokenizer: 'tokenizers.models.Model | None' = None,
     ) -> None:
         """Initialize a new SkyScript instance.

--- a/torchgeo/datasets/so2sat.py
+++ b/torchgeo/datasets/so2sat.py
@@ -199,7 +199,7 @@ class So2Sat(NonGeoDataset):
         split: Literal['train', 'validation', 'test'] = 'train',
         bands: Sequence[str] = BAND_SETS['all'],
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new So2Sat dataset instance.
 

--- a/torchgeo/datasets/soda.py
+++ b/torchgeo/datasets/soda.py
@@ -103,7 +103,7 @@ class SODAA(NonGeoDataset):
         bbox_orientation: Literal['oriented', 'horizontal'] = 'horizontal',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new instance of SODA-A dataset.
 

--- a/torchgeo/datasets/solar_plants_brazil.py
+++ b/torchgeo/datasets/solar_plants_brazil.py
@@ -62,7 +62,7 @@ class SolarPlantsBrazil(NonGeoDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a SolarPlantsBrazil dataset split.
 

--- a/torchgeo/datasets/south_america_soybean.py
+++ b/torchgeo/datasets/south_america_soybean.py
@@ -80,7 +80,7 @@ class SouthAmericaSoybean(RasterDataset):
         transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         time_series: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.

--- a/torchgeo/datasets/spacenet/base.py
+++ b/torchgeo/datasets/spacenet/base.py
@@ -112,7 +112,7 @@ class SpaceNet(NonGeoDataset, ABC):
         mask: str | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SpaceNet Dataset instance.
 

--- a/torchgeo/datasets/ssl4eo.py
+++ b/torchgeo/datasets/ssl4eo.py
@@ -205,7 +205,7 @@ class SSL4EOL(SSL4EO):
         seasons: Literal[1, 2, 3, 4] = 1,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SSL4EOL instance.
 
@@ -535,7 +535,7 @@ class SSL4EOS12(SSL4EO):
         seasons: Literal[1, 2, 3, 4] = 1,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SSL4EOS12 instance.
 

--- a/torchgeo/datasets/ssl4eo_benchmark.py
+++ b/torchgeo/datasets/ssl4eo_benchmark.py
@@ -120,7 +120,7 @@ class SSL4EOLBenchmark(NonGeoDataset):
         classes: list[int] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new SSL4EO Landsat Benchmark instance.
 

--- a/torchgeo/datasets/substation.py
+++ b/torchgeo/datasets/substation.py
@@ -69,7 +69,7 @@ class Substation(NonGeoDataset):
         | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize the Substation.
 

--- a/torchgeo/datasets/sustainbench_crop_yield.py
+++ b/torchgeo/datasets/sustainbench_crop_yield.py
@@ -63,7 +63,7 @@ class SustainBenchCropYield(NonGeoDataset):
         countries: list[Literal['usa', 'brazil', 'argentina']] | None = None,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
 

--- a/torchgeo/datasets/treesatai.py
+++ b/torchgeo/datasets/treesatai.py
@@ -130,7 +130,7 @@ class TreeSatAI(NonGeoDataset):
         sensors: Sequence[Literal['aerial', 's1', 's2']] = all_sensors,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new TreeSatAI instance.
 

--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -90,7 +90,7 @@ class UCMerced(NonGeoClassificationDataset):
         split: Literal['train', 'val', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new UC Merced dataset instance.
 

--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -96,7 +96,7 @@ class USAVars(NonGeoDataset):
         labels: Sequence[Literal['treecover', 'elevation', 'population']] = ALL_LABELS,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new USAVars dataset instance.
 

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -126,7 +126,7 @@ class Vaihingen2D(NonGeoDataset):
         root: Path = 'data',
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new Vaihingen2D dataset instance.
 

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -100,7 +100,7 @@ class VHR10(NonGeoDataset):
         split: Literal['positive', 'negative'] = 'positive',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new VHR-10 dataset instance.
 

--- a/torchgeo/datasets/xbd.py
+++ b/torchgeo/datasets/xbd.py
@@ -77,7 +77,7 @@ class xBD(NonGeoDataset):
         root: Path = 'data',
         split: Literal['train', 'test'] = 'train',
         transforms: Callable[[Sample], Sample] | None = None,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new xBD dataset instance.
 

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -68,7 +68,7 @@ class ZueriCrop(NonGeoDataset):
         bands: Sequence[str] = band_names,
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
     ) -> None:
         """Initialize a new ZueriCrop dataset instance.
 


### PR DESCRIPTION
### Summary

Changes all datasets to validate checksums by default.

### Rationale

Checksum verification adds security and reproducibility to our datasets. We should probably do this by default or even make it required (like torchvision).

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
