### PR TITLE
Check downloaded file size against Content-Length

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -403,6 +403,22 @@ def test_download_url_interrupted(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
     assert list(tmp_path.iterdir()) == []
 
 
+def test_download_url_truncated(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    url = Path('tests/data/vhr10/NWPU VHR-10 dataset.zip').absolute().as_uri()
+    filename = 'NWPU VHR-10 dataset.zip'
+
+    def truncate(fsrc: Any, fdst: Any, *args: Any, **kwargs: Any) -> None:
+        fdst.write(fsrc.read(16))
+
+    monkeypatch.setattr(shutil, 'copyfileobj', truncate)
+
+    with pytest.raises(RuntimeError, match=r'Downloaded file .* is incomplete'):
+        download_url(url, tmp_path, filename=filename)
+
+    assert not (tmp_path / filename).exists()
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_download_and_extract_archive(tmp_path: Path) -> None:
     url = str(Path('tests/data/vhr10/NWPU VHR-10 dataset.zip'))
     md5 = '91dd532523a543fb8dee0887e4188e9b'

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -433,16 +433,21 @@ def download_url(
         try:
             with urllib.request.urlopen(request) as response:
                 total = response.headers.get('Content-Length')
+                expected = int(total) if total else None
                 with (
                     tqdm.wrapattr(
-                        response,
-                        'read',
-                        total=int(total) if total else None,
-                        desc=str(filename),
+                        response, 'read', total=expected, desc=str(filename)
                     ) as reader,
                     open(tmp, 'wb') as f,
                 ):
                     shutil.copyfileobj(reader, f)
+            if expected is not None:
+                actual = os.path.getsize(tmp)
+                if actual != expected:
+                    raise RuntimeError(
+                        f"Downloaded file '{fpath}' is incomplete: expected "
+                        f'{expected} bytes but got {actual}.'
+                    )
             os.replace(tmp, fpath)
         finally:
             if os.path.exists(tmp):


### PR DESCRIPTION
### Summary

In our `torchgeo.datasets.utils.download_url`, if a connection drops partway through a download, then `shutil.copyfileobj` just stops. It does not raise any errors, so the half-written file gets moved into place as if the download had finished.

Making the checksums True by default would help, but is a bunch of extra work for a file we already know is bad.

This PR compares the number of bytes we actually received against the `Content-Length` the server sent, and raises if they differ. The temporary file is already removed in the `finally` block, so nothing is left behind.

### Rationale

I ran into this several times while downloading every dataset from its real server. Three large downloads finished "successfully" but produced unopenable zips, even though the servers were serving valid files.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution