### PR TITLE
docs: clarify DOFA Sentinel-1 wavelength convention

### DIFF
--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -328,10 +328,9 @@ class DOFA(nn.Module):
         Args:
             x: Input mini-batch.
             wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1
-                VV/VH, the DOFA v1 weights currently provided by TorchGeo use
+                VV/VH, the DOFA v1 weights use
                 ``[3.75, 3.75]`` as modality placeholders rather than physical
-                wavelengths. DOFA v2 instead uses ``[5.405, 5.405]``; its weights
-                are not currently provided by TorchGeo.    
+                wavelengths.
 
         Returns:
             Output mini-batch.
@@ -380,11 +379,10 @@ class DOFA(nn.Module):
         Args:
             x: Input mini-batch.
             wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1
-                VV/VH, the DOFA v1 weights currently provided by TorchGeo use
+                VV/VH, the DOFA v1 weights use
                 ``[3.75, 3.75]`` as modality placeholders rather than physical
-                wavelengths. DOFA v2 instead uses ``[5.405, 5.405]``; its weights
-                are not currently provided by TorchGeo.
-        
+                wavelengths.
+
         Returns:
             Output mini-batch.
         """

--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -327,7 +327,11 @@ class DOFA(nn.Module):
 
         Args:
             x: Input mini-batch.
-            wavelengths: Wavelengths of each spectral band (μm).
+            wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1
+                VV/VH, the DOFA v1 weights currently provided by TorchGeo use
+                ``[3.75, 3.75]`` as modality placeholders rather than physical
+                wavelengths. DOFA v2 instead uses ``[5.405, 5.405]``; its weights
+                are not currently provided by TorchGeo.    
 
         Returns:
             Output mini-batch.
@@ -375,8 +379,12 @@ class DOFA(nn.Module):
 
         Args:
             x: Input mini-batch.
-            wavelengths: Wavelengths of each spectral band (μm).
-
+            wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1
+                VV/VH, the DOFA v1 weights currently provided by TorchGeo use
+                ``[3.75, 3.75]`` as modality placeholders rather than physical
+                wavelengths. DOFA v2 instead uses ``[5.405, 5.405]``; its weights
+                are not currently provided by TorchGeo.
+        
         Returns:
             Output mini-batch.
         """

--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -327,10 +327,9 @@ class DOFA(nn.Module):
 
         Args:
             x: Input mini-batch.
-            wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1
-                VV/VH, the DOFA v1 weights use
-                ``[3.75, 3.75]`` as modality placeholders rather than physical
-                wavelengths.
+            wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1 VV/VH,
+                the DOFA v1 weights use ``[3.75, 3.75]`` as modality placeholders
+                rather than physical wavelengths.
 
         Returns:
             Output mini-batch.
@@ -378,10 +377,9 @@ class DOFA(nn.Module):
 
         Args:
             x: Input mini-batch.
-            wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1
-                VV/VH, the DOFA v1 weights use
-                ``[3.75, 3.75]`` as modality placeholders rather than physical
-                wavelengths.
+            wavelengths: Wavelengths of each spectral band (μm). For Sentinel-1 VV/VH,
+                the DOFA v1 weights use ``[3.75, 3.75]`` as modality placeholders
+                rather than physical wavelengths.
 
         Returns:
             Output mini-batch.


### PR DESCRIPTION
### Summary

Updates the `wavelengths` parameter descriptions in `DOFA.forward()` and `DOFA.forward_features()` to document the Sentinel-1 input conventions for DOFA v1 and v2. The current TorchGeo weights use the DOFA v1 convention, `[3.75, 3.75]`, while DOFA v2 uses `[5.405, 5.405]`.

### Rationale

The previous descriptions state that `wavelengths` contains spectral band wavelengths in micrometers. However, for Sentinel-1, these inputs are modality placeholders rather than physical wavelengths. The Sentinel-1 C-SAR instrument has a center frequency of 5.405 GHz, corresponding to a physical wavelength of approximately 5.55 cm (55,500 μm), so the previous wording could be misleading.

Reference: [Sentinel-1 Mission](https://sentiwiki.copernicus.eu/web/s1-mission)

Closes #3931

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution