### PR TITLE
Test model forwards in inference mode

### DIFF
--- a/tests/models/test_changestar.py
+++ b/tests/models/test_changestar.py
@@ -17,7 +17,7 @@ SF = [4, 8, 1]
 
 
 class TestChangeStar:
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_changestar_farseg_classes(self) -> None:
         model = ChangeStarFarSeg(classes=4, backbone='resnet50')
         x = torch.randn(2, 2, 3, 128, 128)
@@ -25,7 +25,7 @@ class TestChangeStar:
 
         assert y['bi_seg_logit'].shape[2] == 4
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_changestar_farseg_output_size(self) -> None:
         model = ChangeStarFarSeg(classes=4, backbone='resnet50')
         model.eval()
@@ -51,7 +51,7 @@ class TestChangeStar:
         with pytest.raises(ValueError, match=match):
             ChangeStarFarSeg(classes=4, backbone='anynet')
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('inc', IN_CHANNELS)
     @pytest.mark.parametrize('innerc', INNNR_CHANNELS)
     @pytest.mark.parametrize('nc', NC)
@@ -67,7 +67,7 @@ class TestChangeStar:
         assert y[0].shape == y[1].shape
         assert y[0].shape == (3, 1, 32 * sf, 32 * sf)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_changestar(self) -> None:
         dense_feature_extractor = nn.modules.Sequential(
             nn.modules.Conv2d(3, 32, 3, 1, 1),
@@ -94,7 +94,7 @@ class TestChangeStar:
         assert y['bi_seg_logit'].shape == (3, 2, 2, 64, 64)
         assert y['change_prob'].shape == (3, 1, 64, 64)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('inference_mode', ['t1t2', 't2t1', 'mean'])
     def test_changestar_inference_output_size(
         self, inference_mode: Literal['t1t2', 't2t1', 'mean']

--- a/tests/models/test_changevit.py
+++ b/tests/models/test_changevit.py
@@ -16,7 +16,7 @@ BATCH_SIZE = [1, 2]
 
 
 class TestChangeViT:
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('b', BATCH_SIZE)
     def test_forward(self, b: int) -> None:
         """Test ChangeViT forward pass with different batch sizes."""
@@ -33,7 +33,7 @@ class TestChangeViT:
         # Output: [B, 1, H, W] - binary change detection logits
         assert y.shape == (b, 1, 32, 32)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_different_img_sizes(self) -> None:
         """Test ChangeViT with different image sizes."""
         for img_size in [32, 48, 64]:
@@ -44,7 +44,7 @@ class TestChangeViT:
             y = model(x)
             assert y.shape == (1, 1, img_size, img_size)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_components(self) -> None:
         """Test ChangeViT has required components."""
         model = ChangeViT(
@@ -58,7 +58,7 @@ class TestChangeViT:
 
 
 class TestDetailCaptureModule:
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_detail_capture_multiscale_output(self) -> None:
         """Test DetailCaptureModule returns 3 scales with correct channels."""
         dcm = DetailCaptureModule(in_channels=6)
@@ -78,7 +78,7 @@ class TestDetailCaptureModule:
 
 
 class TestFeatureInjector:
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_feature_injector_output_shape(self) -> None:
         """Test FeatureInjector preserves ViT feature shape."""
         vit_dim = 384
@@ -101,7 +101,7 @@ class TestFeatureInjector:
 
 
 class TestChangeViTDecoder:
-    @torch.no_grad()
+    @torch.inference_mode()
     def test_decoder_output_shape(self) -> None:
         """Test ChangeViTDecoder returns bidirectional predictions."""
         decoder = ChangeViTDecoder(in_channels=384, num_classes=1)

--- a/tests/models/test_farseg.py
+++ b/tests/models/test_farseg.py
@@ -9,7 +9,7 @@ from torchgeo.models import FarSeg
 
 
 class TestFarSeg:
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize(
         'backbone', ['resnet18', 'resnet34', 'resnet50', 'resnet101']
     )

--- a/tests/models/test_fcsiam.py
+++ b/tests/models/test_fcsiam.py
@@ -12,7 +12,7 @@ CLASSES = [1, 2]
 
 
 class TestFCSiamConc:
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('b', BATCH_SIZE)
     @pytest.mark.parametrize('c', CHANNELS)
     def test_in_channels(self, b: int, c: int) -> None:
@@ -23,7 +23,7 @@ class TestFCSiamConc:
         y = model(x)
         assert y.shape == (b, classes, h, w)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('b', BATCH_SIZE)
     @pytest.mark.parametrize('classes', CLASSES)
     def test_classes(self, b: int, classes: int) -> None:
@@ -35,7 +35,7 @@ class TestFCSiamConc:
 
 
 class TestFCSiamDiff:
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('b', BATCH_SIZE)
     @pytest.mark.parametrize('c', CHANNELS)
     def test_in_channels(self, b: int, c: int) -> None:
@@ -46,7 +46,7 @@ class TestFCSiamDiff:
         y = model(x)
         assert y.shape == (b, classes, h, w)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     @pytest.mark.parametrize('b', BATCH_SIZE)
     @pytest.mark.parametrize('classes', CLASSES)
     def test_classes(self, b: int, classes: int) -> None:


### PR DESCRIPTION
### Summary

Use inference mode for model forward tests.

### Rationale

Avoid autograd overhead in inference-only tests.

### Checklist

- [x] I have read the Contributing docs
- [x] I have read the AI policy
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution