### PR TITLE
Add docs on sampler ROI

### DIFF
--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -52,7 +52,7 @@ The majority of spatial and temporal samplers have both random and sequential va
 Regions of Interest
 ^^^^^^^^^^^^^^^^^^^
 
-Spatial samplers use the full dataset footprint unless a :term:`region of interest (ROI)` is provided. The ``roi`` parameter accepts a Shapely polygon in the same CRS as the dataset. For example, the following sampler restricts Sentinel-2 patches to a 10 km by 10 km bounding box in UTM zone 11N:
+Spatial samplers use the full spatial extent of the dataset unless a :term:`region of interest (ROI)` is provided. The ``roi`` parameter accepts a Shapely geometry in the same CRS as the dataset. For example, the following sampler restricts Sentinel-2 patches to a 10 km by 10 km bounding box in UTM zone 11N, where coordinates are measured in meters:
 
 .. code-block:: python
 

--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -68,7 +68,7 @@ Spatial samplers use the full dataset footprint unless a :term:`region of intere
    dataloader = DataLoader(dataset, sampler=sampler)
 
 
-Reproject geometries to ``dataset.crs`` before using them as an ROI. The sampler intersects the ROI with the dataset footprint, so portions outside the dataset are ignored.
+Reproject geometries to ``dataset.crs`` before using them as an ROI. The sampler intersects the ROI with the dataset's spatial extent, so portions of the ROI outside the dataset are ignored.
 
 Temporal samplers provide an analogous ``toi`` parameter that accepts a :class:`pandas.Interval`. Spatial and temporal samplers can be combined with the ``@`` operator to restrict both the location and time range.
 

--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -52,17 +52,17 @@ The majority of spatial and temporal samplers have both random and sequential va
 Regions of Interest
 ^^^^^^^^^^^^^^^^^^^
 
-Spatial samplers use the full dataset footprint unless a :term:`region of interest (ROI)` is provided. The ``roi`` parameter accepts a Shapely polygon in the same CRS as the dataset. For example, the following sampler restricts patches to a 10 km by 10 km bounding box in a projected CRS with meter units:
+Spatial samplers use the full dataset footprint unless a :term:`region of interest (ROI)` is provided. The ``roi`` parameter accepts a Shapely polygon in the same CRS as the dataset. For example, the following sampler restricts Sentinel-2 patches to a 10 km by 10 km bounding box in UTM zone 11N:
 
 .. code-block:: python
 
    import shapely
    from torch.utils.data import DataLoader
 
-   from torchgeo.datasets import Landsat
+   from torchgeo.datasets import Sentinel2
    from torchgeo.samplers import RandomPatchSampler
 
-   dataset = Landsat(...)
+   dataset = Sentinel2('data/sentinel2', bands=['B02'])
    roi = shapely.box(500000, 4200000, 510000, 4210000)
    sampler = RandomPatchSampler(dataset, size=256, length=10000, roi=roi)
    dataloader = DataLoader(dataset, sampler=sampler)

--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -62,7 +62,7 @@ Spatial samplers use the full dataset footprint unless a :term:`region of intere
    from torchgeo.datasets import Sentinel2
    from torchgeo.samplers import RandomPatchSampler
 
-   dataset = Sentinel2('data/sentinel2', bands=['B02'])
+   dataset = Sentinel2(...)
    roi = shapely.box(500000, 4200000, 510000, 4210000)
    sampler = RandomPatchSampler(dataset, size=256, length=10000, roi=roi)
    dataloader = DataLoader(dataset, sampler=sampler)

--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -49,6 +49,29 @@ This data loader will iterate over all valid locations and all valid times, with
 
 The majority of spatial and temporal samplers have both random and sequential variants. Random variants are recommended at training time to maximize the diversity of the dataset, while sequential variants are recommended at inference time to ensure complete coverage of the dataset.
 
+Regions of Interest
+^^^^^^^^^^^^^^^^^^^
+
+Spatial samplers use the full dataset footprint unless a :term:`region of interest (ROI)` is provided. The ``roi`` parameter accepts a Shapely polygon in the same CRS as the dataset. For example, the following sampler restricts patches to a 10 km by 10 km bounding box in a projected CRS with meter units:
+
+.. code-block:: python
+
+   import shapely
+   from torch.utils.data import DataLoader
+
+   from torchgeo.datasets import Landsat
+   from torchgeo.samplers import RandomPatchSampler
+
+   dataset = Landsat(...)
+   roi = shapely.box(500000, 4200000, 510000, 4210000)
+   sampler = RandomPatchSampler(dataset, size=256, length=10000, roi=roi)
+   dataloader = DataLoader(dataset, sampler=sampler)
+
+
+Reproject geometries to ``dataset.crs`` before using them as an ROI. The sampler intersects the ROI with the dataset footprint, so portions outside the dataset are ignored.
+
+Temporal samplers provide an analogous ``toi`` parameter that accepts a :class:`pandas.Interval`. Spatial and temporal samplers can be combined with the ``@`` operator to restrict both the location and time range.
+
 Spatial Samplers
 ^^^^^^^^^^^^^^^^
 

--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -70,7 +70,7 @@ Spatial samplers use the full spatial extent of the dataset unless a :term:`regi
 
 Reproject geometries to ``dataset.crs`` before using them as an ROI. The sampler intersects the ROI with the dataset's spatial extent, so portions of the ROI outside the dataset are ignored.
 
-Temporal samplers provide an analogous ``toi`` parameter that accepts a :class:`pandas.Interval`. Spatial and temporal samplers can be combined with the ``@`` operator to restrict both the location and time range.
+Temporal samplers similarly accept a ``toi`` parameter containing a :class:`pandas.Interval`. Spatial and temporal samplers can be combined with the ``@`` operator to restrict sampling by both location and time.
 
 Spatial Samplers
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Summary

Add an example of restricting a dataset to a specific spatiotemporal region. Closes #653. See what it looks like at https://torchgeo--4000.org.readthedocs.build/en/4000/api/samplers.html#regions-of-interest

### Rationale

See https://github.com/torchgeo/torchgeo/issues/653 -- people have asked Adam about this since twenty twenty two!
I'm also going to be honest, I did this because I saw the current PR/Issue count was at 3999, would an AI do that?

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution