### PR TITLE
adding SHA256 checksum for FLAIRHUBToy

### DIFF
--- a/tests/datasets/test_flair.py
+++ b/tests/datasets/test_flair.py
@@ -156,6 +156,30 @@ class TestFLAIRHUB:
         with pytest.raises(RuntimeError, match='Dataset found, but corrupted'):
             FLAIRHUB(root=root, checksum=True, bands=['AERIAL_RGBI'])
 
+    def test_toy_checksum(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            FLAIRHUBToy, 'download_link', str(_TEST_DATA / 'FLAIR-HUB_TOY_DATASET.zip')
+        )
+        monkeypatch.setattr(
+            FLAIRHUBToy,
+            'sha256',
+            'f7c19caa216fe37afac70ada47207d7cf1cbd2ce2da24654606bb68c261f3473',
+        )
+        dataset = FLAIRHUBToy(
+            root=tmp_path,
+            split='train',
+            download=True,
+            checksum=True,
+            bands=['AERIAL_RGBI'],
+        )
+        assert len(dataset) == 1
+
+        toy_dir = tmp_path / 'FLAIR-HUB_TOY'
+        shutil.rmtree(toy_dir)
+        (tmp_path / 'FLAIR-HUB_TOY_DATASET.zip').write_text('breaking_SHA256')
+        with pytest.raises(RuntimeError, match='Dataset found, but corrupted'):
+            FLAIRHUBToy(root=tmp_path, checksum=True, bands=['AERIAL_RGBI'])
+
     def test_toy_reextract_and_missing_splits(self, tmp_path: Path) -> None:
         shutil.copy(
             _TEST_DATA / 'FLAIR-HUB_TOY_DATASET.zip',

--- a/tests/datasets/test_flair.py
+++ b/tests/datasets/test_flair.py
@@ -131,7 +131,7 @@ class TestFLAIRHUB:
         directory = root / 'D006-2020_AERIAL_RGBI'
         shutil.rmtree(directory)
 
-        FLAIRHUB(root=root, bands=['AERIAL_RGBI'])
+        FLAIRHUB(root=root, bands=['AERIAL_RGBI'], checksum=False)
         assert directory.is_dir()
         assert not (root / 'D006-2020_AERIAL_RGBI.zip').exists()
 
@@ -190,6 +190,7 @@ class TestFLAIRHUB:
             split='train',
             bands=['AERIAL_RGBI'],
             dataset_type='land_cover',
+            checksum=False,
         )
         toy_dir = tmp_path / 'FLAIR-HUB_TOY'
         shutil.rmtree(toy_dir)
@@ -199,6 +200,7 @@ class TestFLAIRHUB:
             split='train',
             bands=['AERIAL_RGBI'],
             dataset_type='land_cover',
+            checksum=False,
         )
         assert len(dataset) == 1
 

--- a/torchgeo/datasets/flair.py
+++ b/torchgeo/datasets/flair.py
@@ -1917,6 +1917,9 @@ class FLAIRHUBToy(FLAIRHUBBase):
     """
 
     download_link = 'https://storage.gra.cloud.ovh.net/v1/AUTH_366279ce616242ebb14161b7991a8461/defi-ia/flair_hub/FLAIR-HUB_TOY_DATASET.zip'
+    sha256: ClassVar[str] = (
+        'f0af97c8bb26c76d07351299017f11cbe0e015a621b6b5fdde0b451dbac254a1'
+    )
 
     def __init__(
         self,
@@ -1925,6 +1928,7 @@ class FLAIRHUBToy(FLAIRHUBBase):
         split_column: Literal['split_toy'] = 'split_toy',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
+        checksum: bool = False,
         bands: list[AvailableBands] | None = None,
         dataset_type: Literal[
             'land_cover', 'crop_type', 'crop_type_2', 'crop_type_3'
@@ -1941,7 +1945,8 @@ class FLAIRHUBToy(FLAIRHUBBase):
             split: One of ``train``, ``val``, or ``test``.
             split_column: Column name in the official splits GeoPackage.
             transforms: Optional transforms to apply to samples.
-            download: If True, download the toy dataset if not found (~10 MB).
+            download: If True, download the toy dataset if not found.
+            checksum: If True, check the SHA-256 of the downloaded file (may be slow).
             bands: List of bands/modalities to load. See
                 :class:`~torchgeo.datasets.FLAIRHUB` for available options.
                 Defaults to None, which enables all bands.
@@ -1974,6 +1979,7 @@ class FLAIRHUBToy(FLAIRHUBBase):
             split_column=split_column,
             transforms=transforms,
             download=download,
+            checksum=checksum,
             bands=bands,
             dataset_type=dataset_type,
         )
@@ -1986,10 +1992,14 @@ class FLAIRHUBToy(FLAIRHUBBase):
         if toy_dir.is_dir():
             return
 
-        if not toy_zip.is_file():
-            if not self.download:
-                raise DatasetNotFoundError(self)
-            download_url(self.download_link, self.root_folder)
+        if toy_zip.is_file():
+            if self.checksum and not check_integrity(toy_zip, sha256=self.sha256):
+                raise RuntimeError('Dataset found, but corrupted.')
+        elif self.download:
+            sha256 = self.sha256 if self.checksum else None
+            download_url(self.download_link, self.root_folder, sha256=sha256)
+        else:
+            raise DatasetNotFoundError(self)
 
         extract_archive(str(toy_zip), str(self.root_folder))
         self.files = self._load_files()

--- a/torchgeo/datasets/flair.py
+++ b/torchgeo/datasets/flair.py
@@ -1321,7 +1321,7 @@ class FLAIRHUBBase(NonGeoDataset):
         split_column: str = 'split_1',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         bands: list[AvailableBands] | None = None,
         dataset_type: Literal[
             'land_cover', 'crop_type', 'crop_type_2', 'crop_type_3'
@@ -1891,7 +1891,7 @@ class FLAIRHUB(FLAIRHUBBase):
         ] = 'split_1',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         bands: list[AvailableBands] | None = None,
         dataset_type: Literal[
             'land_cover', 'crop_type', 'crop_type_2', 'crop_type_3'
@@ -1917,9 +1917,7 @@ class FLAIRHUBToy(FLAIRHUBBase):
     """
 
     download_link = 'https://storage.gra.cloud.ovh.net/v1/AUTH_366279ce616242ebb14161b7991a8461/defi-ia/flair_hub/FLAIR-HUB_TOY_DATASET.zip'
-    sha256: ClassVar[str] = (
-        'f0af97c8bb26c76d07351299017f11cbe0e015a621b6b5fdde0b451dbac254a1'
-    )
+    sha256 = 'f0af97c8bb26c76d07351299017f11cbe0e015a621b6b5fdde0b451dbac254a1'
 
     def __init__(
         self,
@@ -1928,7 +1926,7 @@ class FLAIRHUBToy(FLAIRHUBBase):
         split_column: Literal['split_toy'] = 'split_toy',
         transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
-        checksum: bool = False,
+        checksum: bool = True,
         bands: list[AvailableBands] | None = None,
         dataset_type: Literal[
             'land_cover', 'crop_type', 'crop_type_2', 'crop_type_3'


### PR DESCRIPTION
### Summary

Adding SHA256 checksum for FLAIRHUBToy, FlairHubToy is not hosted by HuggingFace.

### Rationale

We added it to the main model and we plan to have SHA256 checksum support for all dataset. 

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution

AI used to get bash command to calculate checksum (sha256sum)