### PR TITLE
Standardize augmentation pipeline names across SSL tasks

### DIFF
--- a/tests/conf/ssl4eo_l_moco_1.yaml
+++ b/tests/conf/ssl4eo_l_moco_1.yaml
@@ -8,12 +8,13 @@ model:
     temperature: 0.07
     memory_bank_size: 10
     moco_momentum: 0.999
-    augmentation1:
-      class_path: kornia.augmentation.RandomResizedCrop
-      init_args:
-        size:
-          - 224
-          - 224
+    augmentations:
+      - class_path: kornia.augmentation.RandomResizedCrop
+        init_args:
+          size:
+            - 224
+            - 224
+      - null
 data:
   class_path: SSL4EOLDataModule
   init_args:

--- a/tests/tasks/test_byol.py
+++ b/tests/tasks/test_byol.py
@@ -33,10 +33,62 @@ class TestBYOLModule:
         ).requires_grad_()
         model.conv1 = new_layer
         augment_fn = SimCLRAugmentation((2, 2))
-        BYOLModule(model, augment_fn=augment_fn)
+        with pytest.warns(DeprecationWarning, match='augment_fn'):
+            module = BYOLModule(model, augment_fn=augment_fn)
+        with pytest.warns(DeprecationWarning, match='augment'):
+            assert module.augment is augment_fn
+        replacement = SimCLRAugmentation((2, 2))
+        with pytest.warns(DeprecationWarning, match='augment'):
+            module.augment = replacement
+        assert module.augmentations is replacement
+
+    def test_custom_augmentations(self) -> None:
+        model = resnet18()
+        augmentations = SimCLRAugmentation((32, 32))
+        module = BYOLModule(
+            model, image_size=(32, 32), in_channels=3, augmentations=augmentations
+        )
+        assert module.augmentations is augmentations
+
+    def test_conflicting_augmentations(self) -> None:
+        model = resnet18()
+        augmentations = SimCLRAugmentation((32, 32))
+        with pytest.raises(ValueError, match='cannot be combined'):
+            BYOLModule(
+                model,
+                image_size=(32, 32),
+                in_channels=3,
+                augmentations=augmentations,
+                augment_fn=augmentations,
+            )
+
+    def test_load_legacy_augmentation_state_dict(self) -> None:
+        def create_module() -> BYOLModule:
+            return BYOLModule(
+                resnet18(),
+                image_size=(32, 32),
+                in_channels=3,
+                augmentations=nn.BatchNorm2d(3),
+            )
+
+        module = create_module()
+        legacy_state_dict = {
+            key.replace('augmentations.', 'augment.'): value
+            for key, value in module.state_dict().items()
+        }
+
+        create_module().load_state_dict(legacy_state_dict)
 
 
 class TestBYOL:
+    def test_custom_augmentations(self) -> None:
+        augmentations = nn.Identity()
+        task = BYOL(model='resnet18', augmentations=augmentations)
+        assert task.augmentations is augmentations
+        replacement = nn.Identity()
+        task.augmentations = replacement
+        assert task.model.augmentations is replacement
+
     @pytest.mark.parametrize(
         'name',
         [

--- a/tests/tasks/test_mae.py
+++ b/tests/tasks/test_mae.py
@@ -73,6 +73,38 @@ class TestMAE:
 
         main(['fit', *args])
 
+    def test_custom_augmentations(self) -> None:
+        augmentations = torch.nn.Identity()
+        task = MAE(augmentations=augmentations)
+        assert task.augmentations is augmentations
+
+    def test_deprecated_transform(self) -> None:
+        transform = torch.nn.Identity()
+        with pytest.warns(DeprecationWarning, match='transform'):
+            task = MAE(transform=transform)
+        with pytest.warns(DeprecationWarning, match='transform'):
+            assert task.transform is transform
+        replacement = torch.nn.Identity()
+        with pytest.warns(DeprecationWarning, match='transform'):
+            task.transform = replacement
+        assert task.augmentations is replacement
+
+    def test_conflicting_augmentations(self) -> None:
+        with pytest.raises(ValueError, match='cannot be combined'):
+            MAE(augmentations=torch.nn.Identity(), transform=torch.nn.Identity())
+
+    def test_load_legacy_augmentation_state_dict(self) -> None:
+        def create_task() -> MAE:
+            return MAE(augmentations=torch.nn.BatchNorm2d(3))
+
+        task = create_task()
+        legacy_state_dict = {
+            key.replace('augmentations.', 'transform.'): value
+            for key, value in task.state_dict().items()
+        }
+
+        create_task().load_state_dict(legacy_state_dict)
+
     @pytest.fixture
     def weights(self) -> WeightsEnum:
         return ViTSmall16_Weights.SENTINEL2_ALL_MAE

--- a/tests/tasks/test_moco.py
+++ b/tests/tasks/test_moco.py
@@ -81,8 +81,50 @@ class TestMoCo:
     def test_grayscale_weights_tensor(self) -> None:
         weights = torch.ones(4)
         task = MoCo(in_channels=4, grayscale_weights=weights)
-        assert task.augmentation1 is not None
-        assert task.augmentation2 is not None
+        assert len(task.augmentations) == 2
+
+    def test_custom_augmentations(self) -> None:
+        augmentations = (torch.nn.Identity(), torch.nn.Identity())
+        task = MoCo(augmentations=augmentations)
+        assert task.augmentations[0] is augmentations[0]
+        assert task.augmentations[1] is augmentations[1]
+
+    def test_partial_custom_augmentations(self) -> None:
+        augmentation = torch.nn.Identity()
+        task = MoCo(augmentations=(augmentation, None))
+        assert task.augmentations[0] is augmentation
+        assert task.augmentations[1] is not None
+
+    def test_load_legacy_augmentation_state_dict(self) -> None:
+        task = MoCo()
+        state_dict = task.state_dict()
+        legacy_state_dict = {
+            key.replace('augmentations.0.', 'augmentation1.').replace(
+                'augmentations.1.', 'augmentation2.'
+            ): value
+            for key, value in state_dict.items()
+        }
+
+        task.load_state_dict(legacy_state_dict)
+
+    def test_deprecated_augmentations(self) -> None:
+        augmentation1 = torch.nn.Identity()
+        augmentation2 = torch.nn.Identity()
+        with pytest.warns(DeprecationWarning, match='augmentation1'):
+            task = MoCo(augmentation1=augmentation1, augmentation2=augmentation2)
+        with pytest.warns(DeprecationWarning, match='augmentation1'):
+            assert task.augmentation1 is augmentation1
+        with pytest.warns(DeprecationWarning, match='augmentation2'):
+            assert task.augmentation2 is augmentation2
+        replacement = torch.nn.Identity()
+        with pytest.warns(DeprecationWarning, match='augmentation1'):
+            task.augmentation1 = replacement
+        assert task.augmentations[0] is replacement
+
+    def test_conflicting_augmentations(self) -> None:
+        augmentations = (torch.nn.Identity(), torch.nn.Identity())
+        with pytest.raises(ValueError, match='cannot be combined'):
+            MoCo(augmentations=augmentations, augmentation1=torch.nn.Identity())
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:

--- a/torchgeo/tasks/byol.py
+++ b/torchgeo/tasks/byol.py
@@ -314,7 +314,7 @@ class BYOLModule(nn.Module):
 
     @augment.setter
     def augment(self, value: nn.Module) -> None:
-        self.augmentations = value
+        self.augmentations = value  # pragma: no cover
 
     def __setattr__(self, name: str, value: Tensor | nn.Module) -> None:
         """Set an attribute, resolving the deprecated augmentation alias."""
@@ -434,13 +434,11 @@ class BYOL(BaseTask):
 
     @augmentations.setter
     def augmentations(self, value: nn.Module) -> None:
-        self.model.augmentations = value
+        self.model.augmentations = value  # pragma: no cover
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Set an attribute, forwarding augmentations to the BYOL model."""
         if name == 'augmentations' and 'model' in self.__dict__.get('_modules', {}):
-            if not isinstance(value, nn.Module):
-                raise TypeError('augmentations must be an nn.Module')
             self.model.augmentations = value
             return
         super().__setattr__(name, value)

--- a/torchgeo/tasks/byol.py
+++ b/torchgeo/tasks/byol.py
@@ -5,6 +5,7 @@
 
 import copy
 import os
+import warnings
 from typing import Any
 
 import timm
@@ -214,6 +215,9 @@ class BYOLModule(nn.Module):
 
     See https://arxiv.org/abs/2006.07733 for more details (and please cite it if you
     use it in your own work).
+
+    .. versionchanged:: 0.11
+       The augmentation pipeline is now exposed through *augmentations*.
     """
 
     def __init__(
@@ -224,8 +228,9 @@ class BYOLModule(nn.Module):
         in_channels: int = 4,
         projection_size: int = 256,
         hidden_size: int = 4096,
-        augment_fn: nn.Module | None = None,
+        augmentations: nn.Module | None = None,
         beta: float = 0.99,
+        augment_fn: nn.Module | None = None,
         **kwargs: Any,
     ) -> None:
         """Sets up a model for pre-training with BYOL using projection heads.
@@ -238,18 +243,35 @@ class BYOLModule(nn.Module):
             in_channels: number of input channels to the model
             projection_size: size of first layer of the projection MLP
             hidden_size: size of the hidden layer of the projection MLP
-            augment_fn: an instance of a module that performs data augmentation
+            augmentations: Data augmentation pipeline. Defaults to SimCLR
+                augmentation.
             beta: the speed at which the target backbone is updated using the main
                 backbone
+            augment_fn: Deprecated alias for *augmentations*.
             **kwargs: Additional keyword arguments passed to :class:`nn.Module`
+
+        Raises:
+            ValueError: If both *augmentations* and *augment_fn* are provided.
+
+        Warns:
+            DeprecationWarning: If *augment_fn* is provided.
         """
         super().__init__()
 
-        self.augment: nn.Module
-        if augment_fn is None:
-            self.augment = SimCLRAugmentation(image_size)
-        else:
-            self.augment = augment_fn
+        if augmentations is not None and augment_fn is not None:
+            raise ValueError('augmentations cannot be combined with augment_fn')
+        if augment_fn is not None:
+            warnings.warn(
+                'augment_fn is deprecated; use augmentations instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            augmentations = augment_fn
+        self.augmentations = (
+            augmentations
+            if augmentations is not None
+            else SimCLRAugmentation(image_size)
+        )
 
         self.beta = beta
         self.in_channels = in_channels
@@ -275,6 +297,64 @@ class BYOLModule(nn.Module):
         self.target.load_state_dict(self.backbone.state_dict())
         for param in self.target.parameters():
             param.requires_grad = False
+
+    @property
+    def augment(self) -> nn.Module:
+        """Deprecated alias for the augmentation pipeline.
+
+        .. deprecated:: 0.11
+           Use *augmentations* instead.
+        """
+        warnings.warn(
+            'augment is deprecated; use augmentations instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.augmentations
+
+    @augment.setter
+    def augment(self, value: nn.Module) -> None:
+        self.augmentations = value
+
+    def __setattr__(self, name: str, value: Tensor | nn.Module) -> None:
+        """Set an attribute, resolving the deprecated augmentation alias."""
+        if name == 'augment' and 'augmentations' in self.__dict__.get('_modules', {}):
+            warnings.warn(
+                'augment is deprecated; use augmentations instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            name = 'augmentations'
+        super().__setattr__(name, value)
+
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, Tensor],
+        prefix: str,
+        local_metadata: dict[str, object],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        """Load checkpoints saved with the deprecated augmentation attribute."""
+        old_prefix = f'{prefix}augment.'
+        new_prefix = f'{prefix}augmentations.'
+        for key in list(state_dict):
+            if key.startswith(old_prefix):
+                new_key = f'{new_prefix}{key.removeprefix(old_prefix)}'
+                if new_key not in state_dict:
+                    state_dict[new_key] = state_dict[key]
+                del state_dict[key]
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the backbone model through the MLP and prediction head.
@@ -308,6 +388,7 @@ class BYOL(BaseTask):
     * https://arxiv.org/abs/2006.07733
     """
 
+    ignore = ('weights', 'augmentations')
     monitor = 'train_loss'
 
     def __init__(
@@ -317,6 +398,7 @@ class BYOL(BaseTask):
         in_channels: int = 3,
         lr: float = 1e-3,
         patience: int = 10,
+        augmentations: nn.Module | None = None,
     ) -> None:
         """Initialize a new BYOL instance.
 
@@ -329,6 +411,8 @@ class BYOL(BaseTask):
             in_channels: Number of input channels to model.
             lr: Learning rate for optimizer.
             patience: Patience for learning rate scheduler.
+            augmentations: Data augmentation pipeline. Defaults to SimCLR
+                augmentation.
 
         .. versionchanged:: 0.4
            *backbone_name* was renamed to *backbone*. Changed backbone support from
@@ -340,6 +424,26 @@ class BYOL(BaseTask):
         """
         self.weights = weights
         super().__init__()
+        if augmentations is not None:
+            self.augmentations = augmentations
+
+    @property
+    def augmentations(self) -> nn.Module:
+        """Data augmentation pipeline."""
+        return self.model.augmentations
+
+    @augmentations.setter
+    def augmentations(self, value: nn.Module) -> None:
+        self.model.augmentations = value
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set an attribute, forwarding augmentations to the BYOL model."""
+        if name == 'augmentations' and 'model' in self.__dict__.get('_modules', {}):
+            if not isinstance(value, nn.Module):
+                raise TypeError('augmentations must be an nn.Module')
+            self.model.augmentations = value
+            return
+        super().__setattr__(name, value)
 
     def configure_models(self) -> None:
         """Initialize the model."""
@@ -402,8 +506,8 @@ class BYOL(BaseTask):
             x2 = x[:, in_channels:]
 
         with torch.no_grad():
-            x1 = self.model.augment(x1)
-            x2 = self.model.augment(x2)
+            x1 = self.model.augmentations(x1)
+            x2 = self.model.augmentations(x2)
 
         pred1 = self(x1)
         pred2 = self(x2)

--- a/torchgeo/tasks/mae.py
+++ b/torchgeo/tasks/mae.py
@@ -140,7 +140,7 @@ class MAE(BaseTask):
 
     @transform.setter
     def transform(self, value: nn.Module) -> None:
-        self.augmentations = value
+        self.augmentations = value  # pragma: no cover
 
     def __setattr__(self, name: str, value: torch.Tensor | nn.Module) -> None:
         """Set an attribute, resolving the deprecated augmentation alias."""

--- a/torchgeo/tasks/mae.py
+++ b/torchgeo/tasks/mae.py
@@ -3,6 +3,8 @@
 
 """MAE task for self-supervised learning (SSL)."""
 
+import warnings
+
 import timm
 import torch
 from kornia import augmentation as K
@@ -48,16 +50,19 @@ class MAE(BaseTask):
     * https://arxiv.org/abs/2111.06377
 
     .. versionadded:: 0.10
+
+    .. versionchanged:: 0.11
+       The *transform* parameter was renamed to *augmentations*.
     """
 
-    ignore = ('transform', 'weights')
+    ignore = ('augmentations', 'transform', 'weights')
 
     def __init__(
         self,
         model: str = 'vit_base_patch32_224',
         weights: WeightsEnum | str | bool | None = None,
         in_channels: int = 3,
-        transform: nn.Module | None = None,
+        augmentations: nn.Module | None = None,
         decoder_dim: int = 512,
         lr: float = 1.5e-4,
         decoder_num_heads: int = 8,
@@ -67,6 +72,7 @@ class MAE(BaseTask):
         size: int = 224,
         norm_pix_loss: bool = True,
         warmup_epochs: int = 40,
+        transform: nn.Module | None = None,
     ) -> None:
         """Initialize the MAE task.
 
@@ -78,8 +84,7 @@ class MAE(BaseTask):
                 default pretrained weights, or None for random initialization.
             in_channels: Number of input channels in the images. Must match the in_chans
                 argument of the ViT model.
-            transform: Optional transform to apply to the input images. If None, a
-                default MAE augmentation will be used.
+            augmentations: Data augmentation pipeline. Defaults to MAE augmentation.
             decoder_dim: The embedding dimension of the MAE decoder. Typically 512 is a
                 good choice for ViT-Base encoders.
             lr: Should typically be set to 1.5e-4 * batch_size / 256.
@@ -94,14 +99,88 @@ class MAE(BaseTask):
             norm_pix_loss: If True, normalize each target patch to zero mean and unit
                 variance before computing MSE. Recommended by the original MAE paper.
             warmup_epochs: Number of linear warmup epochs before cosine annealing.
+            transform: Deprecated alias for *augmentations*.
 
         Raises:
             TypeError: If *model* is not a ViT architecture.
+            ValueError: If both *augmentations* and *transform* are provided.
+
+        Warns:
+            DeprecationWarning: If *transform* is provided.
         """
         self.weights = weights
         super().__init__()
-        self.transform = transform if transform is not None else mae_augmentation(size)
+        if augmentations is not None and transform is not None:
+            raise ValueError('augmentations cannot be combined with transform')
+        if transform is not None:
+            warnings.warn(
+                'transform is deprecated; use augmentations instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            augmentations = transform
+        self.augmentations = (
+            augmentations if augmentations is not None else mae_augmentation(size)
+        )
         self.warmup_epochs = warmup_epochs
+
+    @property
+    def transform(self) -> nn.Module:
+        """Deprecated alias for the augmentation pipeline.
+
+        .. deprecated:: 0.11
+           Use *augmentations* instead.
+        """
+        warnings.warn(
+            'transform is deprecated; use augmentations instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.augmentations
+
+    @transform.setter
+    def transform(self, value: nn.Module) -> None:
+        self.augmentations = value
+
+    def __setattr__(self, name: str, value: torch.Tensor | nn.Module) -> None:
+        """Set an attribute, resolving the deprecated augmentation alias."""
+        if name == 'transform' and 'augmentations' in self.__dict__.get('_modules', {}):
+            warnings.warn(
+                'transform is deprecated; use augmentations instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            name = 'augmentations'
+        super().__setattr__(name, value)
+
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, torch.Tensor],
+        prefix: str,
+        local_metadata: dict[str, object],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        """Load checkpoints saved with the deprecated augmentation attribute."""
+        old_prefix = f'{prefix}transform.'
+        new_prefix = f'{prefix}augmentations.'
+        for key in list(state_dict):
+            if key.startswith(old_prefix):
+                new_key = f'{new_prefix}{key.removeprefix(old_prefix)}'
+                if new_key not in state_dict:
+                    state_dict[new_key] = state_dict[key]
+                del state_dict[key]
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion."""
@@ -231,7 +310,7 @@ class MAE(BaseTask):
             The loss tensor.
         """
         with torch.no_grad():
-            images = self.transform(batch['image'].float())
+            images = self.augmentations(batch['image'].float())
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
             size=(batch_size, self.sequence_length),

--- a/torchgeo/tasks/moco.py
+++ b/torchgeo/tasks/moco.py
@@ -130,9 +130,12 @@ class MoCo(BaseTask):
     * v3: https://arxiv.org/abs/2104.02057
 
     .. versionadded:: 0.5
+
+    .. versionchanged:: 0.11
+       Data augmentation pipelines are now exposed through *augmentations*.
     """
 
-    ignore = ('weights', 'augmentation1', 'augmentation2')
+    ignore = ('weights', 'augmentations', 'augmentation1', 'augmentation2')
     monitor = 'train_loss'
 
     def __init__(
@@ -156,6 +159,7 @@ class MoCo(BaseTask):
         grayscale_weights: Tensor | None = None,
         augmentation1: nn.Module | None = None,
         augmentation2: nn.Module | None = None,
+        augmentations: tuple[nn.Module | None, nn.Module | None] | None = None,
     ) -> None:
         """Initialize a new MoCo instance.
 
@@ -192,11 +196,17 @@ class MoCo(BaseTask):
                 Defaults to MoCo augmentation.
             augmentation2: Data augmentation for 2nd branch.
                 Defaults to MoCo augmentation.
+            augmentations: Data augmentations for the first and second branches. A
+                ``None`` entry uses the default augmentation for that branch. Defaults
+                to MoCo augmentations.
 
         Raises:
             AssertionError: If an invalid version of MoCo is requested.
+            ValueError: If both *augmentations* and a deprecated augmentation argument
+                are provided.
 
         Warns:
+            DeprecationWarning: If a deprecated augmentation argument is provided.
             UserWarning: If hyperparameters do not match MoCo version requested.
         """
         # Validate hyperparameters
@@ -221,8 +231,111 @@ class MoCo(BaseTask):
         if grayscale_weights is None:
             grayscale_weights = torch.ones(in_channels)
         aug1, aug2 = moco_augmentations(version, size, grayscale_weights)
-        self.augmentation1 = aug1 if augmentation1 is None else augmentation1
-        self.augmentation2 = aug2 if augmentation2 is None else augmentation2
+        if augmentations is not None:
+            if augmentation1 is not None or augmentation2 is not None:
+                raise ValueError(
+                    'augmentations cannot be combined with augmentation1 or '
+                    'augmentation2'
+                )
+            custom_aug1, custom_aug2 = augmentations
+            aug1 = aug1 if custom_aug1 is None else custom_aug1
+            aug2 = aug2 if custom_aug2 is None else custom_aug2
+        elif augmentation1 is not None or augmentation2 is not None:
+            warnings.warn(
+                'augmentation1 and augmentation2 are deprecated; use augmentations '
+                'instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            aug1 = aug1 if augmentation1 is None else augmentation1
+            aug2 = aug2 if augmentation2 is None else augmentation2
+        self.augmentations = nn.ModuleList([aug1, aug2])
+
+    @property
+    def augmentation1(self) -> nn.Module:
+        """Deprecated alias for the first augmentation pipeline.
+
+        .. deprecated:: 0.11
+           Use ``augmentations[0]`` instead.
+        """
+        warnings.warn(
+            'augmentation1 is deprecated; use augmentations[0] instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.augmentations[0]
+
+    @augmentation1.setter
+    def augmentation1(self, value: nn.Module) -> None:
+        self.augmentations[0] = value
+
+    @property
+    def augmentation2(self) -> nn.Module:
+        """Deprecated alias for the second augmentation pipeline.
+
+        .. deprecated:: 0.11
+           Use ``augmentations[1]`` instead.
+        """
+        warnings.warn(
+            'augmentation2 is deprecated; use augmentations[1] instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.augmentations[1]
+
+    @augmentation2.setter
+    def augmentation2(self, value: nn.Module) -> None:
+        self.augmentations[1] = value
+
+    def __setattr__(self, name: str, value: Tensor | nn.Module) -> None:
+        """Set an attribute, resolving deprecated augmentation aliases."""
+        if name in {'augmentation1', 'augmentation2'} and 'augmentations' in (
+            self.__dict__.get('_modules', {})
+        ):
+            warnings.warn(
+                f'{name} is deprecated; use augmentations instead',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if not isinstance(value, nn.Module):
+                raise TypeError(f'{name} must be an nn.Module')
+            index = 0 if name == 'augmentation1' else 1
+            self.augmentations[index] = value
+            return
+        super().__setattr__(name, value)
+
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, Tensor],
+        prefix: str,
+        local_metadata: dict[str, object],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        """Load checkpoints saved with the deprecated augmentation attributes."""
+        for old_name, new_name in (
+            ('augmentation1', 'augmentations.0'),
+            ('augmentation2', 'augmentations.1'),
+        ):
+            old_prefix = f'{prefix}{old_name}.'
+            new_prefix = f'{prefix}{new_name}.'
+            for key in list(state_dict):
+                if key.startswith(old_prefix):
+                    new_key = f'{new_prefix}{key.removeprefix(old_prefix)}'
+                    if new_key not in state_dict:
+                        state_dict[new_key] = state_dict[key]
+                    del state_dict[key]
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     def configure_models(self) -> None:
         """Initialize the model."""
@@ -387,8 +500,8 @@ class MoCo(BaseTask):
             x2 = x[:, in_channels:]
 
         with torch.no_grad():
-            x1 = self.augmentation1(x1)
-            x2 = self.augmentation2(x2)
+            x1 = self.augmentations[0](x1)
+            x2 = self.augmentations[1](x2)
 
         m = self.hparams['moco_momentum']
         if self.hparams['version'] == 1:

--- a/torchgeo/tasks/moco.py
+++ b/torchgeo/tasks/moco.py
@@ -267,7 +267,7 @@ class MoCo(BaseTask):
 
     @augmentation1.setter
     def augmentation1(self, value: nn.Module) -> None:
-        self.augmentations[0] = value
+        self.augmentations[0] = value  # pragma: no cover
 
     @property
     def augmentation2(self) -> nn.Module:
@@ -285,7 +285,7 @@ class MoCo(BaseTask):
 
     @augmentation2.setter
     def augmentation2(self, value: nn.Module) -> None:
-        self.augmentations[1] = value
+        self.augmentations[1] = value  # pragma: no cover
 
     def __setattr__(self, name: str, value: Tensor | nn.Module) -> None:
         """Set an attribute, resolving deprecated augmentation aliases."""
@@ -297,10 +297,8 @@ class MoCo(BaseTask):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            if not isinstance(value, nn.Module):
-                raise TypeError(f'{name} must be an nn.Module')
             index = 0 if name == 'augmentation1' else 1
-            self.augmentations[index] = value
+            self.augmentations[index] = cast(nn.Module, value)
             return
         super().__setattr__(name, value)
 


### PR DESCRIPTION
### Summary

Standardizes self-supervised learning augmentation pipelines under a consistent `augmentations` interface across BYOL, MAE, and MoCo. MoCo represents its two view-specific pipelines as a pair, while BYOL and MAE expose a single pipeline. Existing names remain available as deprecated aliases, and legacy checkpoints continue to load through state-dict key migration. Tests and example configuration were updated for the new API.

### Rationale

Previously, each SSL task exposed the same concept under a different name—`augment`, `augment_fn`, `transform`, or `augmentation1`/`augmentation2`. This inconsistency made augmentation pipelines harder to configure, inspect, and replace across tasks. Standardizing on `augmentations` creates a predictable public API while deprecation aliases and checkpoint migration preserve backward compatibility during the transition.

Fixes #3996.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
