### PR TITLE
Fix BYOL trainer

### DIFF
--- a/tests/tasks/test_byol.py
+++ b/tests/tasks/test_byol.py
@@ -35,27 +35,6 @@ class TestBYOLModule:
         augment_fn = SimCLRAugmentation((2, 2))
         BYOLModule(model, augment_fn=augment_fn)
 
-    def test_target_network_is_independent(self) -> None:
-        module = BYOLModule(resnet18(), image_size=(64, 64), in_channels=3)
-        backbone_params = dict(module.backbone.named_parameters())
-        target_params = dict(module.target.named_parameters())
-        assert backbone_params.keys() == target_params.keys()
-        for name, param in backbone_params.items():
-            assert param is not target_params[name]
-            assert torch.equal(param, target_params[name])
-            assert not target_params[name].requires_grad
-
-    def test_update_target(self) -> None:
-        module = BYOLModule(resnet18(), image_size=(64, 64), in_channels=3, beta=0.9)
-        with torch.no_grad():
-            for param in module.backbone.parameters():
-                param.add_(1)
-        module.update_target()
-        for p, pt in zip(
-            module.backbone.parameters(), module.target.parameters(), strict=True
-        ):
-            assert torch.allclose(pt, p - 0.9, atol=1e-6)
-
 
 class TestBYOL:
     @pytest.mark.parametrize(

--- a/tests/tasks/test_byol.py
+++ b/tests/tasks/test_byol.py
@@ -35,6 +35,27 @@ class TestBYOLModule:
         augment_fn = SimCLRAugmentation((2, 2))
         BYOLModule(model, augment_fn=augment_fn)
 
+    def test_target_network_is_independent(self) -> None:
+        module = BYOLModule(resnet18(), image_size=(64, 64), in_channels=3)
+        backbone_params = dict(module.backbone.named_parameters())
+        target_params = dict(module.target.named_parameters())
+        assert backbone_params.keys() == target_params.keys()
+        for name, param in backbone_params.items():
+            assert param is not target_params[name]
+            assert torch.equal(param, target_params[name])
+            assert not target_params[name].requires_grad
+
+    def test_update_target(self) -> None:
+        module = BYOLModule(resnet18(), image_size=(64, 64), in_channels=3, beta=0.9)
+        with torch.no_grad():
+            for param in module.backbone.parameters():
+                param.add_(1)
+        module.update_target()
+        for p, pt in zip(
+            module.backbone.parameters(), module.target.parameters(), strict=True
+        ):
+            assert torch.allclose(pt, p - 0.9, atol=1e-6)
+
 
 class TestBYOL:
     @pytest.mark.parametrize(

--- a/torchgeo/tasks/byol.py
+++ b/torchgeo/tasks/byol.py
@@ -3,6 +3,7 @@
 
 """BYOL task for self-supervised learning (SSL)."""
 
+import copy
 import os
 from typing import Any
 
@@ -252,16 +253,28 @@ class BYOLModule(nn.Module):
 
         self.beta = beta
         self.in_channels = in_channels
+        # The target network must be a copy of the online network, otherwise both
+        # networks share the same weights and the momentum update is a no-op. The
+        # copy is made before any hooks are registered on the online network.
+        target_model = copy.deepcopy(model)
         self.backbone = BackboneWrapper(
             model, projection_size, hidden_size, layer=hidden_layer
         )
         self.predictor = MLP(projection_size, projection_size, hidden_size)
         self.target = BackboneWrapper(
-            model, projection_size, hidden_size, layer=hidden_layer
+            target_model, projection_size, hidden_size, layer=hidden_layer
         )
 
-        # Perform a single forward pass to initialize the wrapper correctly
+        # Perform a single forward pass to initialize the wrappers correctly
         self.backbone(torch.zeros(2, self.in_channels, *image_size))
+        with torch.no_grad():
+            self.target(torch.zeros(2, self.in_channels, *image_size))
+
+        # Initialize the target network with the same weights as the online network.
+        # The target network is only ever updated via the momentum update.
+        self.target.load_state_dict(self.backbone.state_dict())
+        for param in self.target.parameters():
+            param.requires_grad = False
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the backbone model through the MLP and prediction head.
@@ -277,7 +290,9 @@ class BYOLModule(nn.Module):
 
     def update_target(self) -> None:
         """Method to update the "target" model weights."""
-        for p, pt in zip(self.backbone.parameters(), self.target.parameters()):
+        for p, pt in zip(
+            self.backbone.parameters(), self.target.parameters(), strict=True
+        ):
             pt.data = self.beta * pt.data + (1 - self.beta) * p.data
 
 
@@ -333,7 +348,10 @@ class BYOL(BaseTask):
 
         # Create backbone
         backbone = timm.create_model(
-            self.hparams['model'], in_chans=in_channels, pretrained=weights is True
+            self.hparams['model'],
+            in_chans=in_channels,
+            num_classes=0,
+            pretrained=weights is True,
         )
 
         # Load weights


### PR DESCRIPTION
Fixing two bugs in the BYOL trainer:
- We used to use the same model instance for both the target and the backbone. This is not how BYOL is suppossed to work.
- We used to create the backbone model without `num_classes=0`. By default this creates an 1000-class fc head that is never used or updated. (**Edit:** fun fact, with a resnet50 sized feature representation this adds 2M extra parameters 🥲)

Note that any BYOL checkpoints written before this change will contain `fc.*` keys (and target weights identical to online weights). This will give you unexpected `fc.*` keys under strict loading.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
