### PR TITLE
Reduce model test input sizes

### DIFF
--- a/tests/models/test_farseg.py
+++ b/tests/models/test_farseg.py
@@ -15,10 +15,10 @@ class TestFarSeg:
     )
     def test_valid_backbone(self, backbone: str) -> None:
         model = FarSeg(classes=4, backbone=backbone)
-        x = torch.randn(2, 3, 128, 128)
+        x = torch.randn(2, 3, 32, 32)
         y = model(x)
 
-        assert y.shape == (2, 4, 128, 128)
+        assert y.shape == (2, 4, 32, 32)
 
     def test_invalid_backbone(self) -> None:
         match = 'unknown backbone: anynet.'

--- a/tests/models/test_rcf.py
+++ b/tests/models/test_rcf.py
@@ -13,7 +13,7 @@ from torchgeo.models import MOSAIKS, RCF
 class TestRCF:
     def test_in_channels(self) -> None:
         model = RCF(in_channels=5, features=4, kernel_size=3, mode='gaussian')
-        x = torch.randn(2, 5, 64, 64)
+        x = torch.randn(2, 5, 32, 32)
         model(x)
 
         model = RCF(in_channels=3, features=4, kernel_size=3, mode='gaussian')
@@ -23,11 +23,11 @@ class TestRCF:
 
     def test_num_features(self) -> None:
         model = RCF(in_channels=5, features=4, kernel_size=3, mode='gaussian')
-        x = torch.randn(2, 5, 64, 64)
+        x = torch.randn(2, 5, 32, 32)
         y = model(x)
         assert y.shape == (2, 4)
 
-        x = torch.randn(1, 5, 64, 64)
+        x = torch.randn(1, 5, 32, 32)
         y = model(x)
         assert y.shape == (1, 4)
 


### PR DESCRIPTION
### Summary

Use smaller inputs in FarSeg and RCF tests.

### Rationale

The tests only need to validate output shape and channel handling.

### Checklist

- [x] I have read the Contributing docs
- [x] I have read the AI policy
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution