### PR TITLE
Correct type annotations found by pyrefly

### DIFF
--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -161,8 +161,8 @@ def test_get_model_weights(builder: Callable[..., nn.Module]) -> None:
 
 
 @pytest.mark.parametrize('enum', enums)
-def test_get_weight(enum: WeightsEnum) -> None:
-    for weight in enum:  # ty: ignore[not-iterable]
+def test_get_weight(enum: type[WeightsEnum]) -> None:
+    for weight in enum:
         assert weight == get_weight(str(weight))
 
 

--- a/torchgeo/datasets/dlrsd.py
+++ b/torchgeo/datasets/dlrsd.py
@@ -75,6 +75,8 @@ class DLRSDBase(NonGeoDataset):
 
     directory = 'DLRSD'
 
+    image_fns: list[str]
+
     classes = (
         'airplane',
         'bare soil',

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -19,6 +19,7 @@ import torch
 from geopandas import GeoDataFrame
 from matplotlib.figure import Figure
 from pyproj import CRS
+from shapely.geometry.base import BaseGeometry
 
 from .errors import DatasetNotFoundError
 from .geo import VectorDataset
@@ -324,7 +325,7 @@ class OpenBuildings(VectorDataset):
 
     def _filter_geometries(
         self, index: GeoSlice, filepaths: list[str]
-    ) -> list[dict[str, Any]]:
+    ) -> list[BaseGeometry]:
         """Filters a df read from the polygon csv file based on index and conf thresh.
 
         Args:

--- a/torchgeo/datasets/treesatai.py
+++ b/torchgeo/datasets/treesatai.py
@@ -290,7 +290,7 @@ class TreeSatAI(NonGeoDataset):
         labels: list[tuple[str, float]] = []
         for i, pct in enumerate(multilabel):
             if pct > 0.001:
-                labels.append((self.classes[i], pct))
+                labels.append((self.classes[i], pct.item()))
 
         labels.sort(key=lambda label: label[1], reverse=True)
         return ', '.join([f'{genus}: {pct:.1%}' for genus, pct in labels])

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -561,7 +561,7 @@ def _list_dict_to_dict_list(samples: Iterable[Sample]) -> dict[str, list[Any]]:
 
     .. versionadded:: 0.2
     """
-    collated = {}
+    collated: dict[str, list[Any]] = {}
     for sample in samples:
         for key, value in sample.items():
             if key not in collated:
@@ -658,7 +658,7 @@ def stack_samples(samples: Iterable[Sample]) -> Sample:
     .. versionadded:: 0.2
     """
     uncollated = _list_dict_to_dict_list(samples)
-    collated = {}
+    collated: Sample = {}
     for key, value in uncollated.items():
         if isinstance(value[0], Tensor):
             collated[key] = torch.stack(value)
@@ -738,7 +738,7 @@ def unbind_samples(sample: Sample) -> list[Sample]:
     return _dict_list_to_list_dict(uncollated)
 
 
-def rasterio_loader(path: Path) -> np.typing.NDArray[np.int_]:
+def rasterio_loader(path: Path) -> np.typing.NDArray[np.int32]:
     """Load an image file using rasterio.
 
     Args:
@@ -748,7 +748,7 @@ def rasterio_loader(path: Path) -> np.typing.NDArray[np.int_]:
         the image
     """
     with rasterio.open(path) as f:
-        array: np.typing.NDArray[np.int_] = f.read().astype(np.int32)
+        array: np.typing.NDArray[np.int32] = f.read().astype(np.int32)
         # NonGeoClassificationDataset expects images returned with channels last (HWC)
         array = array.transpose(1, 2, 0)
     return array

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -103,9 +103,7 @@ _model: dict[str, Callable[..., nn.Module]] = {
     'vit_small_patch14_dinov2': vit_small_patch14_dinov2,
 }
 
-_model_weights: dict[
-    str | Callable[..., nn.Module], WeightsEnum
-] = {  # ty :ignore[invalid-assignment]
+_model_weights: dict[str | Callable[..., nn.Module], type[WeightsEnum]] = {
     aurora_swin_unet: Aurora_Weights,
     copernicusfm_base: CopernicusFM_Base_Weights,
     croma_base: CROMABase_Weights,
@@ -182,7 +180,7 @@ def get_model(name: str, *args: Any, **kwargs: Any) -> nn.Module:
     return model
 
 
-def get_model_weights(name: Callable[..., nn.Module] | str) -> WeightsEnum:
+def get_model_weights(name: Callable[..., nn.Module] | str) -> type[WeightsEnum]:
     """Get the weights enum class associated with a given model.
 
     .. versionadded:: 0.4
@@ -212,7 +210,7 @@ def get_weight(name: str) -> WeightsEnum:
     """
     for weight_name, weight_enum in _model_weights.items():
         if isinstance(weight_name, str):
-            for sub_weight_enum in weight_enum:  # ty: ignore[not-iterable]
+            for sub_weight_enum in weight_enum:
                 if name == str(sub_weight_enum):
                     return sub_weight_enum
 

--- a/torchgeo/samplers/base.py
+++ b/torchgeo/samplers/base.py
@@ -351,7 +351,8 @@ class SpatioTemporalSampler(GeoSampler):
                 t = np.array([tmin, tmax])
                 verts.extend(prism(x, y, t))
             poly = Poly3DCollection(verts, color='tab:blue', alpha=0.3)
-            return ax.add_collection3d(poly)
+            ax.add_collection3d(poly)
+            return (poly,)
 
         def func(index: tuple[slice, slice, slice]) -> Iterable[Artist]:
             """Plot the dynamic samples."""
@@ -376,6 +377,7 @@ class SpatioTemporalSampler(GeoSampler):
             t = np.array([index[2].start.timestamp(), index[2].stop.timestamp()])
             verts = prism(x, y, t)
             poly = Poly3DCollection(verts, color='tab:orange', alpha=0.3)
-            return ax.add_collection3d(poly)
+            ax.add_collection3d(poly)
+            return (poly,)
 
         return FuncAnimation(fig, func=func, frames=self, init_func=init_func)

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -4,8 +4,7 @@
 """TorchGeo samplers."""
 
 import abc
-from collections.abc import Callable, Iterable, Iterator
-from functools import partial
+from collections.abc import Iterator
 
 import numpy as np
 import pandas as pd
@@ -363,11 +362,12 @@ class PreChippedGeoSampler(GeoSampler):
         Yields:
             [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
-        generator: Callable[[int], Iterable[int]] = range
         if self.shuffle:
-            generator = partial(torch.randperm, generator=self.generator)
+            indices = torch.randperm(len(self), generator=self.generator)
+        else:
+            indices = range(len(self))
 
-        for idx in generator(len(self)):
+        for idx in indices:
             i = int(idx)
             xmin, ymin, xmax, ymax = self.index.geometry.iloc[i].bounds
             tmin, tmax = self.index.index[i].left, self.index.index[i].right


### PR DESCRIPTION
## Summary

Annotation-only cleanups found by [pyrefly](https://pyrefly.org/)

### Wrong types

* **`get_model_weights` returns `type[WeightsEnum]`, not `WeightsEnum`.** The values of `_model_weights` are enum *classes* (`Aurora_Weights`, etc.), not members — which is why `get_weight` has to iterate them. The docstring already said "the weights enum class". This drops two suppressions, one of which (`# ty :ignore[invalid-assignment]`) was inert anyway thanks to a typo — a space before `:ignore`.
* **`OpenBuildings._filter_geometries` returns `list[BaseGeometry]`.** It builds its result from `gdf.geometry.tolist()`, so `list[dict[str, Any]]` was never right.
* **`rasterio_loader` returns `NDArray[np.int32]`.** The body does `.astype(np.int32)`; `np.int_` is int64 on Linux and macOS.
* **`TreeSatAI._multilabel_to_string`** collects into `list[tuple[str, float]]` but was appending 0-d tensors — now calls `.item()`.

### Matplotlib compatibility

`SpatioTemporalSampler`'s animation callbacks are annotated `-> Iterable[Artist]` but returned `ax.add_collection3d(poly)` directly. That only started returning the collection in **matplotlib 3.10**; torchgeo supports `>=3.7.3`, where it returns `None`. Harmless today because `FuncAnimation` is constructed with the default `blit=False` and discards the value, but the annotation was wrong on most supported versions. Now calls `add_collection3d` and returns `(poly,)`, which is correct everywhere.

### Untypeable indirection

`PreChippedGeoSampler.__iter__` routed through a `Callable[[int], Iterable[int]]` alias assigned either `range` or `partial(torch.randperm, ...)` — no single signature describes both. Building the index sequence directly in the branch is equivalent and drops the `functools.partial` import.

### Missing declarations

`DLRSDBase` declares `image_fns`, and `_list_dict_to_dict_list` / `stack_samples` annotate their accumulator dicts.

### Checklist

- [X] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [X] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [X] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
