### PR TITLE
CopernicusPretrain: ensure torch.load(weights_only=True)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,8 @@ datasets = [
     # tokenizers 0.14+ required for Python 3.12 wheels
     # tokenizers does not yet provide wheels for Python 3.14t
     "tokenizers>=0.14; python_version<'3.14'",
-    # webdataset 0.2.4+ required for PyTorch tuple seed support
-    "webdataset>=0.2.4",
+    # webdataset 0.2.101+ required for security hardening
+    "webdataset>=0.2.101",
     # xarray 0.17+ required by rioxarray
     "xarray>=0.17",
 ]

--- a/torchgeo/datasets/copernicus/pretrain.py
+++ b/torchgeo/datasets/copernicus/pretrain.py
@@ -3,6 +3,7 @@
 
 """Copernicus-Pretrain dataset."""
 
+import os
 import random
 from collections.abc import Iterator
 from typing import Any, ClassVar
@@ -99,6 +100,9 @@ class CopernicusPretrain(IterableDataset[Sample]):
             *args: Arguments passed to WebDataset base class.
             **kwargs: Keyword arguments passed to WebDataset base class.
         """
+        # https://github.com/torchgeo/torchgeo/security/advisories/GHSA-6gm9-8jxc-p862
+        os.environ['WDS_PYTORCH_WEIGHTS_ONLY'] = '1'
+
         wds = lazy_import('webdataset')
 
         self.dataset = (

--- a/uv.lock
+++ b/uv.lock
@@ -3880,7 +3880,7 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'style'", specifier = ">=2.25" },
     { name = "types-shapely", marker = "extra == 'style'", specifier = ">=2.0.2" },
     { name = "typing-extensions", specifier = ">=4.8" },
-    { name = "webdataset", marker = "extra == 'datasets'", specifier = ">=0.2.4" },
+    { name = "webdataset", marker = "extra == 'datasets'", specifier = ">=0.2.101" },
     { name = "xarray", marker = "extra == 'datasets'", specifier = ">=0.17" },
 ]
 provides-extras = ["datasets", "docs", "models", "style", "tests", "all"]


### PR DESCRIPTION
### Summary

Set environment variable to force WebDataset to use `weights_only=True` with `torch.load`.

### Rationale

Prevents arbitrary code execution.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
