### PR TITLE
CD: switch to uv

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,16 +15,12 @@ jobs:
         with:
           python-version: '3.14'
           activate-environment: true
-      - name: Install dependencies
-        run: uv pip install build
-      - name: List dependencies
-        run: uv tree
       - name: Build project
-        run: python -m build
+        run: uv build
       - name: Upload artifacts
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: pypi-dist
+          name: dist
           path: dist/
   pypi:
     name: pypi
@@ -37,10 +33,15 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          python-version: '3.14'
+          activate-environment: true
       - name: Download artifacts
         uses: actions/download-artifact@v8.0.1
         with:
-          name: pypi-dist
+          name: dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.1
+        run: uv publish


### PR DESCRIPTION
### Summary

Converts our continuous deployment workflow from build to uv.

### Rationale

Allows us to remove a dependency on `pypa/gh-action-pypi-publish` and puts this workflow in line with the rest of the project that uses uv.

Instructions were recently updated in https://github.com/astral-sh/uv/pull/20946 to separate the build and publish steps for security.

Closes #2905

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
