### PR TITLE
Reduce model and transform test input sizes

### DIFF
--- a/tests/models/test_btc.py
+++ b/tests/models/test_btc.py
@@ -24,7 +24,7 @@ class TestBTC:
         model = BTC(backbone=backbone, backbone_pretrained=False)
         model.eval()
         with torch.inference_mode():
-            x = torch.randn(1, 2 * 3, 64, 64)
+            x = torch.randn(1, 2 * 3, 32, 32)
             model(x)
 
     @pytest.fixture

--- a/tests/models/test_changestar.py
+++ b/tests/models/test_changestar.py
@@ -20,7 +20,7 @@ class TestChangeStar:
     @torch.inference_mode()
     def test_changestar_farseg_classes(self) -> None:
         model = ChangeStarFarSeg(classes=4, backbone='resnet50')
-        x = torch.randn(2, 2, 3, 128, 128)
+        x = torch.randn(2, 2, 3, 32, 32)
         y = model(x)
 
         assert y['bi_seg_logit'].shape[2] == 4
@@ -29,18 +29,18 @@ class TestChangeStar:
     def test_changestar_farseg_output_size(self) -> None:
         model = ChangeStarFarSeg(classes=4, backbone='resnet50')
         model.eval()
-        x = torch.randn(2, 2, 3, 128, 128)
+        x = torch.randn(2, 2, 3, 32, 32)
         y = model(x)
 
-        assert y['bi_seg_logit'].shape[3] == 128 and y['bi_seg_logit'].shape[4] == 128
-        assert y['change_prob'].shape[2] == 128 and y['change_prob'].shape[3] == 128
+        assert y['bi_seg_logit'].shape[3] == 32 and y['bi_seg_logit'].shape[4] == 32
+        assert y['change_prob'].shape[2] == 32 and y['change_prob'].shape[3] == 32
 
         model.train()
         y = model(x)
 
-        assert y['bi_seg_logit'].shape[3] == 128 and y['bi_seg_logit'].shape[4] == 128
-        assert y['bi_change_logit'].shape[3] == 128
-        assert y['bi_change_logit'].shape[4] == 128
+        assert y['bi_seg_logit'].shape[3] == 32 and y['bi_seg_logit'].shape[4] == 32
+        assert y['bi_change_logit'].shape[3] == 32
+        assert y['bi_change_logit'].shape[4] == 32
 
     @pytest.mark.parametrize('backbone', BACKBONE)
     def test_valid_changestar_farseg_backbone(self, backbone: str) -> None:
@@ -90,9 +90,9 @@ class TestChangeStar:
         )
         m.eval()
 
-        y = m(torch.rand(3, 2, 3, 64, 64))
-        assert y['bi_seg_logit'].shape == (3, 2, 2, 64, 64)
-        assert y['change_prob'].shape == (3, 1, 64, 64)
+        y = m(torch.rand(3, 2, 3, 32, 32))
+        assert y['bi_seg_logit'].shape == (3, 2, 2, 32, 32)
+        assert y['change_prob'].shape == (3, 1, 32, 32)
 
     @torch.inference_mode()
     @pytest.mark.parametrize('inference_mode', ['t1t2', 't2t1', 'mean'])
@@ -121,8 +121,8 @@ class TestChangeStar:
         )
         m.eval()
 
-        x = torch.randn(2, 2, 3, 128, 128)
+        x = torch.randn(2, 2, 3, 32, 32)
         y = m(x)
 
-        assert y['bi_seg_logit'].shape == (2, 2, CLASSES, 128, 128)
-        assert y['change_prob'].shape == (2, 1, 128, 128)
+        assert y['bi_seg_logit'].shape == (2, 2, CLASSES, 32, 32)
+        assert y['change_prob'].shape == (2, 1, 32, 32)

--- a/tests/models/test_changevit.py
+++ b/tests/models/test_changevit.py
@@ -36,7 +36,7 @@ class TestChangeViT:
     @torch.inference_mode()
     def test_different_img_sizes(self) -> None:
         """Test ChangeViT with different image sizes."""
-        for img_size in [32, 48, 64]:
+        for img_size in [16, 32]:
             model = ChangeViT(
                 backbone='vit_tiny_patch16_224', img_size=img_size, pretrained=False
             )
@@ -62,7 +62,7 @@ class TestDetailCaptureModule:
     def test_detail_capture_multiscale_output(self) -> None:
         """Test DetailCaptureModule returns 3 scales with correct channels."""
         dcm = DetailCaptureModule(in_channels=6)
-        x = torch.randn(2, 6, 256, 256)
+        x = torch.randn(2, 6, 32, 32)
 
         c2, c3, c4 = dcm(x)
 
@@ -72,9 +72,9 @@ class TestDetailCaptureModule:
         assert c4.shape[1] == 256
 
         # Check spatial dimensions (1/2, 1/4, 1/8 of input)
-        assert c2.shape[-2:] == (128, 128)  # 256 / 2
-        assert c3.shape[-2:] == (64, 64)  # 256 / 4
-        assert c4.shape[-2:] == (32, 32)  # 256 / 8
+        assert c2.shape[-2:] == (16, 16)
+        assert c3.shape[-2:] == (8, 8)
+        assert c4.shape[-2:] == (4, 4)
 
 
 class TestFeatureInjector:

--- a/tests/models/test_convlstm.py
+++ b/tests/models/test_convlstm.py
@@ -19,8 +19,8 @@ class TestConvLSTM:
         b = 1
         t = 4
         c = 3
-        h = 64
-        w = 64
+        h = 16
+        w = 16
         input_tensor = torch.rand(b, t, c, h, w)
 
         model = ConvLSTM(input_dim=c, hidden_dim=16, kernel_size=(3, 3), num_layers=1)
@@ -35,8 +35,8 @@ class TestConvLSTM:
         b = 1
         t = 4
         c = 3
-        h = 64
-        w = 64
+        h = 16
+        w = 16
         hidden_dims = [16, 32]
         num_layers = 2
         input_tensor = torch.rand(b, t, c, h, w)
@@ -59,8 +59,8 @@ class TestConvLSTM:
         b = 1
         t = 4
         c = 3
-        h = 64
-        w = 64
+        h = 16
+        w = 16
         input_tensor = torch.rand(b, t, c, h, w)
 
         model = ConvLSTM(
@@ -80,8 +80,8 @@ class TestConvLSTM:
         b = 1
         t = 4
         c = 3
-        h = 64
-        w = 64
+        h = 16
+        w = 16
         input_tensor = torch.rand(b, t, c, h, w)
 
         model = ConvLSTM(
@@ -111,8 +111,8 @@ class TestConvLSTM:
         b = 1
         t = 4
         c = 3
-        h = 64
-        w = 64
+        h = 16
+        w = 16
         input_tensor = torch.rand(b, t, c, h, w)
 
         model = ConvLSTM(

--- a/tests/models/test_copernicusfm.py
+++ b/tests/models/test_copernicusfm.py
@@ -150,7 +150,7 @@ class TestCopernicusFMBase:
 
     def test_copernicusfm_variable(self) -> None:
         model = copernicusfm_base()
-        x = torch.rand(1, 1, 96, 96)
+        x = torch.rand(1, 1, 16, 16)
         metadata = torch.rand(1, 4) + 1
         language_embed = torch.rand(2048)
         input_mode = 'variable'

--- a/tests/models/test_croma.py
+++ b/tests/models/test_croma.py
@@ -32,7 +32,7 @@ class TestCROMA:
     @pytest.mark.parametrize('modalities', [['sar'], ['optical'], ['sar', 'optical']])
     def test_croma(self, modalities: list[str]) -> None:
         batch_size = 2
-        model = CROMA(modalities=modalities)
+        model = CROMA(modalities=modalities, image_size=8)
         if 'sar' in modalities:
             sar_images = torch.randn(
                 [batch_size, 2, model.image_size, model.image_size]
@@ -54,8 +54,8 @@ class TestCROMA:
     @pytest.mark.parametrize(
         'sar_images,optical_images,match',
         [
-            (None, torch.randn(1, 12, 120, 120), 'x_sar is required'),
-            (torch.randn(1, 2, 120, 120), None, 'x_optical is required'),
+            (None, torch.randn(1, 12, 8, 8), 'x_sar is required'),
+            (torch.randn(1, 2, 8, 8), None, 'x_optical is required'),
         ],
     )
     def test_missing_modality(
@@ -64,7 +64,7 @@ class TestCROMA:
         optical_images: torch.Tensor | None,
         match: str,
     ) -> None:
-        model = CROMA()
+        model = CROMA(image_size=8)
         with pytest.raises(ValueError, match=match):
             model(sar_images, optical_images)
 

--- a/tests/models/test_deo.py
+++ b/tests/models/test_deo.py
@@ -47,14 +47,14 @@ class TestDEO:
         model = deo_base(None, model_swin)
         model.eval()
         with torch.no_grad():
-            x = torch.randn(2, 3, 256, 256)
+            x = torch.randn(2, 3, 32, 32)
             model(x)
 
     def test_forward_ms(self, model_swin: str) -> None:
         model = deo_base(None, model_swin)
         model.eval()
         with torch.no_grad():
-            x = torch.randn(2, 10, 256, 256)
+            x = torch.randn(2, 10, 32, 32)
             model(x)
 
     @pytest.mark.slow

--- a/tests/models/test_dofa.py
+++ b/tests/models/test_dofa.py
@@ -55,21 +55,22 @@ class TestDOFA:
         num_classes = 10
         global_pool = num_channels % 2 == 0
         model = DOFA(
+            img_size=16,
             embed_dim=384,
             depth=12,
             num_heads=6,
             num_classes=num_classes,
             global_pool=global_pool,
         )
-        batch = torch.randn([batch_size, num_channels, 224, 224])
+        batch = torch.randn([batch_size, num_channels, 16, 16])
         out = model(batch, wavelengths)
         assert out.shape == torch.Size([batch_size, num_classes])
 
 
 class TestDOFASmall16:
     def test_dofa(self) -> None:
-        model = dofa_small_patch16_224()
-        x = torch.rand(1, 4, 224, 224)
+        model = dofa_small_patch16_224(img_size=16)
+        x = torch.rand(1, 4, 16, 16)
         wavelengths = [664.6, 559.8, 492.4, 832.8]
         model(x, wavelengths)
 
@@ -91,8 +92,8 @@ class TestDOFABase16:
         return weights
 
     def test_dofa(self) -> None:
-        model = dofa_base_patch16_224()
-        x = torch.rand(1, 4, 224, 224)
+        model = dofa_base_patch16_224(img_size=16)
+        x = torch.rand(1, 4, 16, 16)
         wavelengths = [664.6, 559.8, 492.4, 832.8]
         model(x, wavelengths)
 
@@ -101,9 +102,7 @@ class TestDOFABase16:
 
     def test_transforms(self, weights: DOFABase16_Weights) -> None:
         c = 4
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: DOFABase16_Weights) -> None:
@@ -111,7 +110,7 @@ class TestDOFABase16:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = 4
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -136,8 +135,8 @@ class TestDOFALarge16:
         return weights
 
     def test_dofa(self) -> None:
-        model = dofa_large_patch16_224()
-        x = torch.rand(1, 4, 224, 224)
+        model = dofa_large_patch16_224(img_size=16)
+        x = torch.rand(1, 4, 16, 16)
         wavelengths = [664.6, 559.8, 492.4, 832.8]
         model(x, wavelengths)
 
@@ -146,9 +145,7 @@ class TestDOFALarge16:
 
     def test_transforms(self, weights: DOFALarge16_Weights) -> None:
         c = 4
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: DOFALarge16_Weights) -> None:
@@ -156,7 +153,7 @@ class TestDOFALarge16:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = 4
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -166,7 +163,7 @@ class TestDOFALarge16:
 
 class TestDOFAHuge14:
     def test_dofa(self) -> None:
-        model = dofa_huge_patch14_224()
-        x = torch.rand(1, 4, 224, 224)
+        model = dofa_huge_patch14_224(img_size=14)
+        x = torch.rand(1, 4, 14, 14)
         wavelengths = [664.6, 559.8, 492.4, 832.8]
         model(x, wavelengths)

--- a/tests/models/test_earthloc.py
+++ b/tests/models/test_earthloc.py
@@ -40,13 +40,13 @@ class TestEarthLoc:
     def test_earthloc_weights(self, mocked_weights: EarthLoc_Weights) -> None:
         earthloc(weights=mocked_weights)
 
-    def test_earthloc_forward(self, mocked_weights: EarthLoc_Weights) -> None:
-        model = earthloc(weights=mocked_weights)
-        c = mocked_weights.meta['in_chans']
-        h = w = mocked_weights.meta['image_size']
+    def test_earthloc_forward(self) -> None:
+        c, h, w = 3, 32, 32
+        desc_dim = 128
+        model = earthloc(in_channels=c, image_size=h, desc_dim=desc_dim)
         x = torch.randn(1, c, h, w)
         y = model(x)
-        assert y.shape == (1, mocked_weights.meta['desc_dim'])
+        assert y.shape == (1, desc_dim)
 
     def test_bands(self, weights: EarthLoc_Weights) -> None:
         if 'bands' in weights.meta:
@@ -54,9 +54,7 @@ class TestEarthLoc:
 
     def test_transforms(self, weights: EarthLoc_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: EarthLoc_Weights) -> None:
@@ -64,7 +62,7 @@ class TestEarthLoc:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow

--- a/tests/models/test_fcn.py
+++ b/tests/models/test_fcn.py
@@ -10,7 +10,7 @@ from torchgeo.models import FCN
 class TestFCN:
     def test_in_channels(self) -> None:
         model = FCN(in_channels=5, classes=4, num_filters=10)
-        x = torch.randn(2, 5, 64, 64)
+        x = torch.randn(2, 5, 32, 32)
         model(x)
 
         model = FCN(in_channels=3, classes=4, num_filters=10)
@@ -20,7 +20,7 @@ class TestFCN:
 
     def test_classes(self) -> None:
         model = FCN(in_channels=5, classes=4, num_filters=10)
-        x = torch.randn(2, 5, 64, 64)
+        x = torch.randn(2, 5, 32, 32)
         y = model(x)
 
         assert y.shape[1] == 4

--- a/tests/models/test_panopticon.py
+++ b/tests/models/test_panopticon.py
@@ -82,9 +82,9 @@ class TestPanopticonBase:
         assert output.shape == (2, 768)  # (B, embed_dim)
 
     def test_panopticon_weights(self, mocked_weights: Panopticon_Weights) -> None:
-        model = panopticon_vitb14(weights=mocked_weights)
+        model = panopticon_vitb14(weights=mocked_weights, img_size=14)
         x_dict = {
-            'imgs': torch.randn(2, 3, 224, 224),
+            'imgs': torch.randn(2, 3, 14, 14),
             'chn_ids': torch.tensor([[664, 559, 493]]).repeat(2, 1),
         }
         normed_cls_token = model(x_dict)
@@ -93,9 +93,9 @@ class TestPanopticonBase:
     @pytest.mark.slow
     def test_panopticon_download(self, weights: Panopticon_Weights) -> None:
         """Test forward pass with weights loaded."""
-        model = panopticon_vitb14(weights)
+        model = panopticon_vitb14(weights, img_size=14)
         x_dict = {
-            'imgs': torch.randn(2, 3, 224, 224),
+            'imgs': torch.randn(2, 3, 14, 14),
             'chn_ids': torch.tensor([[664, 559, 493]]).repeat(2, 1),
         }
         normed_cls_token = model(x_dict)

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -55,9 +55,7 @@ class TestResNet18:
 
     def test_transforms(self, weights: ResNet18_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ResNet18_Weights) -> None:
@@ -65,7 +63,7 @@ class TestResNet18:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -109,9 +107,7 @@ class TestResNet50:
 
     def test_transforms(self, weights: ResNet50_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ResNet50_Weights) -> None:
@@ -119,7 +115,7 @@ class TestResNet50:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -163,9 +159,7 @@ class TestResNet152:
 
     def test_transforms(self, weights: ResNet152_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ResNet152_Weights) -> None:
@@ -173,7 +167,7 @@ class TestResNet152:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow

--- a/tests/models/test_scale_mae.py
+++ b/tests/models/test_scale_mae.py
@@ -31,8 +31,8 @@ class TestScaleMAE:
         scalemae_large_patch16()
 
     def test_scalemae_forward_pass(self) -> None:
-        model = scalemae_large_patch16(img_size=64, num_classes=2)
-        x = torch.randn(1, 3, 64, 64)
+        model = scalemae_large_patch16(img_size=32, num_classes=2)
+        x = torch.randn(1, 3, 32, 32)
         y = model(x)
         assert y.shape == (1, 2)
 
@@ -41,9 +41,7 @@ class TestScaleMAE:
 
     def test_transforms(self, weights: ScaleMAELarge16_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ScaleMAELarge16_Weights) -> None:
@@ -51,7 +49,7 @@ class TestScaleMAE:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     def test_scalemae_weights_diff_image_size(

--- a/tests/models/test_swin.py
+++ b/tests/models/test_swin.py
@@ -56,9 +56,7 @@ class TestSwin_T:
 
     def test_transforms(self, weights: Swin_T_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: Swin_T_Weights) -> None:
@@ -66,7 +64,7 @@ class TestSwin_T:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -107,9 +105,7 @@ class TestSwin_S:
 
     def test_transforms(self, weights: Swin_S_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: Swin_S_Weights) -> None:
@@ -117,7 +113,7 @@ class TestSwin_S:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -167,9 +163,7 @@ class TestSwin_B:
 
     def test_transforms(self, weights: Swin_B_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: Swin_B_Weights) -> None:
@@ -177,7 +171,7 @@ class TestSwin_B:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -218,9 +212,7 @@ class TestSwin_V2_T:
 
     def test_transforms(self, weights: Swin_V2_T_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: Swin_V2_T_Weights) -> None:
@@ -228,7 +220,7 @@ class TestSwin_V2_T:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -269,9 +261,7 @@ class TestSwin_V2_B:
 
     def test_transforms(self, weights: Swin_V2_B_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: Swin_V2_B_Weights) -> None:
@@ -279,7 +269,7 @@ class TestSwin_V2_B:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow

--- a/tests/models/test_tilenet.py
+++ b/tests/models/test_tilenet.py
@@ -65,7 +65,7 @@ class TestTileNet:
     def test_transforms(self, weights: TileNet_Weights) -> None:
         """Test that transforms run without error."""
         c = weights.meta['in_chans']
-        sample = {'image': torch.arange(c * 50 * 50, dtype=torch.float).view(c, 50, 50)}
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     @pytest.mark.slow

--- a/tests/models/test_unet.py
+++ b/tests/models/test_unet.py
@@ -50,9 +50,7 @@ class TestUnet:
 
     def test_transforms(self, weights: Unet_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: Unet_Weights) -> None:
@@ -60,7 +58,7 @@ class TestUnet:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 256, 256, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -66,9 +66,7 @@ class TestViTSmall16:
 
     def test_transforms(self, weights: ViTSmall16_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ViTSmall16_Weights) -> None:
@@ -76,7 +74,7 @@ class TestViTSmall16:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -123,9 +121,7 @@ class TestViTBase16:
 
     def test_transforms(self, weights: ViTBase16_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ViTBase16_Weights) -> None:
@@ -133,7 +129,7 @@ class TestViTBase16:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -180,9 +176,7 @@ class TestViTLarge16:
 
     def test_transforms(self, weights: ViTLarge16_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ViTLarge16_Weights) -> None:
@@ -190,7 +184,7 @@ class TestViTLarge16:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -237,9 +231,7 @@ class TestViTHuge14:
 
     def test_transforms(self, weights: ViTHuge14_Weights) -> None:
         c = weights.meta['in_chans']
-        sample = {
-            'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
-        }
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ViTHuge14_Weights) -> None:
@@ -247,7 +239,7 @@ class TestViTHuge14:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -297,12 +289,7 @@ class TestViTSmall14_DINOv2:
 
     def test_transforms(self, weights: ViTSmall14_DINOv2_Weights) -> None:
         c = weights.meta['in_chans']
-        img_size = weights.meta['img_size']
-        if isinstance(img_size, int):
-            h = w = img_size
-        else:
-            h, w = img_size
-        sample = {'image': torch.arange(c * h * w, dtype=torch.float).view(c, h, w)}
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ViTSmall14_DINOv2_Weights) -> None:
@@ -310,7 +297,7 @@ class TestViTSmall14_DINOv2:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow
@@ -358,12 +345,7 @@ class TestViTBase14_DINOv2:
 
     def test_transforms(self, weights: ViTBase14_DINOv2_Weights) -> None:
         c = weights.meta['in_chans']
-        img_size = weights.meta['img_size']
-        if isinstance(img_size, int):
-            h = w = img_size
-        else:
-            h, w = img_size
-        sample = {'image': torch.arange(c * h * w, dtype=torch.float).view(c, h, w)}
+        sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
         weights.transforms(sample)
 
     def test_export_transforms(self, weights: ViTBase14_DINOv2_Weights) -> None:
@@ -371,7 +353,7 @@ class TestViTBase14_DINOv2:
         torch = pytest.importorskip('torch', minversion='2.6.0')
         torch.compiler.reset()
         c = weights.meta['in_chans']
-        inputs = (torch.randn(1, c, 224, 224, dtype=torch.float),)
+        inputs = (torch.randn(1, c, 32, 32, dtype=torch.float),)
         torch.export.export(weights.transforms, inputs)
 
     @pytest.mark.slow

--- a/tests/tasks/test_change.py
+++ b/tests/tasks/test_change.py
@@ -263,9 +263,9 @@ class TestChangeDetection:
         model = ChangeDetection(
             model='changevit', backbone='vit_tiny_patch16_224', in_channels=4
         )
-        x = torch.randn(1, 2, 4, 256, 256)
+        x = torch.randn(1, 2, 4, 32, 32)
         y = model(x)
-        assert y.shape == (1, 1, 256, 256)
+        assert y.shape == (1, 1, 32, 32)
 
     def test_changevit_num_classes(self) -> None:
         """Test ChangeViT with multiclass segmentation."""
@@ -275,16 +275,16 @@ class TestChangeDetection:
             task='multiclass',
             num_classes=5,
         )
-        x = torch.randn(1, 2, 3, 256, 256)
+        x = torch.randn(1, 2, 3, 32, 32)
         y = model(x)
-        assert y.shape == (1, 5, 256, 256)
+        assert y.shape == (1, 5, 32, 32)
 
     def test_changevit_predict(self) -> None:
         """Test ChangeViT predict_step to ensure input is not rearranged."""
         model = ChangeDetection(model='changevit', backbone='vit_tiny_patch16_224')
-        batch = {'image': torch.randn(1, 2, 3, 256, 256)}
+        batch = {'image': torch.randn(1, 2, 3, 32, 32)}
         y = model.predict_step(batch, batch_idx=0)
-        assert y.shape == (1, 1, 256, 256)
+        assert y.shape == (1, 1, 32, 32)
 
     @pytest.mark.parametrize('loss_fn', ['bce', 'jaccard', 'focal', 'dice'])
     def test_losses(self, loss_fn: Literal['bce', 'jaccard', 'focal', 'dice']) -> None:

--- a/tests/tasks/test_detection.py
+++ b/tests/tasks/test_detection.py
@@ -134,6 +134,6 @@ class TestObjectDetection:
             in_channels=in_channels,
         )
         model.eval()
-        sample = [torch.randn(in_channels, 224, 224)]
+        sample = [torch.randn(in_channels, 32, 32)]
         with torch.inference_mode():
             model(sample)

--- a/tests/tasks/test_instance_segmentation.py
+++ b/tests/tasks/test_instance_segmentation.py
@@ -123,6 +123,6 @@ class TestInstanceSegmentation:
     def test_multispectral_support(self, in_channels: int) -> None:
         model = InstanceSegmentation(in_channels=in_channels, num_classes=2)
         model.eval()
-        sample = [torch.randn(in_channels, 224, 224)]
+        sample = [torch.randn(in_channels, 32, 32)]
         with torch.inference_mode():
             model(sample)

--- a/tests/tasks/test_segmentation.py
+++ b/tests/tasks/test_segmentation.py
@@ -295,7 +295,7 @@ class TestSemanticSegmentation:
     def test_predict_step_returns_dict(self) -> None:
         """Test that predict_step returns a dictionary."""
         task = SemanticSegmentation(task='multiclass', num_classes=10)
-        batch = {'image': torch.randn(2, 3, 64, 64)}
+        batch = {'image': torch.randn(2, 3, 32, 32)}
         result = task.predict_step(batch, 0)
 
         assert isinstance(result, dict)
@@ -303,7 +303,7 @@ class TestSemanticSegmentation:
     def test_predict_step_contains_required_keys(self) -> None:
         """Test that predict_step dict contains required keys."""
         task = SemanticSegmentation(task='multiclass', num_classes=10)
-        batch = {'image': torch.randn(2, 3, 64, 64)}
+        batch = {'image': torch.randn(2, 3, 32, 32)}
         result = task.predict_step(batch, 0)
 
         assert 'probabilities' in result
@@ -315,7 +315,7 @@ class TestSemanticSegmentation:
         num_classes = 10
         task = SemanticSegmentation(task='multiclass', num_classes=num_classes)
         batch_size = 2
-        height, width = 64, 64
+        height, width = 32, 32
         batch = {'image': torch.randn(batch_size, 3, height, width)}
         result = task.predict_step(batch, 0)
 
@@ -329,7 +329,7 @@ class TestSemanticSegmentation:
         bounds_tensor = torch.randn(2, 9)
         transform_tensor = torch.randn(2, 6)
         batch = {
-            'image': torch.randn(2, 3, 64, 64),
+            'image': torch.randn(2, 3, 32, 32),
             'bounds': bounds_tensor,
             'transform': transform_tensor,
         }


### PR DESCRIPTION
### Summary

Reduce spatial dimensions for tensors passed through models and preprocessing transforms in model and task tests. Most image inputs now use 32 x 32 pixels and patch-based models use their minimum patch size.

### Timing

| Test | Before | After | Change |
| --- | ---: | ---: | ---: |
| Local `tests/models tests/tasks` | 438.27 s | 416.11 s | 22.16 seconds faster |
| GitHub Actions | 8m 21s for Ubuntu latest 3.14 on this PR | [10m 15s for Ubuntu latest 3.14 on this recent PR](https://github.com/torchgeo/torchgeo/actions/runs/31970808604/job/95222879196?pr=3994)  | 114 seconds faster|


- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
