### PR TITLE
Fix rasterio typing errors

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -14,9 +14,10 @@ import pandas as pd
 import pytest
 import rasterio
 import torch
+from affine import Affine
 from numpy.typing import NDArray
 from pytest import MonkeyPatch
-from rasterio import Affine, MemoryFile
+from rasterio import MemoryFile
 from rasterio.transform import from_origin
 from rasterio.vrt import WarpedVRT
 from shapely import MultiPolygon, Polygon, box
@@ -774,7 +775,7 @@ def test_get_valid_footprint_all_nodata_warns() -> None:
             nodata=0,
         ) as dataset:
             dataset.write(np.zeros((1, 4, 4), dtype=np.uint8))
-        with memfile.open() as dataset:
+        with rasterio.open(memfile.name) as dataset:
             with pytest.warns(UserWarning, match='All pixels are nodata'):
                 footprint = get_valid_footprint_from_datasource(dataset)
             assert footprint.is_empty


### PR DESCRIPTION
## Summary

- import `Affine` from its canonical package so `ty` recognizes it as callable
- reopen the in-memory raster with `rasterio.open` so its read-only type is explicit

### Checklist

- [X] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [X] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [X] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
