### PR TITLE
Remove webdataset dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,6 @@ datasets = [
     # tokenizers 0.14+ required for Python 3.12 wheels
     # tokenizers does not yet provide wheels for Python 3.14t
     "tokenizers>=0.14; python_version<'3.14'",
-    # webdataset 0.2.4+ required for PyTorch tuple seed support
-    "webdataset>=0.2.4",
     # xarray 0.17+ required by rioxarray
     "xarray>=0.17",
 ]

--- a/tests/datasets/test_copernicus.py
+++ b/tests/datasets/test_copernicus.py
@@ -1,13 +1,18 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
+import io
 import os
 import shutil
+import tarfile
 from pathlib import Path
+from typing import NamedTuple
 
 import pandas as pd
 import pytest
+import requests
 import torch
+import torch.utils.data
 from _pytest.fixtures import SubRequest
 from matplotlib import pyplot as plt
 from pytest import MonkeyPatch
@@ -127,17 +132,44 @@ class TestCopernicusBench:
             dataset.plot(dataset[0])
 
 
+def create_shard(path: Path, keys: list[str], fields: list[str] | None = None) -> None:
+    if fields is None:
+        fields = [
+            's1_grd',
+            's2_toa',
+            's3_olci',
+            's5p_co',
+            's5p_no2',
+            's5p_o3',
+            's5p_so2',
+            'dem',
+        ]
+    with tarfile.open(path, 'w') as tar:
+        for key in keys:
+            for field in fields:
+                buffer = io.BytesIO()
+                torch.save(torch.rand(2, 2, 2), buffer)
+                data = buffer.getvalue()
+                info = tarfile.TarInfo(f'{key}.{field}.pth')
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+
+class WorkerInfo(NamedTuple):
+    id: int
+    num_workers: int
+
+
 class TestCopernicusPretrain:
     @pytest.fixture
-    def dataset(self) -> CopernicusPretrain:
-        pytest.importorskip('webdataset')
-
+    def urls(self) -> str:
         root = os.path.join('tests', 'data', 'copernicus', 'pretrain')
-        shards = 'example-000000.tar'
-        # WebDataset requires forward slash for paths, even on Windows
-        urls = os.path.join(root, shards).replace('\\', '/')
-        dataset = CopernicusPretrain(urls, shardshuffle=False)
-        return dataset
+        shards = 'example-{000000..000000}.tar'
+        return os.path.join(root, shards)
+
+    @pytest.fixture
+    def dataset(self, urls: str) -> CopernicusPretrain:
+        return CopernicusPretrain(urls, shardshuffle=False)
 
     def test_getitem(self, dataset: CopernicusPretrain) -> None:
         x = next(iter(dataset))
@@ -164,6 +196,61 @@ class TestCopernicusPretrain:
         x = next(iter(dataset))
         dataset.plot(x, suptitle='Test')
         plt.close()
