### PR TITLE
Add EVer to related libraries

### DIFF
--- a/docs/user/alternatives.rst
+++ b/docs/user/alternatives.rst
@@ -15,7 +15,7 @@ When deciding which library is most useful to you, it is worth considering the f
 
    Software is a living, breathing organism and is constantly undergoing change. If any of the below information is incorrect or out of date, or if you want to add a new project to this list, please open a PR!
 
-   *Last updated: November 2025*
+   *Last updated: July 2026*
 
 Features
 --------
@@ -126,3 +126,4 @@ These are download metrics for the project. Note that these numbers can be artif
 .. _AIDE: https://github.com/microsoft/aerial_wildlife_detection
 .. _rs-embed: https://github.com/cybergis/rs-embed
 .. _py4dgeo: https://github.com/3dgeo-heidelberg/py4dgeo
+.. _EVer: https://github.com/Z-Zheng/ever

--- a/docs/user/metrics/common.py
+++ b/docs/user/metrics/common.py
@@ -25,6 +25,7 @@ index = [
     'rs-embed',
     'GeoDeep',
     'torchange',
+    'EVer',
 ]
 
 # Sort by date of first commit (update_timeline.py)
@@ -53,6 +54,7 @@ name_to_github = {
     'TorchGeo': ('torchgeo', 'torchgeo'),
     'geo-bench': ('ServiceNow', 'geo-bench'),
     'torchrs': ('isaaccorley', 'torchrs'),
+    'EVer': ('Z-Zheng', 'ever'),
     'Myria3D': ('IGNF', 'myria3d'),
     'PaddleRS': ('PaddlePaddle', 'PaddleRS'),
     'GeoTorchAI': ('wherobots', 'GeoTorchAI'),
@@ -97,6 +99,7 @@ hardcoded_coverage = {
     'torchange': 0,
     'AIDE': 0,
     'rs-embed': 61,
+    'EVer': 0,
 }
 name_to_pypi = {
     'SPy': 'spectral',
@@ -117,6 +120,7 @@ name_to_pypi = {
     'torchange': 'torchange',
     'rs-embed': 'rs-embed',
     'py4dgeo': 'py4dgeo',
+    'EVer': 'ever-beta',
 }
 name_to_cran = {'SITS': 'sits'}
 name_to_conda = {
@@ -130,4 +134,5 @@ name_to_conda = {
     'GeoAI': 'geoai',
     'TerraTorch': 'terratorch',
     'torchange': 'torchange',
+    'EVer': 'ever-beta',
 }

--- a/docs/user/metrics/features.csv
+++ b/docs/user/metrics/features.csv
@@ -21,3 +21,4 @@ Library,ML Backend,I/O Backend,Spatial Backend,Transform Backend,Datasets,Weight
 `rs-embed`_,PyTorch,"Earth Engine, tifffile, xarray, pandas, pillow","pyproj, affine",-,0,19,✅,❌,❌,❌,✅
 `GeoDeep`_,ONNX,GDAL,-,-,0,7,✅,❌,✅,❌,❌
 `torchange`_,PyTorch,"Apache Arrow, skimage",-,Albumentations,8,8,❌,❌,❌,❌,✅
+`EVer`_,PyTorch,"pillow, tifffile",-,Albumentations,0,0,❌,❌,❌,❌,❌

--- a/docs/user/metrics/github.csv
+++ b/docs/user/metrics/github.csv
@@ -21,3 +21,4 @@ Library,Contributors,Forks,Watchers,Stars,Issues,PRs,Releases,Commits,Test Cover
 `rs-embed`_,5,16,1,140,9,84,4,563,61%,Apache-2.0
 `GeoDeep`_,4,53,12,485,2,4,13,106,0%,AGPL-3.0
 `torchange`_,2,21,6,256,9,16,5,194,0%,Apache-2.0
+`EVer`_,2,14,2,101,1,2,11,74,0%,Apache-2.0


### PR DESCRIPTION
﻿Closes #3327

Adds [EVer](https://github.com/Z-Zheng/ever) to the Related Libraries page, following the [contributing docs workflow](https://torchgeo.readthedocs.io/en/stable/user/contributing.html#related-libraries):

* `common.py`: EVer added to `index`, `name_to_github` (placed by first commit 2021-08-20, between torchrs and Myria3D), `hardcoded_coverage` (0 - repo has no test suite), `name_to_pypi`/`name_to_conda` (`ever-beta`)
* `github.csv`: regenerated with `update_github.py` (all rows refreshed and resorted)
* `features.csv`: EVer row added, rows resorted to match `github.csv`
* `alternatives.rst`: GitHub link added, "Last updated" note bumped

Feature analysis for the EVer row (from reading the source):

* ML backend: PyTorch only
* I/O backend: pillow, tifffile (`ever/preprocess/segm.py`, `ever/util/eda.py`); scikit-image is declared as a dependency but never imported
* Transform backend: Albumentations (`ever/preprocess/albu.py`)
* Datasets/Weights: 0/0 - it is a config-driven training framework (the base of FarSeg/ChangeStar/LoveDA projects); backbones load ImageNet weights, and the DINOv3 SAT-493M variants require user-supplied checkpoints
* No CLI entry point, GUI, reprojection, STAC, or time-series support

Not done: `downloads.csv` - `update_downloads.py` requires a pepy.tech API key I don't have. Happy to update if a maintainer can run it, or I can request a key.

Criteria check: 101 stars, 11 releases (PyPI + conda-forge), last commit 2026-01-28, Apache-2.0.
