### PR TITLE
Basic Usage: change order of Embeddings tutorial

### DIFF
--- a/docs/tutorials/basic_usage.rst
+++ b/docs/tutorials/basic_usage.rst
@@ -6,9 +6,9 @@ The following tutorials introduce the basic concepts and components of TorchGeo:
 * `Transforms <transforms.ipynb>`_: Preprocessing and data augmentation transforms for geospatial data
 * `Spectral Indices <indices.ipynb>`_: Visualizing and appending spectral indices
 * `Pretrained Weights <pretrained_weights.ipynb>`_: Models and pretrained weights
-* `Embeddings <embeddings.ipynb>`_: Using pretrained models to extract fixed-length embeddings
 * `Lightning Tasks <tasks.ipynb>`_: PyTorch Lightning data modules and tasks
 * `Command-Line Interface <cli.ipynb>`_: TorchGeo's command-line interface
+* `Embeddings <embeddings.ipynb>`_: Using pretrained models to extract fixed-length embeddings
 
 .. toctree::
    :hidden:
@@ -17,6 +17,6 @@ The following tutorials introduce the basic concepts and components of TorchGeo:
    transforms
    indices
    pretrained_weights
-   embeddings
    tasks
    cli
+   embeddings


### PR DESCRIPTION
### Summary

Move Embeddings tutorial to the end of the Basic Usage list.

### Rationale

The Embeddings tutorial uses a Lightning datamodule, which isn't introduced until later tutorials. Alternative is to rewrite it without a datamodule.

@calebrob6 

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
