### PR TITLE
Add ELECTS EarlyRewardLoss 

### DIFF
--- a/tests/losses/test_elects.py
+++ b/tests/losses/test_elects.py
@@ -20,7 +20,7 @@ class TestEarlyRewardLoss:
         )
         log_probs = logits.log_softmax(dim=-1)
         probability_stopping = torch.tensor([[0.2, 0.5, 0.9], [0.4, 0.5, 0.9]])
-        target = torch.tensor([[0, 0, 0], [1, 1, 1]])
+        target = torch.tensor([0, 1])
         return log_probs, probability_stopping, target
 
     def test_decision_probability(self) -> None:
@@ -55,8 +55,24 @@ class TestEarlyRewardLoss:
             'earliness_reward',
             'probability_making_decision',
         }
-        assert stats['probability_making_decision'].shape == target.shape
+        assert stats['probability_making_decision'].shape == probability_stopping.shape
         assert all(not value.requires_grad for value in stats.values())
+
+    def test_temporal_target(
+        self, inputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ) -> None:
+        log_probs, probability_stopping, target = inputs
+        temporal_target = target.unsqueeze(dim=1).expand(-1, log_probs.shape[1])
+        expected = EarlyRewardLoss()(log_probs, probability_stopping, target)
+        actual = EarlyRewardLoss()(log_probs, probability_stopping, temporal_target)
+        assert torch.equal(actual, expected)
+
+    def test_spatial_target(self) -> None:
+        log_probs = torch.randn(2, 3, 4, 5, 6).log_softmax(dim=2)
+        probability_stopping = torch.rand(2, 3, 5, 6)
+        target = torch.randint(4, (2, 5, 6))
+        loss = EarlyRewardLoss()(log_probs, probability_stopping, target)
+        assert loss.ndim == 0
 
     def test_weight(
         self, inputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
@@ -75,3 +91,21 @@ class TestEarlyRewardLoss:
     def test_invalid_epsilon(self) -> None:
         with pytest.raises(ValueError, match='Invalid epsilon value'):
             EarlyRewardLoss(epsilon=-1)
+
+    def test_invalid_log_probs_shape(self) -> None:
+        with pytest.raises(ValueError, match='log_probs must have shape'):
+            EarlyRewardLoss()(torch.rand(2, 3), torch.rand(2, 3), torch.ones(2))
+
+    def test_invalid_stopping_shape(self) -> None:
+        with pytest.raises(ValueError, match='probability_stopping must have shape'):
+            EarlyRewardLoss()(
+                torch.rand(2, 3, 4), torch.rand(2, 4), torch.ones(2, dtype=torch.long)
+            )
+
+    def test_invalid_target_shape(self) -> None:
+        with pytest.raises(ValueError, match='target must have shape'):
+            EarlyRewardLoss()(
+                torch.rand(2, 3, 4),
+                torch.rand(2, 3),
+                torch.ones(2, 2, dtype=torch.long),
+            )

--- a/tests/losses/test_elects.py
+++ b/tests/losses/test_elects.py
@@ -1,0 +1,77 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+import torch
+
+from torchgeo.losses import EarlyRewardLoss
+from torchgeo.losses.elects import _decision_probability
+
+
+class TestEarlyRewardLoss:
+    @pytest.fixture
+    def inputs(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        logits = torch.tensor(
+            [
+                [[2.0, 1.0], [1.0, 2.0], [2.0, 1.0]],
+                [[1.0, 2.0], [2.0, 1.0], [1.0, 2.0]],
+            ],
+            requires_grad=True,
+        )
+        log_probs = logits.log_softmax(dim=-1)
+        probability_stopping = torch.tensor([[0.2, 0.5, 0.9], [0.4, 0.5, 0.9]])
+        target = torch.tensor([[0, 0, 0], [1, 1, 1]])
+        return log_probs, probability_stopping, target
+
+    def test_decision_probability(self) -> None:
+        probability_stopping = torch.tensor([[0.2, 0.5, 0.9]])
+        actual = _decision_probability(probability_stopping)
+        expected = torch.tensor([[0.2, 0.4, 0.4]])
+        assert torch.allclose(actual, expected)
+
+    def test_single_time_step(self) -> None:
+        actual = _decision_probability(torch.tensor([[0.5], [0.1]]))
+        assert torch.equal(actual, torch.ones(2, 1))
+
+    def test_forward(
+        self, inputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ) -> None:
+        log_probs, probability_stopping, target = inputs
+        loss = EarlyRewardLoss(epsilon=0)(log_probs, probability_stopping, target)
+        assert loss.ndim == 0
+        loss.backward()
+        assert log_probs.grad_fn is not None
+
+    def test_return_stats(
+        self, inputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ) -> None:
+        log_probs, probability_stopping, target = inputs
+        output = EarlyRewardLoss()(log_probs, probability_stopping, target, True)
+        assert isinstance(output, tuple)
+        loss, stats = output
+        assert loss.ndim == 0
+        assert set(stats) == {
+            'classification_loss',
+            'earliness_reward',
+            'probability_making_decision',
+        }
+        assert stats['probability_making_decision'].shape == target.shape
+        assert all(not value.requires_grad for value in stats.values())
+
+    def test_weight(
+        self, inputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ) -> None:
+        log_probs, probability_stopping, target = inputs
+        loss = EarlyRewardLoss(weight=torch.tensor([1.0, 2.0]))(
+            log_probs, probability_stopping, target
+        )
+        assert torch.isfinite(loss)
+
+    @pytest.mark.parametrize('alpha', [-0.1, 1.1])
+    def test_invalid_alpha(self, alpha: float) -> None:
+        with pytest.raises(ValueError, match='Invalid alpha value'):
+            EarlyRewardLoss(alpha=alpha)
+
+    def test_invalid_epsilon(self) -> None:
+        with pytest.raises(ValueError, match='Invalid epsilon value'):
+            EarlyRewardLoss(epsilon=-1)

--- a/torchgeo/losses/__init__.py
+++ b/torchgeo/losses/__init__.py
@@ -3,6 +3,7 @@
 
 """TorchGeo losses."""
 
+from .elects import EarlyRewardLoss
 from .qr import QRLoss, RQLoss
 
-__all__ = ('QRLoss', 'RQLoss')
+__all__ = ('EarlyRewardLoss', 'QRLoss', 'RQLoss')

--- a/torchgeo/losses/elects.py
+++ b/torchgeo/losses/elects.py
@@ -26,7 +26,7 @@ class EarlyRewardLoss(Module):
     <https://doi.org/10.1016/j.isprsjprs.2022.12.016>`_. It balances
     classification accuracy against making correct predictions early in a sequence.
 
-    .. versionadded:: 0.10
+    .. versionadded:: 0.11
     """
 
     def __init__(

--- a/torchgeo/losses/elects.py
+++ b/torchgeo/losses/elects.py
@@ -1,0 +1,112 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""Loss function for early classification of time series."""
+
+import torch
+from torch import Tensor
+from torch.nn import NLLLoss
+from torch.nn.modules import Module
+
+
+def _decision_probability(probability_stopping: Tensor) -> Tensor:
+    """Compute the probability of making a decision at each time step."""
+    remaining = torch.cumprod(1 - probability_stopping[:, :-1], dim=1)
+    budget = torch.cat([torch.ones_like(probability_stopping[:, :1]), remaining], dim=1)
+    return torch.cat(
+        [probability_stopping[:, :-1] * budget[:, :-1], budget[:, -1:]], dim=1
+    )
+
+
+class EarlyRewardLoss(Module):
+    """ELECTS loss for early classification of time series.
+
+    This loss is defined in `'End-to-end learned early classification of time
+    series for in-season crop type mapping'
+    <https://doi.org/10.1016/j.isprsjprs.2022.12.016>`_. It balances
+    classification accuracy against making correct predictions early in a sequence.
+
+    .. versionadded:: 0.10
+    """
+
+    def __init__(
+        self, alpha: float = 0.5, epsilon: float = 10, weight: Tensor | None = None
+    ) -> None:
+        """Initialize a new EarlyRewardLoss instance.
+
+        Args:
+            alpha: Trade-off between classification accuracy and earliness. Must be
+                between 0 and 1.
+            epsilon: Additive smoothing applied to the decision probabilities. Must
+                be greater than or equal to 0.
+            weight: Manual rescaling weight for each class.
+
+        Raises:
+            ValueError: If ``alpha`` or ``epsilon`` is outside its valid range.
+        """
+        if not 0 <= alpha <= 1:
+            raise ValueError(f'Invalid alpha value: {alpha}')
+        if epsilon < 0:
+            raise ValueError(f'Invalid epsilon value: {epsilon}')
+
+        super().__init__()
+        self.alpha = alpha
+        self.epsilon = epsilon
+        self.nll_loss = NLLLoss(weight=weight, reduction='none')
+
+    def forward(
+        self,
+        log_probs: Tensor,
+        probability_stopping: Tensor,
+        target: Tensor,
+        return_stats: bool = False,
+    ) -> Tensor | tuple[Tensor, dict[str, Tensor]]:
+        """Compute the ELECTS early classification loss.
+
+        Args:
+            log_probs: Log class probabilities with shape B x T x C.
+            probability_stopping: Probability of stopping with shape B x T. The
+                final value is ignored because a decision is always made at the final
+                time step.
+            target: Class indices with shape B x T.
+            return_stats: Return the loss components and decision probabilities.
+
+        Returns:
+            The scalar loss, or the loss and detached statistics when
+            ``return_stats`` is true.
+        """
+        batch_size, sequence_length, num_classes = log_probs.shape
+        decision_probability = _decision_probability(probability_stopping)
+        decision_probability = decision_probability + self.epsilon / sequence_length
+
+        time = torch.arange(
+            sequence_length, device=log_probs.device, dtype=log_probs.dtype
+        )
+        correct_probability = (
+            log_probs.gather(dim=-1, index=target.unsqueeze(dim=-1))
+            .squeeze(dim=-1)
+            .exp()
+        )
+        earliness_reward = (
+            (decision_probability * correct_probability * (1 - time / sequence_length))
+            .sum(dim=1)
+            .mean()
+        )
+
+        classification_loss = self.nll_loss(
+            log_probs.reshape(batch_size * sequence_length, num_classes),
+            target.reshape(batch_size * sequence_length),
+        ).reshape(batch_size, sequence_length)
+        classification_loss = (
+            (classification_loss * decision_probability).sum(dim=1).mean()
+        )
+
+        loss = self.alpha * classification_loss - (1 - self.alpha) * earliness_reward
+        if return_stats:
+            stats = {
+                'classification_loss': classification_loss.detach(),
+                'earliness_reward': earliness_reward.detach(),
+                'probability_making_decision': decision_probability.detach(),
+            }
+            return loss, stats
+        return loss

--- a/torchgeo/losses/elects.py
+++ b/torchgeo/losses/elects.py
@@ -46,7 +46,7 @@ class EarlyRewardLoss(Module):
         """
         if not 0 <= alpha <= 1:
             raise ValueError(f'Invalid alpha value: {alpha}')
-        if epsilon < 0:
+        if not 0 <= epsilon:
             raise ValueError(f'Invalid epsilon value: {epsilon}')
 
         super().__init__()

--- a/torchgeo/losses/elects.py
+++ b/torchgeo/losses/elects.py
@@ -64,28 +64,55 @@ class EarlyRewardLoss(Module):
         """Compute the ELECTS early classification loss.
 
         Args:
-            log_probs: Log class probabilities with shape B x T x C.
-            probability_stopping: Probability of stopping with shape B x T. The
-                final value is ignored because a decision is always made at the final
-                time step.
-            target: Class indices with shape B x T.
+            log_probs: Log class probabilities with shape B x T x C x ... .
+            probability_stopping: Probability of stopping with shape B x T x ... .
+                The final value is ignored because a decision is always made at the
+                final time step.
+            target: Class indices with shape B x ... . Targets already repeated over
+                time with shape B x T x ... are also supported.
             return_stats: Return the loss components and decision probabilities.
 
         Returns:
             The scalar loss, or the loss and detached statistics when
             ``return_stats`` is true.
+
+        Raises:
+            ValueError: If any input has an incompatible shape.
         """
-        batch_size, sequence_length, num_classes = log_probs.shape
+        if log_probs.ndim < 3:
+            raise ValueError(
+                'log_probs must have shape B x T x C x ..., '
+                f'but found {tuple(log_probs.shape)}'
+            )
+
+        batch_size, sequence_length, num_classes, *spatial_shape = log_probs.shape
+        expected_stopping_shape = (batch_size, sequence_length, *spatial_shape)
+        if probability_stopping.shape != expected_stopping_shape:
+            raise ValueError(
+                'probability_stopping must have shape '
+                f'{expected_stopping_shape}, but found '
+                f'{tuple(probability_stopping.shape)}'
+            )
+
+        expected_target_shape = (batch_size, *spatial_shape)
+        temporal_target_shape = (batch_size, sequence_length, *spatial_shape)
+        if target.shape == expected_target_shape:
+            target = target.unsqueeze(dim=1).expand(temporal_target_shape)
+        elif target.shape != temporal_target_shape:
+            raise ValueError(
+                f'target must have shape {expected_target_shape} or '
+                f'{temporal_target_shape}, but found {tuple(target.shape)}'
+            )
+
         decision_probability = _decision_probability(probability_stopping)
         decision_probability = decision_probability + self.epsilon / sequence_length
 
         time = torch.arange(
             sequence_length, device=log_probs.device, dtype=log_probs.dtype
         )
+        time = time.reshape(1, sequence_length, *([1] * len(spatial_shape)))
         correct_probability = (
-            log_probs.gather(dim=-1, index=target.unsqueeze(dim=-1))
-            .squeeze(dim=-1)
-            .exp()
+            log_probs.gather(dim=2, index=target.unsqueeze(dim=2)).squeeze(dim=2).exp()
         )
         earliness_reward = (
             (decision_probability * correct_probability * (1 - time / sequence_length))
@@ -94,9 +121,11 @@ class EarlyRewardLoss(Module):
         )
 
         classification_loss = self.nll_loss(
-            log_probs.reshape(batch_size * sequence_length, num_classes),
-            target.reshape(batch_size * sequence_length),
-        ).reshape(batch_size, sequence_length)
+            log_probs.reshape(
+                batch_size * sequence_length, num_classes, *spatial_shape
+            ),
+            target.reshape(batch_size * sequence_length, *spatial_shape),
+        ).reshape(batch_size, sequence_length, *spatial_shape)
         classification_loss = (
             (classification_loss * decision_probability).sum(dim=1).mean()
         )


### PR DESCRIPTION
### Summary

Add loss from https://github.com/MarcCoru/elects

CC @MarcCoru

Note: Unlike the reference ELECTS implementation by Marc, this version fixes an off-by-one error in stopping probabilities (TBC) and supports both sequence-level `(B,)` and spatial `(B, H, W)` targets **without repeating labels across time**. This makes the loss compatible with standard TorchGeo classification and segmentation data formats while preserving the reference implementation support for repeated targets.

### Rationale

Long term objective: Reproducing elects paper with torchgeo and use of ELECTS with other models. 

Note ELECTS a training method, not a fixed architecture. Any causal sequence encoder could be used if it produces features at every timestep and has:

- A classification head producing (B, T, classes).
- A sigmoid stopping head producing (B, T).
- No access to future observations when predicting timestep t.

Thus, an LSTM with those two heads is sufficient -> a follow up PR can address this with a PASTIS-compatible ConvLSTM variant

### Checklist

- [ ] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
