### PR TITLE
VHR-10: derive length from loaded images

### DIFF
--- a/tests/datasets/test_vhr10.py
+++ b/tests/datasets/test_vhr10.py
@@ -39,7 +39,7 @@ class TestVHR10:
 
     def test_len(self, dataset: VHR10) -> None:
         if dataset.split == 'positive':
-            assert len(dataset) == 650
+            assert len(dataset) == 5
         elif dataset.split == 'negative':
             assert len(dataset) == 150
 

--- a/tests/datasets/test_vhr10.py
+++ b/tests/datasets/test_vhr10.py
@@ -38,10 +38,7 @@ class TestVHR10:
             assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: VHR10) -> None:
-        if dataset.split == 'positive':
-            assert len(dataset) == 650
-        elif dataset.split == 'negative':
-            assert len(dataset) == 150
+        assert len(dataset) == 5
 
     def test_already_downloaded(self, dataset: VHR10) -> None:
         VHR10(root=dataset.root, download=True, checksum=False)
@@ -49,6 +46,11 @@ class TestVHR10:
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             VHR10(tmp_path)
+
+    def test_not_extracted(self, tmp_path: Path) -> None:
+        (tmp_path / VHR10.image_meta['filename']).touch()
+        with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
+            VHR10(tmp_path, split='negative', checksum=False)
 
     def test_plot(self, dataset: VHR10) -> None:
         x = dataset[0]

--- a/tests/datasets/test_vhr10.py
+++ b/tests/datasets/test_vhr10.py
@@ -39,7 +39,7 @@ class TestVHR10:
 
     def test_len(self, dataset: VHR10) -> None:
         if dataset.split == 'positive':
-            assert len(dataset) == 5
+            assert len(dataset) == 650
         elif dataset.split == 'negative':
             assert len(dataset) == 150
 

--- a/tests/tasks/test_instance_segmentation.py
+++ b/tests/tasks/test_instance_segmentation.py
@@ -104,8 +104,7 @@ class TestInstanceSegmentation:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
-        monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
+    def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictInstanceSegmentationDataModule(
             root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
         )

--- a/tests/tasks/test_instance_segmentation.py
+++ b/tests/tasks/test_instance_segmentation.py
@@ -18,6 +18,11 @@ from torchgeo.tasks import InstanceSegmentation
 pytest.importorskip('pycocotools')
 
 
