### PR TITLE
PASTIS: animated time series GIF

### DIFF
--- a/torchgeo/datasets/pastis.py
+++ b/torchgeo/datasets/pastis.py
@@ -7,12 +7,13 @@ import os
 from collections.abc import Callable, Sequence
 from typing import ClassVar
 
+import einops
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from matplotlib.animation import FuncAnimation
 from matplotlib.colors import ListedColormap
-from matplotlib.figure import Figure
 from torch import Tensor
 
 from .errors import DatasetNotFoundError
@@ -377,7 +378,7 @@ class PASTIS(NonGeoDataset):
 
     def plot(
         self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
-    ) -> Figure:
+    ) -> FuncAnimation:
         """Plot a sample from the dataset.
 
         Args:
@@ -386,53 +387,49 @@ class PASTIS(NonGeoDataset):
             suptitle: optional string to use as a suptitle
 
         Returns:
-            a matplotlib Figure with the rendered sample
+            a matplotlib animation with the rendered sample
         """
-        # Keep the RGB bands and quantile-normalize each frame independently.
-        rgb_frames = sample['image'][:, [2, 1, 0], :, :]
-        rgb_frames = torch.stack(
-            [quantile_normalization(frame) for frame in rgb_frames]
-        )
-        images = rgb_frames.numpy().transpose(0, 2, 3, 1)
-        mask = sample['mask'].numpy()
+        frames = sample['image'][:, [2, 1, 0], :, :]
+        frames = torch.stack([quantile_normalization(frame) for frame in frames])
+        frames = einops.rearrange(frames, 't c h w -> t h w c')
 
+        mask = sample['mask']
         if self.mode == 'instance':
             label = sample['label']
-            mask = label[mask.argmax(axis=0)].numpy()
+            mask = label[mask.argmax(axis=0)]
 
-        num_panels = 3
+        num_panels = 2
         showing_predictions = 'prediction' in sample
         if showing_predictions:
-            predictions = sample['prediction'].numpy()
+            predictions = sample['prediction']
             num_panels += 1
             if self.mode == 'instance':
                 predictions = predictions.argmax(axis=0)
                 label = sample['prediction_labels']
-                predictions = label[predictions].numpy()
+                predictions = label[predictions]
 
         fig, axs = plt.subplots(1, num_panels, figsize=(num_panels * 4, 4))
-        axs[0].imshow(images[0])
-        axs[1].imshow(images[1])
-        axs[2].imshow(mask, vmin=0, vmax=19, cmap=self.cmap, interpolation='none')
+        ani = FuncAnimation(fig, func=axs[0].imshow, frames=frames)
         axs[0].axis('off')
+
+        axs[1].imshow(mask, vmin=0, vmax=19, cmap=self.cmap, interpolation='none')
         axs[1].axis('off')
-        axs[2].axis('off')
         if showing_predictions:
-            axs[3].imshow(
+            axs[2].imshow(
                 predictions, vmin=0, vmax=19, cmap=self.cmap, interpolation='none'
             )
-            axs[3].axis('off')
+            axs[2].axis('off')
 
         if show_titles:
-            axs[0].set_title('Image 0')
-            axs[1].set_title('Image 1')
-            axs[2].set_title('Mask')
+            axs[0].set_title('Images')
+            axs[1].set_title('Mask')
             if showing_predictions:
-                axs[3].set_title('Prediction')
+                axs[2].set_title('Prediction')
 
         if suptitle is not None:
-            plt.suptitle(suptitle)
-        return fig
+            fig.suptitle(suptitle)
+
+        return ani
 
 
 class PASTIS100(PASTIS):


### PR DESCRIPTION
### Summary

Includes the following changes:

- [x] Instead of plotting the first two timestamps, plot an animated GIF
- [x] Don't cast to numpy, keep everything as a Tensor

Could be separated into two PRs if desired to make it easier to review.

#### Before

<img width="1200" height="400" alt="before" src="https://github.com/user-attachments/assets/d0eee701-d198-4627-9c52-d9630eb747b7" />

#### After

<img width="800" height="400" alt="after" src="https://github.com/user-attachments/assets/ee9f08e8-769e-41d5-af59-410471c6a3d4" />

Note that this is a backwards-incompatible change, as we now return a FuncAnimation instead of a Figure. However, `plt.show()` continues to work as expected, and saving the plot saves it as a static PNG of the current image, so it shouldn't be too different. Unfortunately only returning `fig` doesn't work, as the animation is closed immediately. `ds.plot()` also doesn't work, you have to use `ani = ds.plot()`.

Curious what @calebrob6 thinks of this. I have a student working on TorchGeo plotting and want to make more of our plots interactive. This PR is a proof of concept, but the plan is to eventually do this for all time-series datasets.

### Rationale

We used the previous two-timestamp plot in a manuscript and the reviewers complained that we should either plot the first timestamp or plot all timestamps. This PR is the best of both worlds, as you can directly visualize the animation and save it as either a GIF (dynamic) or PNG (static).

P.S. I'm considering reverting #3881, as the animation is more clear if all frames use the same normalization. We can change the threshold to account for frequent cloud cover.

@yichiac @robmarkcole 

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