+
+    def test_expand_urls(self, urls: str) -> None:
+        assert len(CopernicusPretrain('example-{000000..000009}.tar').urls) == 10
+        assert CopernicusPretrain('example-000000.tar').urls == ['example-000000.tar']
+        assert len(CopernicusPretrain([urls, urls]).urls) == 2
+
+    def test_shardshuffle(self, urls: str) -> None:
+        dataset = CopernicusPretrain(urls, shardshuffle=True)
+        assert len(list(dataset)) == 1
+
+    def test_resampled(self, urls: str) -> None:
+        dataset = CopernicusPretrain(urls, resampled=True)
+        it = iter(dataset)
+        for _ in range(2):
+            assert isinstance(next(it)['s1_grd.pth'], torch.Tensor)
+
+    def test_shuffle_buffer(self, urls: str) -> None:
+        dataset = CopernicusPretrain([urls, urls], shuffle_buffer=1)
+        assert len(list(dataset)) == 2
+
+    def test_remote_shards(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        path = tmp_path / 'example-000000.tar'
+        create_shard(path, keys=['a', 'b'])
+
+        class Response:
+            raw: io.BufferedReader
+
+            def raise_for_status(self) -> None:
+                pass
+
+        with open(path, 'rb') as f:
+            Response.raw = f
+            monkeypatch.setattr(requests, 'get', lambda url, **kwargs: Response())
+            dataset = CopernicusPretrain('https://example.com/example-000000.tar')
+            assert len(list(dataset)) == 2
+
+    def test_worker_split(self, monkeypatch: MonkeyPatch, urls: str) -> None:
+        monkeypatch.setattr(
+            torch.utils.data, 'get_worker_info', lambda: WorkerInfo(1, 2)
+        )
+        dataset = CopernicusPretrain([urls, urls])
+        assert len(list(dataset)) == 1
+
+    def test_distributed_split(self, monkeypatch: MonkeyPatch, urls: str) -> None:
+        monkeypatch.setattr(torch.distributed, 'is_initialized', lambda: True)
+        monkeypatch.setattr(torch.distributed, 'get_rank', lambda: 0)
+        monkeypatch.setattr(torch.distributed, 'get_world_size', lambda: 2)
+        dataset = CopernicusPretrain([urls, urls])
+        assert len(list(dataset)) == 1
+
+    def test_missing_modalities(self, tmp_path: Path) -> None:
+        path = tmp_path / 'example-000000.tar'
+        create_shard(path, keys=['a'], fields=['s1_grd'])
+        dataset = CopernicusPretrain(str(path))
+        assert list(dataset) == []
 
 
 class TestCopernicusEmbed:

--- a/torchgeo/datasets/copernicus/pretrain.py
+++ b/torchgeo/datasets/copernicus/pretrain.py
@@ -3,18 +3,49 @@
 
 """Copernicus-Pretrain dataset."""
 
+import io
+import os
 import random
-from collections.abc import Iterator
-from typing import Any, ClassVar
+import re
+import tarfile
+from collections.abc import Iterator, Sequence
+from typing import ClassVar
 
+import requests
 import torch
+import torch.distributed as dist
+import torch.utils.data
 from einops import rearrange
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
-from torch import Tensor
 from torch.utils.data import IterableDataset
 
-from ..utils import Sample, lazy_import, quantile_normalization
+from ..utils import Sample, quantile_normalization
+
+
+def _expand_urls(urls: str | Sequence[str]) -> list[str]:
+    """Expand brace notation into a list of shard paths or URLs.
+
+    Args:
+        urls: One or more shard paths or URLs, optionally containing numeric
+            brace notation such as ``example-{000000..000009}.tar``.
+
+    Returns:
+        The expanded list of shard paths or URLs.
+    """
+    if not isinstance(urls, str):
+        return [expanded for url in urls for expanded in _expand_urls(url)]
+
+    match = re.search(r'\{(\d+)\.\.(\d+)\}', urls)
+    if match is None:
+        return [urls]
+
+    start, stop = match.group(1), match.group(2)
+    expanded = []
+    for i in range(int(start), int(stop) + 1):
+        shard = urls[: match.start()] + str(i).zfill(len(start)) + urls[match.end() :]
+        expanded.extend(_expand_urls(shard))
+    return expanded
 
 
 class CopernicusPretrain(IterableDataset[Sample]):
@@ -25,10 +56,10 @@ class CopernicusPretrain(IterableDataset[Sample]):
     consistent with ERA5), densely covering the whole land surface and near-land ocean
     with time series from eight distinct Sentinel modalities.
 
-    This dataset class uses WebDataset for efficient data loading in distributed
-    environments, which returns a PyTorch IterableDataset that is compatible with
-    Pytorch DataLoader. Note: it is recommended to further use webdataset.WebLoader
-    (a wrapper on DataLoader) for more features in data loading.
+    This dataset streams samples directly from its sharded tar archives, which can be
+    local files or remote http(s) URLs. It is a PyTorch IterableDataset that is
+    compatible with :class:`torch.utils.data.DataLoader`, and shards are automatically
+    split across distributed ranks and DataLoader workers.
 
     The full dataset has a varying number of modalities, S1/2 local patches, and
     timestamps for different grids. It also contains metadata including the filenames
@@ -61,26 +92,21 @@ class CopernicusPretrain(IterableDataset[Sample]):
        dem = sample['dem.pth']
 
        # Create a DataLoader for distributed training on 2 GPUs
