### PR TITLE
ci: retry on transient RasterioIOError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,8 @@ tests = [
     "pytest>=7.3.2",
     # pytest-cov 4+ required for pytest 7.2+ compatibility
     "pytest-cov>=4",
+    # pytest-rerunfailures 14+ required for pytest 8.2+ compatibility
+    "pytest-rerunfailures>=14",
     # pytest-xdist 3.0.2+ required for --dist=loadgroup with pytest 9
     "pytest-xdist>=3.0.2",
     # pytest-socket 0.3.4+ required for wheels
@@ -190,7 +192,8 @@ show_missing = true
 
 [tool.pytest.ini_options]
 # Skip slow tests by default
-addopts = "-m 'not slow' --disable-socket"
+# Retry only transient rasterio I/O errors seen flaking on CI runners, not real failures
+addopts = "-m 'not slow' --disable-socket --reruns 2 --reruns-delay 1 --only-rerun RasterioIOError"
 # https://docs.pytest.org/en/latest/how-to/capture-warnings.html
 filterwarnings = [
     # Warnings raised by dependencies of dependencies, out of our control

--- a/uv.lock
+++ b/uv.lock
@@ -2993,6 +2993,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/0114e45d4b2fcd5f6297dac655c067b47de28be4d33e088f200f0f2c4c28/pytest_rerunfailures-16.6.tar.gz", hash = "sha256:29dbfee46f542073c888e0ed4e81c51e15b9096f49a299eb1a759629c601684a", size = 42806, upload-time = "2026-08-17T07:11:00.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5e/1e994889673d7a0da11651f17ef789b6c83bfe349f29f871873dd3802445/pytest_rerunfailures-16.6-py3-none-any.whl", hash = "sha256:6af2d1ebd6e5cb79666ac408942cd6a0672a49fefd8523664770718560795e13", size = 19137, upload-time = "2026-08-17T07:10:59.121Z" },
+]
+
+[[package]]
 name = "pytest-socket"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3811,6 +3824,7 @@ all = [
     { name = "pydata-sphinx-theme" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-socket" },
     { name = "pytest-xdist" },
     { name = "rioxarray" },
@@ -3864,6 +3878,7 @@ tests = [
     { name = "packaging" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-socket" },
     { name = "pytest-xdist" },
 ]
@@ -3897,6 +3912,7 @@ requires-dist = [
     { name = "pyproj", specifier = ">=3.6.1" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.3.2" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=4" },
+    { name = "pytest-rerunfailures", marker = "extra == 'tests'", specifier = ">=14" },
     { name = "pytest-socket", marker = "extra == 'tests'", specifier = ">=0.3.4" },
     { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.0.2" },
     { name = "rasterio", specifier = ">=1.4.3" },


### PR DESCRIPTION
CI keeps flaking on the chesapeake_cvpr trainer test with transient RasterioIOErrors on files that are fine on disk (seen twice recently: "Cannot read TIFF header", "not recognized as being in a supported file format"). Adds pytest-rerunfailures, scoped to only retry RasterioIOError so real failures still fail fast.