### PR TITLE
Use --no-sign-request when downloading from S3

### DIFF
--- a/torchgeo/datasets/satlas.py
+++ b/torchgeo/datasets/satlas.py
@@ -702,7 +702,7 @@ class SatlasPretrain(NonGeoDataset):
 
                 # Download and extract the tarball
                 aws = which('aws')
-                aws('s3', 'cp', self.url + tarball, self.root)
+                aws('s3', 'cp', '--no-sign-request', self.url + tarball, self.root)
                 check_integrity(path, md5 if self.checksum else None)
                 extract_archive(path)
 

--- a/torchgeo/datasets/spacenet/base.py
+++ b/torchgeo/datasets/spacenet/base.py
@@ -341,7 +341,7 @@ class SpaceNet(NonGeoDataset, ABC):
                 # Download the dataset
                 url = self.url.format(dataset_id=self.dataset_id, tarball=tarball)
                 aws = which('aws')
-                aws('s3', 'cp', url, root)
+                aws('s3', 'cp', '--no-sign-request', url, root)
                 check_integrity(
                     os.path.join(root, tarball), md5 if self.checksum else None
                 )


### PR DESCRIPTION
SpaceNet and SatlasPretrain download their data with `aws s3 cp`, but without `--no-sign-request`. That makes the AWS CLI look for credentials, so anyone who hasn't configured AWS gets:

```
fatal error: Unable to locate credentials
```

Both buckets are public and can be read anonymously:

```console
$ aws s3 ls --no-sign-request s3://spacenet-dataset/spacenet/SN1_buildings/tarballs/
2019-11-05 19:52:56 2571888708 SN1_buildings_train_AOI_1_Rio_3band.tar.gz
...
```

This adds the flag so no credentials are needed. Affects SpaceNet 1-8 and SatlasPretrain.

Found while testing every dataset download against the real servers.



### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution