### PR TITLE
FarSeg should be able to use torchgeo weights

### DIFF
--- a/tests/models/test_farseg.py
+++ b/tests/models/test_farseg.py
@@ -2,10 +2,14 @@
 # Licensed under the MIT License.
 
 
+from pathlib import Path
+
 import pytest
 import torch
+from pytest import MonkeyPatch
+from timm import create_model
 
-from torchgeo.models import FarSeg
+from torchgeo.models import FarSeg, ResNet50_Weights
 
 
 class TestFarSeg:
@@ -24,3 +28,27 @@ class TestFarSeg:
         match = 'unknown backbone: anynet.'
         with pytest.raises(ValueError, match=match):
             FarSeg(classes=4, backbone='anynet')
+
+    @torch.inference_mode()
+    def test_torchgeo_weights(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+    ) -> None:
+        weights = ResNet50_Weights.LANDSAT_TM_TOA_MOCO
+        path = tmp_path / f'{weights}.pth'
+        model = create_model('resnet50', in_chans=weights.meta['in_chans'])
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
+
+        model = FarSeg(classes=4, backbone='resnet50', backbone_weights=weights)
+        x = torch.randn(2, weights.meta['in_chans'], 32, 32)
+        y = model(x)
+
+        assert y.shape == (2, 4, 32, 32)
+
+    def test_mismatched_torchgeo_weights(self) -> None:
+        match = 'backbone weights are for resnet50, not resnet18.'
+        with pytest.raises(ValueError, match=match):
+            FarSeg(
+                backbone='resnet18',
+                backbone_weights=ResNet50_Weights.LANDSAT_TM_TOA_MOCO,
+            )

--- a/torchgeo/models/farseg.py
+++ b/torchgeo/models/farseg.py
@@ -5,7 +5,7 @@
 
 import math
 from collections import OrderedDict
-from typing import Protocol, cast
+from typing import cast
 
 import torch.nn.functional as F
 from torch import Tensor
@@ -26,19 +26,6 @@ from torchvision.ops import FeaturePyramidNetwork as FPN
 
 from . import resnet as torchgeo_resnet
 from .resnet import ResNet18_Weights, ResNet50_Weights
-
-
-class _ResNetBackbone(Protocol):
-    """ResNet feature extraction interface."""
-
-    conv1: Module
-    bn1: Module
-    relu: Module
-    maxpool: Module
-    layer1: Module
-    layer2: Module
-    layer3: Module
-    layer4: Module
 
 
 class FarSeg(Module):
@@ -92,7 +79,7 @@ class FarSeg(Module):
             model = getattr(torchgeo_resnet, backbone)(weights=backbone_weights)
         else:
             model = getattr(torchvision_resnet, backbone)(weights=backbone_weights)
-        self.backbone = cast(_ResNetBackbone, model)
+        self.backbone = model
 
         self.fpn = FPN(
             in_channels_list=[max_channels // (2 ** (3 - i)) for i in range(4)],

--- a/torchgeo/models/farseg.py
+++ b/torchgeo/models/farseg.py
@@ -5,7 +5,7 @@
 
 import math
 from collections import OrderedDict
-from typing import cast
+from typing import Protocol, cast
 
 import torch.nn.functional as F
 from torch import Tensor
@@ -20,9 +20,25 @@ from torch.nn.modules import (
     Sigmoid,
     UpsamplingBilinear2d,
 )
-from torchvision.models import resnet
+from torchvision.models import resnet as torchvision_resnet
 from torchvision.models._api import WeightsEnum
 from torchvision.ops import FeaturePyramidNetwork as FPN
+
+from . import resnet as torchgeo_resnet
+from .resnet import ResNet18_Weights, ResNet50_Weights
+
+
+class _ResNetBackbone(Protocol):
+    """ResNet feature extraction interface."""
+
+    conv1: Module
+    bn1: Module
+    relu: Module
+    maxpool: Module
+    layer1: Module
+    layer2: Module
+    layer3: Module
+    layer4: Module
 
 
 class FarSeg(Module):
@@ -53,6 +69,9 @@ class FarSeg(Module):
             classes: number of output segmentation classes
             backbone_weights: Pre-trained model weights to use.
 
+        Raises:
+            ValueError: If the backbone is unsupported or does not match the weights.
+
         .. versionadded:: 0.9
            The *backbone_weights* parameter.
         """
@@ -64,7 +83,16 @@ class FarSeg(Module):
         else:
             raise ValueError(f'unknown backbone: {backbone}.')
 
-        self.backbone = getattr(resnet, backbone)(weights=backbone_weights)
+        if isinstance(backbone_weights, (ResNet18_Weights, ResNet50_Weights)):
+            expected_backbone = cast(str, backbone_weights.meta['model'])
+            if backbone != expected_backbone:
+                raise ValueError(
+                    f'backbone weights are for {expected_backbone}, not {backbone}.'
+                )
+            model = getattr(torchgeo_resnet, backbone)(weights=backbone_weights)
+        else:
+            model = getattr(torchvision_resnet, backbone)(weights=backbone_weights)
+        self.backbone = cast(_ResNetBackbone, model)
 
         self.fpn = FPN(
             in_channels_list=[max_channels // (2 ** (3 - i)) for i in range(4)],
@@ -84,7 +112,10 @@ class FarSeg(Module):
         """
         x = self.backbone.conv1(x)
         x = self.backbone.bn1(x)
-        x = self.backbone.relu(x)
+        activation: Module | None = getattr(self.backbone, 'act1', None)
+        if activation is None:
+            activation = self.backbone.relu
+        x = activation(x)
         x = self.backbone.maxpool(x)
 
         c2 = self.backbone.layer1(x)


### PR DESCRIPTION
FarSeg passed TorchGeo weights to TorchVision ResNet builders, which rejected them because the weight enum types did not match.

This change uses TorchGeo ResNet builders for TorchGeo weights while keeping the existing TorchVision behavior for TorchVision weights. It also checks that the selected weights match the requested backbone.

Closes #3540.

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution