### PR TITLE
Set default std for all datamodules

### DIFF
--- a/torchgeo/datamodules/agrifieldnet.py
+++ b/torchgeo/datamodules/agrifieldnet.py
@@ -21,6 +21,8 @@ class AgriFieldNetDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/bright.py
+++ b/torchgeo/datamodules/bright.py
@@ -17,6 +17,8 @@ class BRIGHTDFC2025DataModule(NonGeoDataModule):
     .. versionadded:: 0.8
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 32, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/bright.py
+++ b/torchgeo/datamodules/bright.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import BRIGHTDFC2025
 from .geo import NonGeoDataModule

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -21,6 +21,8 @@ class ChesapeakeCVPRDataModule(GeoDataModule):
     and test sets.
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         train_splits: list[str],

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 import torch.nn.functional as F
 
 from ..datasets import ChesapeakeCVPR

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -5,6 +5,7 @@
 
 from typing import Any
 
+import torch
 from torch import Generator
 from torch.utils.data import random_split
 

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -15,6 +15,8 @@ from .geo import NonGeoDataModule
 class COWCCountingDataModule(NonGeoDataModule):
     """LightningDataModule implementation for the COWC Counting dataset."""
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -5,6 +5,7 @@
 
 from typing import Any
 
+import torch
 from torch.utils.data import Subset
 
 from ..datasets import TropicalCyclone

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -23,6 +23,8 @@ class TropicalCycloneDataModule(NonGeoDataModule):
         consistent with TropicalCyclone dataset.
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -20,6 +20,8 @@ class DeepGlobeLandCoverDataModule(NonGeoDataModule):
     Uses the train/test splits from the dataset.
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/digital_typhoon.py
+++ b/torchgeo/datamodules/digital_typhoon.py
@@ -21,6 +21,8 @@ class DigitalTyphoonDataModule(NonGeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     valid_split_types = ('time', 'typhoon_id')
 
     def __init__(

--- a/torchgeo/datamodules/digital_typhoon.py
+++ b/torchgeo/datamodules/digital_typhoon.py
@@ -7,6 +7,7 @@ import copy
 from collections import defaultdict
 from typing import Any
 
+import torch
 from torch.utils.data import Subset
 
 from ..datasets import DigitalTyphoon

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -5,6 +5,8 @@
 
 from typing import Any
 
+import torch
+
 from ..datasets import FAIR1M
 from .geo import NonGeoDataModule
 from .utils import collate_fn_detection

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -16,6 +16,8 @@ class FAIR1MDataModule(NonGeoDataModule):
     .. versionadded:: 0.2
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/fire_risk.py
+++ b/torchgeo/datamodules/fire_risk.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import FireRisk
 from .geo import NonGeoDataModule

--- a/torchgeo/datamodules/fire_risk.py
+++ b/torchgeo/datamodules/fire_risk.py
@@ -17,6 +17,8 @@ class FireRiskDataModule(NonGeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/geonrw.py
+++ b/torchgeo/datamodules/geonrw.py
@@ -23,6 +23,8 @@ class GeoNRWDataModule(NonGeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, size: int = 256, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/geonrw.py
+++ b/torchgeo/datamodules/geonrw.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch.utils.data import Subset
 
 from ..datasets import GeoNRW

--- a/torchgeo/datamodules/gid15.py
+++ b/torchgeo/datamodules/gid15.py
@@ -22,6 +22,8 @@ class GID15DataModule(NonGeoDataModule):
     .. versionadded:: 0.4
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import InriaAerialImageLabeling
 from ..samplers.utils import _to_tuple

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -21,6 +21,8 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
     .. versionadded:: 0.3
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/iobench.py
+++ b/torchgeo/datamodules/iobench.py
@@ -16,6 +16,8 @@ class IOBenchDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 32,

--- a/torchgeo/datamodules/iobench.py
+++ b/torchgeo/datamodules/iobench.py
@@ -5,6 +5,8 @@
 
 from typing import Any
 
+import torch
+
 from ..datasets import IOBench
 from ..samplers import GriddedPatchSampler, RandomPatchSampler
 from .geo import GeoDataModule

--- a/torchgeo/datamodules/l7irish.py
+++ b/torchgeo/datamodules/l7irish.py
@@ -21,6 +21,8 @@ class L7IrishDataModule(GeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 1,

--- a/torchgeo/datamodules/l8biome.py
+++ b/torchgeo/datamodules/l8biome.py
@@ -21,6 +21,8 @@ class L8BiomeDataModule(GeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 1,

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -17,6 +17,8 @@ class LandCoverAIDataModule(NonGeoDataModule):
     Uses the train/val/test splits from the dataset.
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
@@ -52,6 +54,8 @@ class LandCoverAI100DataModule(NonGeoDataModule):
 
     .. versionadded:: 0.7
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import LandCoverAI, LandCoverAI100
 from .geo import NonGeoDataModule

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -20,6 +20,8 @@ class LEVIRCDDataModule(NonGeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 8,

--- a/torchgeo/datamodules/loveda.py
+++ b/torchgeo/datamodules/loveda.py
@@ -5,6 +5,8 @@
 
 from typing import Any
 
+import torch
+
 from ..datasets import LoveDA
 from .geo import NonGeoDataModule
 

--- a/torchgeo/datamodules/loveda.py
+++ b/torchgeo/datamodules/loveda.py
@@ -17,6 +17,8 @@ class LoveDADataModule(NonGeoDataModule):
     .. versionadded:: 0.2
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 32, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import kornia.augmentation as K
 import shapely
+import torch
 from matplotlib.figure import Figure
 
 from ..datasets import (

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -29,6 +29,8 @@ class NAIPChesapeakeDataModule(GeoDataModule):
     Uses the train/val/test splits from the dataset.
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/pastis.py
+++ b/torchgeo/datamodules/pastis.py
@@ -21,6 +21,8 @@ class PASTISDataModule(NonGeoDataModule):
     .. versionadded:: 0.8
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 32,
@@ -83,6 +85,8 @@ class PASTIS100DataModule(NonGeoDataModule):
 
     .. versionadded:: 0.9
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self,

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -22,6 +22,8 @@ class Potsdam2DDataModule(NonGeoDataModule):
     .. versionadded:: 0.2
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/reforestree.py
+++ b/torchgeo/datamodules/reforestree.py
@@ -20,6 +20,8 @@ class ReforesTreeDataModule(NonGeoDataModule):
 
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_cdl.py
+++ b/torchgeo/datamodules/sentinel2_cdl.py
@@ -22,6 +22,8 @@ class Sentinel2CDLDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_eurocrops.py
+++ b/torchgeo/datamodules/sentinel2_eurocrops.py
@@ -24,6 +24,8 @@ class Sentinel2EuroCropsDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_nccm.py
+++ b/torchgeo/datamodules/sentinel2_nccm.py
@@ -22,6 +22,8 @@ class Sentinel2NCCMDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_south_america_soybean.py
+++ b/torchgeo/datamodules/sentinel2_south_america_soybean.py
@@ -23,6 +23,8 @@ class Sentinel2SouthAmericaSoybeanDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/skippd.py
+++ b/torchgeo/datamodules/skippd.py
@@ -21,6 +21,8 @@ class SKIPPDDataModule(NonGeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/southafricacroptype.py
+++ b/torchgeo/datamodules/southafricacroptype.py
@@ -21,6 +21,8 @@ class SouthAfricaCropTypeDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/spacenet.py
+++ b/torchgeo/datamodules/spacenet.py
@@ -23,6 +23,8 @@ class SpaceNetBaseDataModule(NonGeoDataModule):
     .. versionadded:: 0.7
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         spacenet_ds_class: type[SpaceNet],

--- a/torchgeo/datamodules/ssl4eo.py
+++ b/torchgeo/datamodules/ssl4eo.py
@@ -17,6 +17,8 @@ class SSL4EOLDataModule(NonGeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/ssl4eo_benchmark.py
+++ b/torchgeo/datamodules/ssl4eo_benchmark.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from kornia.constants import DataKey, Resample
 
 from ..datasets import SSL4EOLBenchmark

--- a/torchgeo/datamodules/ssl4eo_benchmark.py
+++ b/torchgeo/datamodules/ssl4eo_benchmark.py
@@ -19,6 +19,8 @@ class SSL4EOLBenchmarkDataModule(NonGeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/substation.py
+++ b/torchgeo/datamodules/substation.py
@@ -19,6 +19,8 @@ class SubstationDataModule(NonGeoDataModule):
     .. versionadded:: 0.7
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sustainbench_crop_yield.py
+++ b/torchgeo/datamodules/sustainbench_crop_yield.py
@@ -15,6 +15,8 @@ class SustainBenchCropYieldDataModule(NonGeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 32, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/sustainbench_crop_yield.py
+++ b/torchgeo/datamodules/sustainbench_crop_yield.py
@@ -5,6 +5,8 @@
 
 from typing import Any
 
+import torch
+
 from ..datasets import SustainBenchCropYield
 from .geo import NonGeoDataModule
 

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import UCMerced
 from .geo import NonGeoDataModule

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -17,6 +17,8 @@ class UCMercedDataModule(NonGeoDataModule):
     Uses random train/val/test splits.
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/usavars.py
+++ b/torchgeo/datamodules/usavars.py
@@ -5,6 +5,8 @@
 
 from typing import Any
 
+import torch
+
 from ..datasets import USAVars
 from .geo import NonGeoDataModule
 

--- a/torchgeo/datamodules/usavars.py
+++ b/torchgeo/datamodules/usavars.py
@@ -17,6 +17,8 @@ class USAVarsDataModule(NonGeoDataModule):
     .. versionadded:: 0.3
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -22,6 +22,8 @@ class Vaihingen2DDataModule(NonGeoDataModule):
     .. versionadded:: 0.2
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/xbd.py
+++ b/torchgeo/datamodules/xbd.py
@@ -22,6 +22,8 @@ class xBDDataModule(NonGeoDataModule):
     .. versionadded:: 0.2
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,


### PR DESCRIPTION
### Summary

Copies the current default standard deviation of 255 to all datamodules that do not explicitly override it. No behavior changes, although the current std may not be correct for all datasets.

### Rationale

Prerequisite for #2630 so we can merge it without breaking any existing datamodules. Note that all current datamodule PRs will also need to be updated. All user-defined datamodules will still break, meaning #2630 will be a backwards-incompatible breaking change.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
