### PR TITLE
Fix default std normalization values

### DIFF
--- a/torchgeo/datamodules/agrifieldnet.py
+++ b/torchgeo/datamodules/agrifieldnet.py
@@ -21,6 +21,8 @@ class AgriFieldNetDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/bright.py
+++ b/torchgeo/datamodules/bright.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import BRIGHTDFC2025
 from .geo import NonGeoDataModule
@@ -16,6 +17,8 @@ class BRIGHTDFC2025DataModule(NonGeoDataModule):
 
     .. versionadded:: 0.8
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self, batch_size: int = 32, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 import torch.nn.functional as F
 
 from ..datasets import ChesapeakeCVPR
@@ -20,6 +21,8 @@ class ChesapeakeCVPRDataModule(GeoDataModule):
     Uses the random splits defined per state to partition tiles into train, val,
     and test sets.
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self,

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -5,6 +5,7 @@
 
 from typing import Any
 
+import torch
 from torch import Generator
 from torch.utils.data import random_split
 
@@ -14,6 +15,8 @@ from .geo import NonGeoDataModule
 
 class COWCCountingDataModule(NonGeoDataModule):
     """LightningDataModule implementation for the COWC Counting dataset."""
+
+    std = torch.tensor(255)
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -5,6 +5,7 @@
 
 from typing import Any
 
+import torch
 from torch.utils.data import Subset
 
 from ..datasets import TropicalCyclone
@@ -22,6 +23,8 @@ class TropicalCycloneDataModule(NonGeoDataModule):
         Class name changed from CycloneDataModule to TropicalCycloneDataModule to be
         consistent with TropicalCyclone dataset.
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/fire_risk.py
+++ b/torchgeo/datamodules/fire_risk.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import FireRisk
 from .geo import NonGeoDataModule
