### PR TITLE
test: mark memory-intensive model tests, run them in bfloat16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ filterwarnings = [
 ]
 markers = [
     "slow: marks tests as slow",
+    "xdist_group: marks tests to run on the same pytest-xdist worker",
 ]
 norecursedirs = [
     ".ipynb_checkpoints",

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1,10 +1,32 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
+import os
+from collections.abc import Iterator
+
 import pytest
+import torch
 from _pytest.fixtures import SubRequest
 
 
 @pytest.fixture(params=[True, False])
 def features_only(request: SubRequest) -> bool:
     return bool(request.param)
+
+
+@pytest.fixture(autouse=True)
+def set_precision(request: SubRequest) -> Iterator[None]:
+    previous_dtype = torch.get_default_dtype()
+    group = request.node.get_closest_marker('xdist_group')
+
+    if (
+        os.environ.get('TORCHGEO_USE_BFLOAT16') == 'true'
+        and group is not None
+        and group.args == ('memory_intensive',)
+    ):
+        torch.set_default_dtype(torch.bfloat16)
+
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(previous_dtype)

--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -5,6 +5,7 @@ import enum
 from collections.abc import Callable
 
 import pytest
+from _pytest.mark.structures import ParameterSet
 from torch import nn
 from torchvision.models._api import WeightsEnum
 
@@ -78,14 +79,16 @@ from torchgeo.models import (
     vit_small_patch16_224,
 )
 
+memory_intensive = pytest.mark.xdist_group('memory_intensive')
+
 builders = [
-    aurora_swin_unet,
+    pytest.param(aurora_swin_unet, marks=memory_intensive),
     copernicusfm_base,
     croma_base,
-    croma_large,
+    pytest.param(croma_large, marks=memory_intensive),
     deo_base,
     dofa_base_patch16_224,
-    dofa_huge_patch14_224,
+    pytest.param(dofa_huge_patch14_224, marks=memory_intensive),
     dofa_large_patch16_224,
     dofa_small_patch16_224,
     earthloc,
@@ -97,7 +100,7 @@ builders = [
     resnet50,
     resnet152,
     satclip,
-    scalemae_large_patch16,
+    pytest.param(scalemae_large_patch16, marks=memory_intensive),
     swin_t,
     swin_s,
     swin_b,
@@ -108,8 +111,8 @@ builders = [
     unet,
     vit_base_patch14_dinov2,
     vit_base_patch16_224,
-    vit_huge_patch14_224,
-    vit_large_patch16_224,
+    pytest.param(vit_huge_patch14_224, marks=memory_intensive),
+    pytest.param(vit_large_patch16_224, marks=memory_intensive),
     vit_small_patch14_dinov2,
     vit_small_patch16_224,
 ]
@@ -181,7 +184,10 @@ def test_get_weight(enum: type[WeightsEnum]) -> None:
 
 
 def test_list_models() -> None:
-    models = [builder.__name__ for builder in builders]
+    models = [
+        (builder.values[0] if isinstance(builder, ParameterSet) else builder).__name__
+        for builder in builders
+    ]
     assert set(models) == set(list_models())
 
 

--- a/tests/models/test_aurora.py
+++ b/tests/models/test_aurora.py
@@ -14,6 +14,7 @@ from torchgeo.models import Aurora_Weights, aurora_swin_unet
 pytest.importorskip('aurora')
 
 
+@pytest.mark.xdist_group('memory_intensive')
 class TestAurora:
     @pytest.fixture(params=[*Aurora_Weights])
     def weights(self, request: SubRequest) -> Aurora_Weights:

--- a/tests/models/test_croma.py
+++ b/tests/models/test_croma.py
@@ -65,6 +65,10 @@ class TestCROMA:
         match: str,
     ) -> None:
         model = CROMA(image_size=8)
+        if sar_images is not None:
+            sar_images = sar_images.to(torch.get_default_dtype())
+        if optical_images is not None:
+            optical_images = optical_images.to(torch.get_default_dtype())
         with pytest.raises(ValueError, match=match):
             model(sar_images, optical_images)
 
@@ -96,6 +100,7 @@ class TestCROMABase:
         croma_base(weights=weights)
 
 
+@pytest.mark.xdist_group('memory_intensive')
 class TestCROMALarge:
     @pytest.fixture(params=[*CROMALarge_Weights])
     def weights(self, request: SubRequest) -> CROMALarge_Weights:

--- a/tests/models/test_dofa.py
+++ b/tests/models/test_dofa.py
@@ -161,6 +161,7 @@ class TestDOFALarge16:
         dofa_large_patch16_224(weights=weights)
 
 
+@pytest.mark.xdist_group('memory_intensive')
 class TestDOFAHuge14:
     def test_dofa(self) -> None:
         model = dofa_huge_patch14_224(img_size=14)

--- a/tests/models/test_scale_mae.py
+++ b/tests/models/test_scale_mae.py
@@ -11,6 +11,7 @@ from pytest import MonkeyPatch
 from torchgeo.models import ScaleMAELarge16_Weights, scalemae_large_patch16
 
 
+@pytest.mark.xdist_group('memory_intensive')
 class TestScaleMAE:
     @pytest.fixture(params=[*ScaleMAELarge16_Weights])
     def weights(self, request: SubRequest) -> ScaleMAELarge16_Weights:

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -137,6 +137,7 @@ class TestViTBase16:
         vit_base_patch16_224(weights=weights)
 
 
+@pytest.mark.xdist_group('memory_intensive')
 class TestViTLarge16:
     @pytest.fixture(params=[*ViTLarge16_Weights])
     def weights(self, request: SubRequest) -> ViTLarge16_Weights:
@@ -192,6 +193,7 @@ class TestViTLarge16:
         vit_large_patch16_224(weights=weights)
 
 
+@pytest.mark.xdist_group('memory_intensive')
 class TestViTHuge14:
     @pytest.fixture(params=[*ViTHuge14_Weights])
     def weights(self, request: SubRequest) -> ViTHuge14_Weights:


### PR DESCRIPTION
Split out of #3300. Marks memory-intensive model tests directly (`xdist_group('memory_intensive')`) instead of matching test names in `tests/conftest.py`, and runs them in bfloat16 when `TORCHGEO_USE_BFLOAT16=true`.

### Checklist

- [x] I have read the Contributing docs
- [x] I have read the AI policy
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
