### PR TITLE
Restore uv cache pruning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           python-version: '3.14'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml
@@ -50,6 +51,7 @@ jobs:
         with:
           python-version: '3.14'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: '3.14'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml
@@ -48,6 +49,7 @@ jobs:
         with:
           python-version: '3.14'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml
@@ -54,6 +55,7 @@ jobs:
         with:
           python-version: '3.12'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml
@@ -80,6 +82,7 @@ jobs:
         with:
           python-version: '3.14'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           python-version: '3.14'
           enable-cache: true
+          prune-cache: true
           activate-environment: true
           cache-dependency-glob: |
             pyproject.toml


### PR DESCRIPTION
Restore uv cache pruning after the `setup-uv` v9 default changed.

See https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0