+@pytest.fixture(autouse=True)
+def vhr10_length(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
+
+
 class PredictInstanceSegmentationDataModule(VHR10DataModule):
     def setup(self, stage: str) -> None:
         self.predict_dataset = VHR10(**self.kwargs)
@@ -33,13 +38,8 @@ def plot_missing_bands(*args: Any, **kwargs: Any) -> None:
 
 class TestInstanceSegmentation:
     @pytest.mark.parametrize('name', ['vhr10_ins_seg'])
-    def test_trainer(
-        self, monkeypatch: MonkeyPatch, name: str, fast_dev_run: bool
-    ) -> None:
+    def test_trainer(self, name: str, fast_dev_run: bool) -> None:
         config = os.path.join('tests', 'conf', name + '.yaml')
-
-        if name.startswith('vhr10'):
-            monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
 
         args = [
             '--config',
@@ -75,7 +75,6 @@ class TestInstanceSegmentation:
             InstanceSegmentation(backbone='invalid_backbone')
 
     def test_no_plot_method(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
-        monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
         monkeypatch.setattr(VHR10DataModule, 'plot', plot)
         datamodule = VHR10DataModule(
             root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
@@ -90,7 +89,6 @@ class TestInstanceSegmentation:
         trainer.validate(model=model, datamodule=datamodule)
 
     def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
-        monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
         monkeypatch.setattr(VHR10DataModule, 'plot', plot_missing_bands)
         datamodule = VHR10DataModule(
             root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
@@ -104,8 +102,7 @@ class TestInstanceSegmentation:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
-        monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
+    def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictInstanceSegmentationDataModule(
             root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
         )

--- a/tests/tasks/test_instance_segmentation.py
+++ b/tests/tasks/test_instance_segmentation.py
@@ -104,7 +104,8 @@ class TestInstanceSegmentation:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, fast_dev_run: bool) -> None:
+    def test_predict(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
+        monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
         datamodule = PredictInstanceSegmentationDataModule(
             root='tests/data/vhr10', batch_size=1, num_workers=0, checksum=False
         )

--- a/tests/tasks/test_instance_segmentation.py
+++ b/tests/tasks/test_instance_segmentation.py
@@ -18,11 +18,6 @@ from torchgeo.tasks import InstanceSegmentation
 pytest.importorskip('pycocotools')
 
 
-@pytest.fixture(autouse=True)
-def vhr10_length(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(VHR10, '__len__', lambda self: 5)
-
-
 class PredictInstanceSegmentationDataModule(VHR10DataModule):
     def setup(self, stage: str) -> None:
         self.predict_dataset = VHR10(**self.kwargs)

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -3,6 +3,7 @@
 
 """NWPU VHR-10 dataset."""
 
+import glob
 import json
 import os
 from collections import defaultdict
@@ -129,6 +130,14 @@ class VHR10(NonGeoDataset):
         if not self._check_integrity():
             raise DatasetNotFoundError(self)
 
+        directory = os.path.join(
+            self.root, 'NWPU VHR-10 dataset', f'{self.split} image set'
+        )
+        self.files = sorted(glob.glob(os.path.join(directory, '*.jpg')))
+
+        if not self.files:
+            raise DatasetNotFoundError(self)
+
         if split == 'positive':
             path = os.path.join(self.root, 'NWPU VHR-10 dataset', 'annotations.json')
             with open(path) as f:
@@ -136,8 +145,11 @@ class VHR10(NonGeoDataset):
 
                 # Gather image shapes
                 out_shapes = []
+                image_ids = {}
                 for image in annotations['images']:
                     out_shapes.append((image['height'], image['width']))
+                    image_ids[image['file_name']] = image['id']
+                self.ids = [image_ids[os.path.basename(file)] for file in self.files]
 
                 self.labels = defaultdict(list)
                 self.boxes = defaultdict(list)
@@ -170,20 +182,17 @@ class VHR10(NonGeoDataset):
         """
         sample = {}
 
-        # Both 'positive' and 'negative' splits have an image
-        split = f'{self.split} image set'
-        file = f'{index + 1:03d}.jpg'
-        path = os.path.join(self.root, 'NWPU VHR-10 dataset', split, file)
-        with Image.open(path) as f:
+        with Image.open(self.files[index]) as f:
             tensor = torch.from_numpy(np.array(f)).float()
             tensor = einops.rearrange(tensor, 'h w c -> c h w')
             sample['image'] = tensor
 
         # Only 'positive' split has target labels
         if self.split == 'positive':
-            sample['label'] = torch.tensor(self.labels[index])
-            sample['bbox_xyxy'] = torch.tensor(self.boxes[index])
-            sample['mask'] = torch.stack(self.masks[index])
+            id_ = self.ids[index]
+            sample['label'] = torch.tensor(self.labels[id_])
+            sample['bbox_xyxy'] = torch.tensor(self.boxes[id_])
+            sample['mask'] = torch.stack(self.masks[id_])
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -196,10 +205,7 @@ class VHR10(NonGeoDataset):
         Returns:
             length of the dataset
         """
-        if self.split == 'positive':
-            return 650
-        else:
-            return 150
+        return len(self.files)
 
     def _check_integrity(self) -> bool:
         """Check integrity of dataset.

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -133,6 +133,7 @@ class VHR10(NonGeoDataset):
             path = os.path.join(self.root, 'NWPU VHR-10 dataset', 'annotations.json')
             with open(path) as f:
                 annotations = json.load(f)
+                self._length = len(annotations['images'])
 
                 # Gather image shapes
                 out_shapes = []
@@ -197,7 +198,7 @@ class VHR10(NonGeoDataset):
             length of the dataset
         """
         if self.split == 'positive':
-            return 650
+            return self._length
         else:
             return 150
 

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -133,7 +133,6 @@ class VHR10(NonGeoDataset):
             path = os.path.join(self.root, 'NWPU VHR-10 dataset', 'annotations.json')
             with open(path) as f:
                 annotations = json.load(f)
-                self._length = len(annotations['images'])
 
                 # Gather image shapes
                 out_shapes = []
@@ -198,7 +197,7 @@ class VHR10(NonGeoDataset):
             length of the dataset
         """
         if self.split == 'positive':
-            return self._length
+            return 650
         else:
             return 150
 

--- a/uv.lock
+++ b/uv.lock
@@ -4072,15 +4072,15 @@ wheels = [
 
 [[package]]
 name = "types-rasterio"
-version = "1.5.0.20260728"
+version = "1.5.0.20260810"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/27/39bedd54ec2174a55a40af904c5e3994ebd45bba20d3eaaa43d1edf26e31/types_rasterio-1.5.0.20260728.tar.gz", hash = "sha256:634fad70698a3a7c566539e0cfee66eb2ef32f7f2e08bad06fb548b987e85322", size = 26880, upload-time = "2026-07-28T04:51:45.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/3d/3994309af47ca7d30e5e6fd6a72b6171d3f2775bebef7baacb176be118ef/types_rasterio-1.5.0.20260810.tar.gz", hash = "sha256:45e2e43dc5c97eeaf2f3c9f8b89b3d269914d1cf2a0a2c32e6fe029ee79dd5e6", size = 27017, upload-time = "2026-08-10T03:41:17.497Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/b7/88926f6b1d017dbc89b725d7c65b0f369eb863ad0d7670330d22ccc80d85/types_rasterio-1.5.0.20260728-py3-none-any.whl", hash = "sha256:00b62bd1335fb49b8a137d97e90604b6356bcaa7a32d8678bb3e414c5966115d", size = 38653, upload-time = "2026-07-28T04:51:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/39/18/9feb4df702aa9b23d3cd2e9a1b0d57ef49cfb00e7fb30c4ef59f7918dd39/types_rasterio-1.5.0.20260810-py3-none-any.whl", hash = "sha256:206a71e32b5c3820c9eb25ee40185918afe852458459fdcfc0a2b00dec491742", size = 38645, upload-time = "2026-08-10T03:41:16.671Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

Determine VHR10 split length dynamically.
Check for the case where the VHR10 dataset was downloaded but not extracted.

### Rationale

VHR10 previously hardcoded a length of 650 positive and 150 negative images even when a partial or fake dataset was loaded (https://github.com/torchgeo/torchgeo/pull/3500). This didn't cause problems previously because we also hardcoded those values into the dataset tests, and monkeypatched the instance segmentation tests to make len return 5 instead. It looks like we missed monkeypatching in the predict step (which didn't cause tests to fail as it only iterates for a single batch as fast_dev_run is usually true). When running the integration tests with fast_dev_run=False, the prediction step is looking for all 650 items, which don't exist because the test dataset only has 5.

The simplest fix is to just add `monkeypatch.setattr(VHR10, '__len__', lambda self: 5)` to the test_predict method in the instance segmentation trainer tests, but this seems like a better way to do it overall (as a reader of the instance segmentation trainer tests shouldn't need to figure our why tf we're monkeypatching a dataset length method).

Bonus round: previously,  `_check_integrity()` could succeed when the archive existed even if its extracted image directory was missing. We now check for this too.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution