### PR TITLE
Fix ResNet weight metadata

### DIFF
--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -53,6 +53,9 @@ class TestResNet18:
         if 'bands' in weights.meta:
             assert len(weights.meta['bands']) == weights.meta['in_chans']
 
+    def test_model(self, weights: ResNet18_Weights) -> None:
+        assert weights.meta['model'] == 'resnet18'
+
     def test_transforms(self, weights: ResNet18_Weights) -> None:
         c = weights.meta['in_chans']
         sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
@@ -105,6 +108,9 @@ class TestResNet50:
         if 'bands' in weights.meta:
             assert len(weights.meta['bands']) == weights.meta['in_chans']
 
+    def test_model(self, weights: ResNet50_Weights) -> None:
+        assert weights.meta['model'] == 'resnet50'
+
     def test_transforms(self, weights: ResNet50_Weights) -> None:
         c = weights.meta['in_chans']
         sample = {'image': torch.arange(c * 32 * 32, dtype=torch.float).view(c, 32, 32)}
@@ -156,6 +162,9 @@ class TestResNet152:
     def test_bands(self, weights: ResNet152_Weights) -> None:
         if 'bands' in weights.meta:
             assert len(weights.meta['bands']) == weights.meta['in_chans']
+
+    def test_model(self, weights: ResNet152_Weights) -> None:
+        assert weights.meta['model'] == 'resnet152'
 
     def test_transforms(self, weights: ResNet152_Weights) -> None:
         c = weights.meta['in_chans']

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -449,7 +449,7 @@ class ResNet50_Weights(WeightsEnum):
         meta={
             'dataset': 'SSL4EO-L',
             'in_chans': 6,
-            'model': 'resnet18',
+            'model': 'resnet50',
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/torchgeo/torchgeo',
             'ssl_method': 'moco',
@@ -463,7 +463,7 @@ class ResNet50_Weights(WeightsEnum):
         meta={
             'dataset': 'SSL4EO-L',
             'in_chans': 6,
-            'model': 'resnet18',
+            'model': 'resnet50',
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/torchgeo/torchgeo',
             'ssl_method': 'simclr',
@@ -816,7 +816,7 @@ class ResNet152_Weights(WeightsEnum):
         meta={
             'dataset': 'SatlasPretrain',
             'in_chans': 9,
-            'model': 'resnet50',
+            'model': 'resnet152',
             'publication': 'https://arxiv.org/abs/2211.15660',
             'repo': 'https://github.com/allenai/satlaspretrain_models',
             'bands': _satlas_sentinel2_bands,
@@ -829,7 +829,7 @@ class ResNet152_Weights(WeightsEnum):
         meta={
             'dataset': 'SatlasPretrain',
             'in_chans': 3,
-            'model': 'resnet50',
+            'model': 'resnet152',
             'publication': 'https://arxiv.org/abs/2211.15660',
             'repo': 'https://github.com/allenai/satlaspretrain_models',
             'bands': _satlas_bands,
@@ -842,7 +842,7 @@ class ResNet152_Weights(WeightsEnum):
         meta={
             'dataset': 'SatlasPretrain',
             'in_chans': 9,
-            'model': 'resnet50',
+            'model': 'resnet152',
             'publication': 'https://arxiv.org/abs/2211.15660',
             'repo': 'https://github.com/allenai/satlaspretrain_models',
             'bands': _satlas_sentinel2_bands,
@@ -855,7 +855,7 @@ class ResNet152_Weights(WeightsEnum):
         meta={
             'dataset': 'SatlasPretrain',
             'in_chans': 3,
-            'model': 'resnet50',
+            'model': 'resnet152',
             'publication': 'https://arxiv.org/abs/2211.15660',
             'repo': 'https://github.com/allenai/satlaspretrain_models',
             'bands': _satlas_bands,


### PR DESCRIPTION
## Summary

- Correct the model metadata for two ResNet-50 SSL4EO-L weights
- Correct the model metadata for four ResNet-152 Satlas weights found during the wider audit
- Test the model metadata for every ResNet weight enum entry

### Rationale

They were wrong

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution