### PR TITLE
Inria: increase test coverage

### DIFF
--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -1,6 +1,7 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
+import shutil
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -53,7 +54,7 @@ class TestInriaAerialImageLabeling:
 
     def test_extract(self, tmp_path: Path) -> None:
         src = Path('tests/data/inria/NEW2-AerialImageDataset.zip')
-        src.copy(tmp_path / 'NEW2-AerialImageDataset.zip')
+        shutil.copy(src, tmp_path)
         InriaAerialImageLabeling(tmp_path, checksum=False)
 
     def test_plot(self, dataset: InriaAerialImageLabeling) -> None:

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -1,7 +1,6 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
-import os
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -16,7 +15,7 @@ from torchgeo.datasets import DatasetNotFoundError, InriaAerialImageLabeling
 class TestInriaAerialImageLabeling:
     @pytest.fixture(params=['train', 'val', 'test'])
     def dataset(self, request: SubRequest) -> InriaAerialImageLabeling:
-        root = os.path.join('tests', 'data', 'inria')
+        root = Path('tests/data/inria')
         transforms = nn.Identity()
         return InriaAerialImageLabeling(
             root, split=request.param, transforms=transforms, checksum=False
@@ -51,6 +50,10 @@ class TestInriaAerialImageLabeling:
         (tmp_path / InriaAerialImageLabeling.filename).touch()
         with pytest.raises(RuntimeError, match='Dataset corrupted'):
             InriaAerialImageLabeling(root=tmp_path, checksum=True)
+
+    def test_extract(self, tmp_path: Path) -> None:
+        Path('tests/data/inria/NEW2-AerialImageDataset.zip').copy_into(tmp_path)
+        InriaAerialImageLabeling(tmp_path, checksum=False)
 
     def test_plot(self, dataset: InriaAerialImageLabeling) -> None:
         x = dataset[0].copy()

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -52,7 +52,8 @@ class TestInriaAerialImageLabeling:
             InriaAerialImageLabeling(root=tmp_path, checksum=True)
 
     def test_extract(self, tmp_path: Path) -> None:
-        Path('tests/data/inria/NEW2-AerialImageDataset.zip').copy_into(tmp_path)
+        src = Path('tests/data/inria/NEW2-AerialImageDataset.zip')
+        src.copy(tmp_path / 'NEW2-AerialImageDataset.zip')
         InriaAerialImageLabeling(tmp_path, checksum=False)
 
     def test_plot(self, dataset: InriaAerialImageLabeling) -> None:


### PR DESCRIPTION
### Summary

Adds a test for dataset extraction.

### Rationale

Get's us back up to 100% coverage. No idea when this changed.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
