### PR TITLE
Only require ChesapeakeCVPR subdatasets used by the requested layers

### DIFF
--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -184,8 +184,6 @@ class TestChesapeakeCVPR:
             ChesapeakeCVPR(tmp_path)
 
     def test_base_only_without_prior_extension(self, tmp_path: Path) -> None:
-        # Regression test: the prior extension is a separate archive, so a
-        # complete base install must work when no prior layer is requested.
         shutil.copy(
             os.path.join(
                 'tests', 'data', 'chesapeake', 'cvpr', 'cvpr_chesapeake_landcover.zip'
@@ -195,8 +193,6 @@ class TestChesapeakeCVPR:
         ChesapeakeCVPR(tmp_path, splits=['de-test'], layers=['naip-new', 'lc'])
 
     def test_prior_extension_missing(self, tmp_path: Path) -> None:
-        # Requesting a prior layer without the prior extension archive should
-        # still raise, rather than silently failing later.
         shutil.copy(
             os.path.join(
                 'tests', 'data', 'chesapeake', 'cvpr', 'cvpr_chesapeake_landcover.zip'

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -120,7 +120,15 @@ class TestChesapeakeCVPR:
         monkeypatch.setattr(
             ChesapeakeCVPR,
             '_files',
-            ['de_1m_2013_extended-debuffered-test_tiles', 'spatial_index.geojson'],
+            {
+                'base': (
+                    'de_1m_2013_extended-debuffered-test_tiles',
+                    'spatial_index.geojson',
+                ),
+                'prior_extension': (
+                    'de_1m_2013_extended-debuffered-test_tiles/m_3807504_ne_18_1_prior_from_cooccurrences_101_31_no_osm_no_buildings.tif',
+                ),
+            },
         )
         root = tmp_path
         transforms = nn.Identity()
@@ -174,6 +182,33 @@ class TestChesapeakeCVPR:
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             ChesapeakeCVPR(tmp_path)
+
+    def test_base_only_without_prior_extension(self, tmp_path: Path) -> None:
+        # Regression test: the prior extension is a separate archive, so a
+        # complete base install must work when no prior layer is requested.
+        shutil.copy(
+            os.path.join(
+                'tests', 'data', 'chesapeake', 'cvpr', 'cvpr_chesapeake_landcover.zip'
+            ),
+            tmp_path,
+        )
+        ChesapeakeCVPR(tmp_path, splits=['de-test'], layers=['naip-new', 'lc'])
+
+    def test_prior_extension_missing(self, tmp_path: Path) -> None:
+        # Requesting a prior layer without the prior extension archive should
+        # still raise, rather than silently failing later.
+        shutil.copy(
+            os.path.join(
+                'tests', 'data', 'chesapeake', 'cvpr', 'cvpr_chesapeake_landcover.zip'
+            ),
+            tmp_path,
+        )
+        with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
+            ChesapeakeCVPR(
+                tmp_path,
+                splits=['de-test'],
+                layers=['naip-new', ChesapeakeCVPR.prior_layer],
+            )
 
     def test_out_of_bounds_index(self, dataset: ChesapeakeCVPR) -> None:
         with pytest.raises(

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -500,36 +500,43 @@ class ChesapeakeCVPR(GeoDataset):
         + [f'{state}-test' for state in states]
     )
 
-    # these are used to check the integrity of the dataset
-    _files = (
-        'de_1m_2013_extended-debuffered-test_tiles',
-        'de_1m_2013_extended-debuffered-train_tiles',
-        'de_1m_2013_extended-debuffered-val_tiles',
-        'md_1m_2013_extended-debuffered-test_tiles',
-        'md_1m_2013_extended-debuffered-train_tiles',
-        'md_1m_2013_extended-debuffered-val_tiles',
-        'ny_1m_2013_extended-debuffered-test_tiles',
-        'ny_1m_2013_extended-debuffered-train_tiles',
-        'ny_1m_2013_extended-debuffered-val_tiles',
-        'pa_1m_2013_extended-debuffered-test_tiles',
-        'pa_1m_2013_extended-debuffered-train_tiles',
-        'pa_1m_2013_extended-debuffered-val_tiles',
-        'va_1m_2014_extended-debuffered-test_tiles',
-        'va_1m_2014_extended-debuffered-train_tiles',
-        'va_1m_2014_extended-debuffered-val_tiles',
-        'wv_1m_2014_extended-debuffered-test_tiles',
-        'wv_1m_2014_extended-debuffered-train_tiles',
-        'wv_1m_2014_extended-debuffered-val_tiles',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_buildings.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_landsat-leaf-off.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_landsat-leaf-on.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_lc.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_naip-new.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_naip-old.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_nlcd.tif',
-        'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_prior_from_cooccurrences_101_31_no_osm_no_buildings.tif',
-        'spatial_index.geojson',
-    )
+    # the layer that is only distributed in the prior extension archive
+    prior_layer = 'prior_from_cooccurrences_101_31_no_osm_no_buildings'
+
+    # these are used to check the integrity of each subdataset
+    _files: ClassVar[dict[str, tuple[str, ...]]] = {
+        'base': (
+            'de_1m_2013_extended-debuffered-test_tiles',
+            'de_1m_2013_extended-debuffered-train_tiles',
+            'de_1m_2013_extended-debuffered-val_tiles',
+            'md_1m_2013_extended-debuffered-test_tiles',
+            'md_1m_2013_extended-debuffered-train_tiles',
+            'md_1m_2013_extended-debuffered-val_tiles',
+            'ny_1m_2013_extended-debuffered-test_tiles',
+            'ny_1m_2013_extended-debuffered-train_tiles',
+            'ny_1m_2013_extended-debuffered-val_tiles',
+            'pa_1m_2013_extended-debuffered-test_tiles',
+            'pa_1m_2013_extended-debuffered-train_tiles',
+            'pa_1m_2013_extended-debuffered-val_tiles',
+            'va_1m_2014_extended-debuffered-test_tiles',
+            'va_1m_2014_extended-debuffered-train_tiles',
+            'va_1m_2014_extended-debuffered-val_tiles',
+            'wv_1m_2014_extended-debuffered-test_tiles',
+            'wv_1m_2014_extended-debuffered-train_tiles',
+            'wv_1m_2014_extended-debuffered-val_tiles',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_buildings.tif',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_landsat-leaf-off.tif',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_landsat-leaf-on.tif',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_lc.tif',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_naip-new.tif',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_naip-old.tif',
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_nlcd.tif',
+            'spatial_index.geojson',
+        ),
+        'prior_extension': (
+            'wv_1m_2014_extended-debuffered-val_tiles/m_3708035_ne_17_1_prior_from_cooccurrences_101_31_no_osm_no_buildings.tif',
+        ),
+    }
 
     p_src_crs = pyproj.CRS('epsg:3857')
     p_transformers: ClassVar[dict[str, pyproj.Transformer]] = {
@@ -570,6 +577,11 @@ class ChesapeakeCVPR(GeoDataset):
         Raises:
             AssertionError: if ``splits`` or ``layers`` are not valid
             DatasetNotFoundError: If dataset is not found and *download* is False.
+
+        .. versionchanged:: 0.10
+           Only the subdatasets required by *layers* are verified and downloaded.
+           The prior extension archive is no longer needed unless
+           ``"prior_from_cooccurrences_101_31_no_osm_no_buildings"`` is requested.
         """
         for split in splits:
             assert split in self.splits
@@ -580,6 +592,12 @@ class ChesapeakeCVPR(GeoDataset):
         self.cache = cache
         self.download = download
         self.checksum = checksum
+
+        # The prior extension ships as a separate archive, so only require it
+        # when one of its layers is actually requested.
+        self.subdatasets: tuple[str, ...] = ('base',)
+        if self.prior_layer in layers:
+            self.subdatasets += ('prior_extension',)
 
         self._verify()
 
@@ -696,7 +714,11 @@ class ChesapeakeCVPR(GeoDataset):
             return os.path.exists(os.path.join(self.root, filename))
 
         # Check if the extracted files already exist
-        if all(map(exists, self._files)):
+        if all(
+            exists(filename)
+            for subdataset in self.subdatasets
+            for filename in self._files[subdataset]
+        ):
             return
 
         # Check if the zip files have already been downloaded

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -593,11 +593,10 @@ class ChesapeakeCVPR(GeoDataset):
         self.download = download
         self.checksum = checksum
 
-        # The prior extension ships as a separate archive, so only require it
-        # when one of its layers is actually requested.
-        self.subdatasets: tuple[str, ...] = ('base',)
         if self.prior_layer in layers:
-            self.subdatasets += ('prior_extension',)
+            self.subdatasets = ('base', 'prior_extension')
+        else:
+            self.subdatasets = ('base',)
 
         self._verify()
 

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -434,7 +434,7 @@ class ChesapeakeCVPR(GeoDataset):
     * https://doi.org/10.1109/cvpr.2019.01301
     """
 
-    subdatasets = ('base', 'prior_extension')
+    subdatasets: tuple[str, ...] = ('base', 'prior_extension')
     urls: ClassVar[dict[str, str]] = {
         'base': 'https://lilawildlife.blob.core.windows.net/lila-wildlife/lcmcvpr2019/cvpr_chesapeake_landcover.zip',
         'prior_extension': 'https://zenodo.org/records/5866525/files/cvpr_chesapeake_landcover_prior_extension.zip?download=1',


### PR DESCRIPTION
ChesapeakeCVPR is distributed as the base dataset and a prior extension. Previously, our verify method would fail, even if you didn't want the layers from the prior dataset, unless you had both base and prior downloaded. Now it doesn't do that.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