-       dataset = dataset.dataset.batched(10)  # batch size
-       dataloader = webdataset.WebLoader(dataset, batch_size=None, num_workers=2)
-       # Unbatch, shuffle, and rebatch to mix samples from different workers
-       dataloader = dataloader.unbatched().shuffle(100).batched(10)
-       # A resampled dataset is infinite size, but we can recreate a fixed epoch length
+       dataloader = DataLoader(dataset, batch_size=10, num_workers=2)
+       # A resampled dataset is infinite size, so limit the epoch length
        # Total number of samples / (batch size * world size)
        number_of_batches = 1000 // (10 * 2)
-       dataloader = dataloader.with_epoch(number_of_batches)
 
     If you use this dataset in your research, please cite the following paper:
 
     * https://arxiv.org/abs/2503.11849
 
-    .. note::
-
-       This dataset requires the following additional library to be installed:
-
-       * `<https://pypi.org/project/webdataset/>`_ to load the dataset.
-
     .. versionadded:: 0.7
+
+    .. versionchanged:: 0.10
+       *webdataset* is no longer required to load this dataset. The constructor now
+       accepts explicit *urls*, *shardshuffle*, *resampled*, and *shuffle_buffer*
+       arguments instead of forwarding all arguments to ``webdataset.WebDataset``.
     """
 
     url_dict: ClassVar[dict[str, str]] = {
@@ -92,24 +118,27 @@ class CopernicusPretrain(IterableDataset[Sample]):
         '100_example': 'https://hf.co/datasets/wangyi111/Copernicus-Pretrain/resolve/d17e1098bd4fef52e7994805658434ce7e5800fc/example_100_grids/example_100_webdataset/example-{000000..000009}.tar',
     }
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        urls: str | Sequence[str],
+        shardshuffle: bool = False,
+        resampled: bool = False,
+        shuffle_buffer: int = 10,
+    ) -> None:
         """Initialize a new CopernicusPretrain instance.
 
         Args:
-            *args: Arguments passed to WebDataset base class.
-            **kwargs: Keyword arguments passed to WebDataset base class.
+            urls: One or more shard paths or http(s) URLs, optionally containing
+                numeric brace notation such as ``example-{000000..000009}.tar``.
+            shardshuffle: Shuffle the order of shards each epoch.
+            resampled: Yield an infinite stream of samples by sampling shards
+                with replacement instead of iterating over each shard once.
+            shuffle_buffer: Size of the buffer used to shuffle samples.
         """
-        wds = lazy_import('webdataset')
-
-        self.dataset = (
-            wds.WebDataset(*args, **kwargs)
-            .shuffle(10)  # shuffle individual samples before batching
-            .decode()  # decode binary data
-            .map(self._drop_metadata)  # remove non-Tensor metadata
-            .select(self._has_all_modalities)  # select samples with all modalities
-            .map(self._sample_one_local_patch)  # sample one local patch for S1 and S2
-            .map(self._sample_one_time_stamp)  # sample one timestamp for all modalities
-        )
+        self.urls = _expand_urls(urls)
+        self.shardshuffle = shardshuffle
+        self.resampled = resampled
+        self.shuffle_buffer = shuffle_buffer
 
     def __iter__(self) -> Iterator[Sample]:
         """Iterate over images in the dataset.