@@ -16,6 +17,8 @@ class FireRiskDataModule(NonGeoDataModule):
 
     .. versionadded:: 0.5
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/l8biome.py
+++ b/torchgeo/datamodules/l8biome.py
@@ -21,6 +21,8 @@ class L8BiomeDataModule(GeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 1,

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import kornia.augmentation as K
 import shapely
+import torch
 from matplotlib.figure import Figure
 
 from ..datasets import (
@@ -28,6 +29,8 @@ class NAIPChesapeakeDataModule(GeoDataModule):
 
     Uses the train/val/test splits from the dataset.
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self,

--- a/torchgeo/datamodules/pastis.py
+++ b/torchgeo/datamodules/pastis.py
@@ -21,6 +21,8 @@ class PASTISDataModule(NonGeoDataModule):
     .. versionadded:: 0.8
     """
 
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 32,
@@ -83,6 +85,8 @@ class PASTIS100DataModule(NonGeoDataModule):
 
     .. versionadded:: 0.9
     """
+
+    std = torch.tensor(10000)
 
     def __init__(
         self,

--- a/torchgeo/datamodules/reforestree.py
+++ b/torchgeo/datamodules/reforestree.py
@@ -20,6 +20,8 @@ class ReforesTreeDataModule(NonGeoDataModule):
 
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_cdl.py
+++ b/torchgeo/datamodules/sentinel2_cdl.py
@@ -22,6 +22,8 @@ class Sentinel2CDLDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_eurocrops.py
+++ b/torchgeo/datamodules/sentinel2_eurocrops.py
@@ -24,6 +24,8 @@ class Sentinel2EuroCropsDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_nccm.py
+++ b/torchgeo/datamodules/sentinel2_nccm.py
@@ -22,6 +22,8 @@ class Sentinel2NCCMDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sentinel2_south_america_soybean.py
+++ b/torchgeo/datamodules/sentinel2_south_america_soybean.py
@@ -23,6 +23,8 @@ class Sentinel2SouthAmericaSoybeanDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/southafricacroptype.py
+++ b/torchgeo/datamodules/southafricacroptype.py
@@ -21,6 +21,8 @@ class SouthAfricaCropTypeDataModule(GeoDataModule):
     .. versionadded:: 0.6
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/ssl4eo.py
+++ b/torchgeo/datamodules/ssl4eo.py
@@ -17,6 +17,8 @@ class SSL4EOLDataModule(NonGeoDataModule):
     .. versionadded:: 0.5
     """
 
+    std = torch.tensor(255)
+
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:

--- a/torchgeo/datamodules/ssl4eo_benchmark.py
+++ b/torchgeo/datamodules/ssl4eo_benchmark.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from kornia.constants import DataKey, Resample
 
 from ..datasets import SSL4EOLBenchmark
@@ -18,6 +19,8 @@ class SSL4EOLBenchmarkDataModule(NonGeoDataModule):
 
     .. versionadded:: 0.5
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self,

--- a/torchgeo/datamodules/substation.py
+++ b/torchgeo/datamodules/substation.py
@@ -19,6 +19,8 @@ class SubstationDataModule(NonGeoDataModule):
     .. versionadded:: 0.7
     """
 
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 64,

--- a/torchgeo/datamodules/sustainbench_crop_yield.py
+++ b/torchgeo/datamodules/sustainbench_crop_yield.py
@@ -5,6 +5,8 @@
 
 from typing import Any
 
+import torch
+
 from ..datasets import SustainBenchCropYield
 from .geo import NonGeoDataModule
 
@@ -14,6 +16,8 @@ class SustainBenchCropYieldDataModule(NonGeoDataModule):
 
     .. versionadded:: 0.5
     """
+
+    std = torch.tensor(1)
 
     def __init__(
         self, batch_size: int = 32, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 
 from ..datasets import UCMerced
 from .geo import NonGeoDataModule
@@ -16,6 +17,8 @@ class UCMercedDataModule(NonGeoDataModule):
 
     Uses random train/val/test splits.
     """
+
+    std = torch.tensor(255)
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any


### PR DESCRIPTION
| Datamodule | Dtype | Image source | Correct std |
|---|---|---|---|
| AgriFieldNetDataModule | uint8 | Radiant MLHub / Azure competition mirror | 255 |
| BRIGHTDFC2025DataModule | uint8 | HuggingFace | 255 |
| ChesapeakeCVPRDataModule | uint8 (default naip layers) | HuggingFace (torchgeo/chesapeake) | 255 |
| COWCCountingDataModule | uint8 | LLNL GDO152 | 255 |
| TropicalCycloneDataModule | uint8 | Radiant MLHub / Azure | 255 |
| FireRiskDataModule | uint8 | HuggingFace | 255 |
| L8BiomeDataModule | uint8 | HuggingFace (torchgeo/l8biome) | 255 |
| NAIPChesapeakeDataModule | uint8 | Microsoft Planetary Computer | 255 |
| PASTISDataModule / PASTIS100DataModule | int16 | Zenodo / HuggingFace mirror | 10000 |
| ReforesTreeDataModule | uint8 | Zenodo | 255 |
| Sentinel2CDLDataModule | uint16 (image side) | AWS Earth Search Sentinel-2 COGs | 10000 |
| Sentinel2EuroCropsDataModule | uint16 (image side) | Sentinel-2 | 10000 |
| Sentinel2NCCMDataModule | uint16 (image side) | Sentinel-2 | 10000 |
| Sentinel2SouthAmericaSoybeanDataModule | uint16 (image side) | Sentinel-2 | 10000 |
| SouthAfricaCropTypeDataModule | uint8 (S2 default) | Radiant Earth Azure blob | 255 |
| SSL4EOLDataModule | uint8 (all 5 splits) | HuggingFace (torchgeo/ssl4eo_l) | 255 |
| SSL4EOLBenchmarkDataModule | uint8 | HuggingFace (torchgeo/ssl4eo-l-benchmark) | 255 |
| SubstationDataModule | float64 (real range up to 6404) | GCS archive | 10000 |
| SustainBenchCropYieldDataModule | float64 [0,1] | HuggingFace | 1 |
| UCMercedDataModule | uint8 | HuggingFace | 255 |