### PR TITLE
Change Detection Tutorial: factor in GRSM revisions

### DIFF
--- a/docs/tutorials/change_detection.ipynb
+++ b/docs/tutorials/change_detection.ipynb
@@ -212,7 +212,9 @@
     "\n",
     "- Model checkpointing, that saves the best model based on a metric we define\n",
     "- Early stopping to prevent overfitting\n",
-    "- TensorBoard logs metrics for visualization"
+    "- TensorBoard logs metrics for visualization\n",
+    "\n",
+    "**A note on early stopping**: with only 20 validation samples, the validation F1 curve is noisy, so we train for at least 20 epochs (`min_epochs`) and use a generous `patience` of 20 epochs. A tighter patience can stop training long before the model has converged, which drastically hurts test performance.\n"
    ]
   },
   {
@@ -231,7 +233,7 @@
     "    save_last=True,\n",
     ")\n",
     "early_stopping_callback = EarlyStopping(\n",
-    "    monitor='val_AverageF1Score', mode='max', min_delta=0.0, patience=10\n",
+    "    monitor='val_AverageF1Score', mode='max', min_delta=0.0, patience=20\n",
     ")\n",
     "logger = TensorBoardLogger(save_dir=default_root_dir, name='change_detection_logs')"
    ]
@@ -248,7 +250,7 @@
     "    fast_dev_run=fast_dev_run,\n",
     "    log_every_n_steps=1,\n",
     "    logger=logger,\n",
-    "    min_epochs=1,\n",
+    "    min_epochs=20,\n",
     "    max_epochs=max_epochs,\n",
     ")"
    ]
@@ -351,7 +353,7 @@
    "cell_type": "markdown",
    "id": "27",
    "metadata": {},
-   "source": "## Interpreting the Results\n\nWith BTC (swin_tiny) and a frozen backbone you should expect:\n\n- **Accuracy**: ~93–95%\n- **F1 Score**: ~0.55–0.65\n- **IoU (Jaccard Index)**: ~0.40–0.50\n\nChange detection is hard due to class imbalance as most pixels show no change, especially on such a small toy dataset. We set a random seed to improve reproducibility, but results may vary slightly between runs, as Swin Transformer's attention uses CUDA kernels that have no deterministic implementation.\n\n## To Go Further\n\n- Train on the full [OSCD](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html) dataset (24 city pairs) with full resolution\n- Train for 100+ epochs with a learning rate scheduler\n- Try a larger backbone (`swin_small`, `swin_base`) for higher capacity\n- Use all 13 Sentinel-2 bands with S2 pretrained weights — requires a `swin_v2_b` backbone with `Swin_V2_B_Weights.SENTINEL2_MI_MS_SATLAS`"
+   "source": "## Interpreting the Results\n\nWith BTC (swin_tiny) and a frozen backbone you should expect:\n\n- **Accuracy**: ~93–96%\n- **F1 Score**: ~0.55–0.65\n- **IoU (Jaccard Index)**: ~0.40–0.50\n\nChange detection is hard due to class imbalance as most pixels show no change, especially on such a small toy dataset. We set a random seed to improve reproducibility, but results may vary slightly between runs, as Swin Transformer's attention uses CUDA kernels that have no deterministic implementation.\n\n## To Go Further\n\n- Train on the full [OSCD](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html) dataset (24 city pairs) with full resolution\n- Train for 100+ epochs with a learning rate scheduler\n- Try a larger backbone (`swin_small`, `swin_base`) for higher capacity\n- Use all 13 Sentinel-2 bands with S2 pretrained weights — requires a `swin_v2_b` backbone with `Swin_V2_B_Weights.SENTINEL2_MI_MS_SATLAS`"
   }
  ],
  "metadata": {

--- a/docs/tutorials/change_detection.ipynb
+++ b/docs/tutorials/change_detection.ipynb
@@ -15,7 +15,25 @@
    "cell_type": "markdown",
    "id": "1",
    "metadata": {},
-   "source": "# Change Detection\n_Written by: Harald Kristen_\n\nIn this tutorial, we demonstrate how to train a change detection model using TorchGeo.\n\n**What is Change Detection**:\nChange detection is the process of identifying differences between images of the same location captured at different times. It is a fundamental task in remote sensing with numerous real-world applications:\n\n- **Urban Monitoring**: Track city growth, new construction, and infrastructure development\n- **Disaster Response**: Assess damage from floods, earthquakes, wildfires, and tropical cyclones\n- **Deforestation Tracking**: Monitor illegal logging and forest loss\n- **Agriculture**: Detect crop changes, irrigation patterns, and land use shifts\n- **Environmental Monitoring**: Track glacial retreat, coastal erosion, and wetland changes\n\nIn this tutorial, we will train a binary change detection model on the [OSCD100](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html#torchgeo.datasets.OSCD100) dataset to detect urban changes in bi-temporal Sentinel-2 imagery. Our model will learn to identify where new buildings have been constructed or existing ones removed.\n\nIt is recommended to run this notebook on Google Colab if you do not have your own GPU. Click the \"Open in Colab\" button above to get started."
+   "source": [
+    "# Change Detection\n",
+    "_Written by: Harald Kristen_\n",
+    "\n",
+    "In this tutorial, we demonstrate how to train a change detection model using TorchGeo.\n",
+    "\n",
+    "**What is Change Detection**:\n",
+    "Change detection is the process of identifying differences between images of the same location captured at different times. It is a fundamental task in remote sensing with numerous real-world applications:\n",
+    "\n",
+    "- **Urban Monitoring**: Track city growth, new construction, and infrastructure development\n",
+    "- **Disaster Response**: Assess damage from floods, earthquakes, wildfires, and tropical cyclones\n",
+    "- **Deforestation Tracking**: Monitor illegal logging and forest loss\n",
+    "- **Agriculture**: Detect crop changes, irrigation patterns, and land use shifts\n",
+    "- **Environmental Monitoring**: Track glacial retreat, coastal erosion, and wetland changes\n",
+    "\n",
+    "In this tutorial, we will train a binary change detection model on the [OSCD100](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html#torchgeo.datasets.OSCD100) dataset to detect urban changes in bi-temporal Sentinel-2 imagery. Our model will learn to identify where new buildings have been constructed or existing ones removed.\n",
+    "\n",
+    "It is recommended to run this notebook on Google Colab if you do not have your own GPU. Click the \"Open in Colab\" button above to get started."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -84,7 +102,7 @@
     "\n",
     "Let's download the dataset and look at some examples from OSCD100.\n",
     "\n",
-    "**About OSCD100**: This is a smaller, downsampled version of the full [OSCD](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html#torchgeo.datasets.OSCD) (Onera Satellite Change Detection) dataset. It is designed for tutorials and quick experimentation. It contains 100 image pairs at 256×256 resolution with 60 training, 20 validation, and 20 test samples.\n",
+    "**About OSCD100**: This is a smaller, downsampled version of the full [OSCD](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html#torchgeo.datasets.OSCD) (Onera Satellite Change Detection) dataset. It is designed for tutorials and quick experimentation. It contains 100 image pairs at 256\u00d7256 resolution with 60 training, 20 validation, and 20 test samples.\n",
     "\n",
     "Each sample contains all 13 Sentinel-2 spectral bands, though we only use the RGB bands for simplicity in this notebook. For research and benchmarking, use the full OSCD dataset."
    ]
@@ -115,7 +133,14 @@
    "cell_type": "markdown",
    "id": "8",
    "metadata": {},
-   "source": "## Lightning Modules\n\nTorchGeo uses [PyTorch Lightning](https://lightning.ai/docs/pytorch/stable/) to organize the training code and set up the data loader. The `OSCD100DataModule`:\n1. Downloads the data\n2. Sets up train, validation, and test data loaders\n3. Applies preprocessing and augmentation"
+   "source": [
+    "## Lightning Modules\n",
+    "\n",
+    "TorchGeo uses [PyTorch Lightning](https://lightning.ai/docs/pytorch/stable/) to organize the training code and set up the data loader. The `OSCD100DataModule`:\n",
+    "1. Downloads the data\n",
+    "2. Sets up train, validation, and test data loaders\n",
+    "3. Applies preprocessing and augmentation"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -180,7 +205,44 @@
    "cell_type": "markdown",
    "id": "14",
    "metadata": {},
-   "source": "We use [**BTC** (Be The Change)](https://docs.torchgeo.org/en/stable/api/models/btc.html), a change-detection-specific architecture that uses a [Swin Transformer](https://arxiv.org/abs/2103.14030) backbone pretrained on [Cityscapes](https://www.cityscapes-dataset.com/) followed by a [UPerNet](https://arxiv.org/abs/1807.10221) decoder. Unlike general segmentation models that simply concatenate both images into a single tensor, BTC processes them through separate encoder paths and fuses temporal features in a change-aware way.\n\nKey configuration choices:\n- RGB bands (`in_channels=3`): Red, Green, Blue for a fast tutorial training experiment\n- `weights=True`: Load Cityscapes-pretrained Swin-Tiny encoder\n- `freeze_backbone=True`: Freeze the pretrained encoder and only fine-tune the decoder head — faster convergence and less overfitting on this small dataset\n- `pos_weight=10.0`: Upweights the change class to counter severe class imbalance — most pixels show no change\n- `lr=0.0001`: Use a small learning rate since we already have a pre-trained model\n- `loss='bce'`: Binary cross-entropy loss\n\nFor other supported models and backbones, check the [tasks documentation](https://docs.torchgeo.org/en/stable/api/tasks.html#torchgeo.tasks.ChangeDetection)."
+   "source": [
+    "We use [**BTC** (Be The Change)](https://docs.torchgeo.org/en/stable/api/models/btc.html), a change-detection-specific architecture that uses a [Swin Transformer](https://arxiv.org/abs/2103.14030) backbone pretrained on [Cityscapes](https://www.cityscapes-dataset.com/) followed by a [UPerNet](https://arxiv.org/abs/1807.10221) decoder. Unlike general segmentation models that simply concatenate both images into a single tensor, BTC processes them through separate encoder paths and fuses temporal features in a change-aware way.\n",
+    "\n",
+    "**Why a Cityscapes-pretrained backbone for satellite imagery?** Since we train on the three RGB bands, the input modality matches the RGB encoder exactly, so no spectral adaptation is needed. Cityscapes pretraining is dense-prediction pretraining on urban scenes, which transfers well to detecting urban change, and it is the pretraining used by the original BTC authors. If you instead train on all 13 Sentinel-2 bands, you should pick an encoder pretrained on multispectral satellite imagery, such as the Sentinel-2 Satlas weights shown in *To Go Further* below.\n",
+    "\n",
+    "Key configuration choices:\n",
+    "- RGB bands (`in_channels=3`): Red, Green, Blue for a fast tutorial training experiment\n",
+    "- `weights=True`: Load Cityscapes-pretrained Swin-Tiny encoder\n",
+    "- `freeze_backbone=True`: Freeze the pretrained encoder and only fine-tune the decoder head, for faster convergence and less overfitting on this small dataset\n",
+    "- `pos_weight=10.0`: Upweights the change class to counter severe class imbalance, since most pixels show no change\n",
+    "- `lr=0.0001`: Use a small learning rate since we already have a pre-trained model\n",
+    "- `loss='bce'`: Binary cross-entropy loss\n",
+    "\n",
+    "For other supported models and backbones, check the [tasks documentation](https://docs.torchgeo.org/en/stable/api/tasks.html#torchgeo.tasks.ChangeDetection).\n",
+    "\n",
+    "**How was `pos_weight` chosen?** A common starting point is the negative-to-positive class ratio of the training set, which balances both classes in the loss. Let's compute it:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "masks = torch.cat([sample['mask'].flatten() for sample in dataset])\n",
+    "num_neg = (masks == 0).sum().item()\n",
+    "num_pos = (masks == 1).sum().item()\n",
+    "print(f'no-change : change = {num_neg / num_pos:.1f} : 1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14b",
+   "metadata": {},
+   "source": [
+    "The heuristic suggests a value around 19. In practice it should be treated as an upper bound to tune from: on OSCD100 the full ratio overweights the change class and produces many false positives, and we found that a slightly lower value of 10.0 yields a better precision/recall trade-off and a higher validation F1 score.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -259,7 +321,9 @@
    "cell_type": "markdown",
    "id": "19",
    "metadata": {},
-   "source": "**Note**: With a frozen backbone, training completes in ~50 seconds using ~2GB VRAM of your GPU."
+   "source": [
+    "**Note**: With a frozen backbone, training completes in ~50 seconds using ~2GB VRAM of your GPU."
+   ]
   },
   {
    "cell_type": "code",
@@ -282,7 +346,7 @@
     "\n",
     "**In Google Colab**, run the cell below to launch TensorBoard inline.\n",
     "\n",
-    "**Locally**, run from your terminal `tensorboard --logdir /tmp/experiments` and navigate to https://localhost:6006"
+    "**Locally**, run from your terminal `tensorboard --logdir /tmp/experiments` and navigate to http://localhost:6006"
    ]
   },
   {
@@ -326,7 +390,11 @@
    "cell_type": "markdown",
    "id": "25",
    "metadata": {},
-   "source": "## Visualize Predictions\n\nLet's visualize predictions on the test set. We create a fresh dataset (without the random crop augmentation the datamodule applies) so predictions align with the full 256×256 ground truth masks. We add the predicted mask to each sample and pass it to the dataset's built-in `plot()` method."
+   "source": [
+    "## Visualize Predictions\n",
+    "\n",
+    "Let's visualize predictions on the test set. We create a fresh dataset (without the random crop augmentation the datamodule applies) so predictions align with the full 256\u00d7256 ground truth masks. To get an honest picture of model performance rather than cherry-picked examples, we compute the IoU of every test sample and plot the best, median, and worst predictions. We add the predicted mask to each sample and pass it to the dataset's built-in `plot()` method.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -339,13 +407,25 @@
     "\n",
     "task.eval()\n",
     "\n",
-    "for idx in [1, 7, 13]:\n",
+    "results = []\n",
+    "for idx in range(len(viz_dataset)):\n",
     "    sample = viz_dataset[idx]\n",
     "    normed = datamodule.aug({'image': sample['image'].float().unsqueeze(0)})['image']\n",
     "    with torch.no_grad():\n",
     "        prob = task.predict_step({'image': normed.to(task.device)}, 0).squeeze().cpu()\n",
-    "    sample['prediction'] = (prob > 0.5).float().unsqueeze(0)\n",
-    "    fig = viz_dataset.plot(sample, suptitle=f'Test Sample {idx}')\n",
+    "    pred = prob > 0.5\n",
+    "    gt = sample['mask'].bool()\n",
+    "    union = (pred | gt).sum().item()\n",
+    "    iou = (pred & gt).sum().item() / union if union else 1.0\n",
+    "    results.append((iou, idx, sample, pred))\n",
+    "\n",
+    "results.sort(key=lambda r: r[0])\n",
+    "ranks = [(len(results) - 1, 'Best'), (len(results) // 2, 'Median'), (0, 'Worst')]\n",
+    "for pos, label in ranks:\n",
+    "    iou, idx, sample, pred = results[pos]\n",
+    "    sample['prediction'] = pred.float().unsqueeze(0)\n",
+    "    title = f'{label} IoU = {iou:.2f} (Test Sample {idx})'\n",
+    "    fig = viz_dataset.plot(sample, suptitle=title)\n",
     "    plt.show()"
    ]
   },
@@ -353,12 +433,29 @@
    "cell_type": "markdown",
    "id": "27",
    "metadata": {},
-   "source": "## Interpreting the Results\n\nWith BTC (swin_tiny) and a frozen backbone you should expect:\n\n- **Accuracy**: ~93–96%\n- **F1 Score**: ~0.55–0.65\n- **IoU (Jaccard Index)**: ~0.40–0.50\n\nChange detection is hard due to class imbalance as most pixels show no change, especially on such a small toy dataset. We set a random seed to improve reproducibility, but results may vary slightly between runs, as Swin Transformer's attention uses CUDA kernels that have no deterministic implementation.\n\n## To Go Further\n\n- Train on the full [OSCD](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html) dataset (24 city pairs) with full resolution\n- Train for 100+ epochs with a learning rate scheduler\n- Try a larger backbone (`swin_small`, `swin_base`) for higher capacity\n- Use all 13 Sentinel-2 bands with S2 pretrained weights — requires a `swin_v2_b` backbone with `Swin_V2_B_Weights.SENTINEL2_MI_MS_SATLAS`"
+   "source": [
+    "## Interpreting the Results\n",
+    "\n",
+    "With BTC (swin_tiny) and a frozen backbone you should expect:\n",
+    "\n",
+    "- **Accuracy**: ~93\u201396%\n",
+    "- **F1 Score**: ~0.55\u20130.65\n",
+    "- **IoU (Jaccard Index)**: ~0.40\u20130.50\n",
+    "\n",
+    "Change detection is hard due to class imbalance as most pixels show no change, especially on such a small toy dataset. We set a random seed to improve reproducibility, but results may vary slightly between runs, as Swin Transformer's attention uses CUDA kernels that have no deterministic implementation.\n",
+    "\n",
+    "## To Go Further\n",
+    "\n",
+    "- Train on the full [OSCD](https://docs.torchgeo.org/en/stable/api/datasets/oscd.html) dataset (24 city pairs) with full resolution\n",
+    "- Train for 100+ epochs with a learning rate scheduler\n",
+    "- Try a larger backbone (`swin_small`, `swin_base`) for higher capacity\n",
+    "- Use all 13 Sentinel-2 bands with S2 pretrained weights, which requires a `swin_v2_b` backbone with `Swin_V2_B_Weights.SENTINEL2_MI_MS_SATLAS`"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "torchgeo-dev-py313",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -372,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Summary

Fixes premature early stopping that silently degraded test performance and adds reviewer-requested explanations for the pos_weight and backbone choices we did. Visualization now ranks test predictions by IoU (best/median/worst) instead of showing only cherry-picked samples.

### Rationale

The tutorial's early stopping (patience=10, min_epochs=1) could halt training before epoch 10 on the noisy 20-sample validation curve, producing much worse test metrics than reported. This also addresses GRSM reviewer feedback requesting justification for the Cityscapes backbone choice and the pos_weight=10 hyperparameter.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
