### PR TITLE
Tests: add branch coverage to MMFlood and BioMassters plot

### DIFF
--- a/tests/datasets/test_biomassters.py
+++ b/tests/datasets/test_biomassters.py
@@ -40,3 +40,5 @@ class TestBioMassters:
             sample['prediction'] = sample['label']
         dataset.plot(sample)
         plt.close()
+        dataset.plot(sample, show_titles=False)
+        plt.close()

--- a/tests/datasets/test_mmflood.py
+++ b/tests/datasets/test_mmflood.py
@@ -93,6 +93,8 @@ class TestMMFlood:
         x = dataset[dataset.bounds]
         dataset.plot(x, suptitle='Test')
         plt.close()
+        dataset.plot(x, show_titles=False)
+        plt.close()
 
     def test_plot_prediction(self, dataset: MMFlood) -> None:
         x = dataset[dataset.bounds]


### PR DESCRIPTION
## Summary

This PR adds branch coverage to the `plot()` tests for **MMFlood** and **BioMassters**, following the pattern established in #3734. Both datasets' `plot()` implementations have `show_titles` branches that were never exercised by the test suite.

## Changes

- `tests/datasets/test_mmflood.py`: call `plot(x, show_titles=False)` in `test_plot`
- `tests/datasets/test_biomassters.py`: call `plot(sample, show_titles=False)` in `test_plot`

## Impact on coverage

Running with `--cov-branch` locally:

| Dataset | Branches newly covered |
|---|---|
| `torchgeo/datasets/mmflood.py` | `show_titles` and `suptitle is None` paths |
| `torchgeo/datasets/biomassters.py` | all three `show_titles` branches (dataset now at 100% branch coverage) |

All existing tests pass (`122 passed` for the two files combined). This contributes toward the branch-coverage goal tracked in #2501.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/torchgeo/torchgeo/blob/main/docs/user/contributing.md)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)
- [x] `ruff format` and `ruff check` pass
- [x] Tests pass locally for the affected modules

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution

Refs: #2501

Note: this does not fully resolve all of #2501 (which spans the whole repo) but advances it for these two datasets.