@@ -120,23 +149,104 @@ class CopernicusPretrain(IterableDataset[Sample]):
         .. versionchanged:: 0.10
            Removed *json* metadata.
         """
-        return iter(self.dataset)
+        samples = (
+            sample
+            for shard in self._iter_shards()
+            for sample in self._iter_samples(shard)
+        )
+        for sample in self._shuffle_samples(samples):
+            if self._has_all_modalities(sample):
+                sample = self._sample_one_local_patch(sample)
+                sample = self._sample_one_time_stamp(sample)
+                yield sample
 
-    def _drop_metadata(self, sample: dict[str, object]) -> Sample:
-        """Mapping function: remove all non-Tensor metadata.
+    def _iter_shards(self) -> Iterator[str]:
+        """Yield the shards that this rank and DataLoader worker should read.
+
+        If *resampled*, shards are sampled indefinitely with replacement.
+        Otherwise, shards are split across distributed ranks and DataLoader
+        workers, and each assigned shard is yielded once.
+
+        Yields:
+            Shard paths or URLs.
+        """
+        shards = self.urls
+        if self.resampled:
+            while True:
+                yield random.choice(shards)
+        else:
+            if dist.is_available() and dist.is_initialized():
+                shards = shards[dist.get_rank() :: dist.get_world_size()]
+            worker_info = torch.utils.data.get_worker_info()
+            if worker_info is not None:
+                shards = shards[worker_info.id :: worker_info.num_workers]
+            if self.shardshuffle:
+                shards = random.sample(shards, k=len(shards))
+            yield from shards
+
+    def _open_shard(self, shard: str) -> tarfile.TarFile:
+        """Open a local or remote tar shard for sequential streaming.
 
         Args:
-            sample: A single sample from the dataset.
+            shard: Local path or http(s) URL of a tar shard.
 
         Returns:
-            The same sample with only Tensor images.
+            The tar archive opened in streaming mode.
         """
-        new_sample = {}
-        for key, value in sample.items():
-            if isinstance(value, Tensor):
-                new_sample[key] = value
+        if shard.startswith(('http://', 'https://')):
+            response = requests.get(shard, stream=True, timeout=30)
+            response.raise_for_status()
+            return tarfile.open(fileobj=response.raw, mode='r|*')
+        return tarfile.open(shard, mode='r|*')
 
-        return new_sample
+    def _iter_samples(self, shard: str) -> Iterator[Sample]:
+        """Sequentially read samples from a single tar shard.
+
+        Files are grouped into samples by their prefix up to the first dot,
+        and ``.pth`` entries are decoded into tensors. All other entries,
+        including *json* metadata, are skipped.
+
+        Args:
+            shard: Local path or http(s) URL of a tar shard.
+
+        Yields:
+            sample of images
+        """
+        with self._open_shard(shard) as tar:
+            key = None
+            sample: Sample = {}
+            for member in (m for m in tar if m.isfile()):
+                prefix, _, field = os.path.basename(member.name).partition('.')
+                if prefix != key:
+                    if sample:
+                        yield sample
+                    key = prefix
+                    sample = {}
+                if field.endswith('.pth'):
+                    data = tar.extractfile(member)
+                    assert data is not None
+                    sample[field] = torch.load(
+                        io.BytesIO(data.read()), weights_only=True
+                    )
+            if sample:
+                yield sample
+
+    def _shuffle_samples(self, samples: Iterator[Sample]) -> Iterator[Sample]:
+        """Shuffle a stream of samples using a fixed-size buffer.
+
+        Args:
+            samples: Stream of samples to shuffle.
+
+        Yields:
+            sample of images
+        """
+        buffer: list[Sample] = []
+        for sample in samples:
+            buffer.append(sample)
+            if len(buffer) >= self.shuffle_buffer:
+                yield buffer.pop(random.randrange(len(buffer)))
+        while buffer:
+            yield buffer.pop(random.randrange(len(buffer)))
 
     def _has_all_modalities(self, sample: Sample) -> bool:
         """Selection function: filter samples with all required modalities.

--- a/uv.lock
+++ b/uv.lock
@@ -305,15 +305,6 @@ css = [
 ]
 
 [[package]]
-name = "braceexpand"
-version = "0.1.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/93/badd4f5ccf25209f3fef2573073da9fe4a45a3da99fca2f800f942130c0f/braceexpand-0.1.7.tar.gz", hash = "sha256:e6e539bd20eaea53547472ff94f4fb5c3d3bf9d0a89388c4b56663aba765f705", size = 7777, upload-time = "2021-05-07T13:49:07.323Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/93/e8c04e80e82391a6e51f218ca49720f64236bc824e92152a2633b74cf7ab/braceexpand-0.1.7-py2.py3-none-any.whl", hash = "sha256:91332d53de7828103dcae5773fb43bc34950b0c8160e35e0f44c4427a3b85014", size = 5923, upload-time = "2021-05-07T13:49:05.146Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -721,7 +712,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -752,43 +743,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1068,7 +1059,7 @@ name = "h5py"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
 wheels = [
@@ -2137,7 +2128,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2176,7 +2167,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2188,7 +2179,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2218,9 +2209,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2232,7 +2223,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2417,7 +2408,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3668,7 +3659,7 @@ name = "tokenizers"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
 wheels = [
@@ -3786,7 +3777,6 @@ all = [
     { name = "types-rasterio" },
     { name = "types-requests" },
     { name = "types-shapely" },
-    { name = "webdataset" },
     { name = "xarray" },
 ]
 datasets = [
@@ -3797,7 +3787,6 @@ datasets = [
     { name = "rioxarray" },
     { name = "scipy" },
     { name = "tokenizers", marker = "python_full_version < '3.14'" },
-    { name = "webdataset" },
     { name = "xarray" },
 ]
 docs = [
@@ -3880,7 +3869,6 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'style'", specifier = ">=2.25" },
     { name = "types-shapely", marker = "extra == 'style'", specifier = ">=2.0.2" },
     { name = "typing-extensions", specifier = ">=4.8" },
-    { name = "webdataset", marker = "extra == 'datasets'", specifier = ">=0.2.4" },
     { name = "xarray", marker = "extra == 'datasets'", specifier = ">=0.17" },
 ]
 provides-extras = ["datasets", "docs", "models", "style", "tests", "all"]
@@ -4163,20 +4151,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
-]
-
-[[package]]
-name = "webdataset"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "braceexpand" },
-    { name = "numpy" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/3a/68800d92e065cf4750ebecf973b13979c0c929b439e1293012938862038d/webdataset-1.0.2.tar.gz", hash = "sha256:7f0498be827cfa46cc5430a58768a24e2c6a410676a61be1838f53d61afdaab4", size = 80090, upload-time = "2025-06-19T23:26:21.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/00/aca6beb3658dab4ed3dbb41a78e6e7f31342e0b41d28088f205525751601/webdataset-1.0.2-py3-none-any.whl", hash = "sha256:3dbfced32b25c0d199c6b9787937b6f85742bc3c84f652c846893075c1c082d9", size = 74956, upload-time = "2025-06-19T23:26:20.354Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
webdataset's only consumer in torchgeo was `CopernicusPretrain`. This PR keeps the dataset but replaces webdataset with a minimal built-in tar-shard streamer, dropping `webdataset` and its `braceexpand` dependency from the `datasets` extra.

### What the built-in loader supports

* Numeric brace notation (`example-{000000..000009}.tar`) for shard lists.
* Streaming reads of local shards and remote http(s) shards (via `requests`, already a required dependency) — shards are never fully loaded into memory.
* Sample grouping by key prefix with `.pth` entries decoded via `torch.load(..., weights_only=True)`; `.json` metadata is skipped (matching the existing behavior of dropping non-Tensor values).
* A fixed-size sample shuffle buffer (`shuffle_buffer`, default 10, matching the previous `.shuffle(10)`).
* Automatic shard splitting across distributed ranks and DataLoader workers, and `resampled=True` for an infinite stream sampling shards with replacement.

### API changes

* The constructor now takes explicit `urls`, `shardshuffle`, `resampled`, and `shuffle_buffer` arguments instead of forwarding `*args/**kwargs` to `webdataset.WebDataset` (documented with `versionchanged:: 0.10`).
* The internal `dataset.dataset` attribute (the wds pipeline) is gone, so the documented `webdataset.WebLoader` / `.batched()` usage patterns no longer apply — the docstring example now shows plain `DataLoader` usage. Sample dicts and their keys (`s1_grd.pth`, …) are unchanged.

### Testing

* Existing `test_getitem`/`test_plot` pass unchanged against the real fixture shard.
* New tests cover brace expansion, multi-sample shards, remote (http) streaming via a stubbed `requests.get`, worker and distributed-rank splitting, `shardshuffle`, `resampled`, the shuffle buffer, and samples with missing modalities.
* Full `tests/datasets/test_copernicus.py` run with a stub `webdataset` package that raises `ImportError` on import: 165 passed, `pretrain.py` at 100% line coverage. `ruff` 0.16.1 and `ty` 0.0.66 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)