### PR TITLE
Fix quantile normalization for integer and large images

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -589,6 +589,11 @@ def test_quantile_normalization_large() -> None:
     assert not torch.count_nonzero(img)
 
 
+def test_quantile_normalization_nan() -> None:
+    img = quantile_normalization(torch.tensor([1, 2, float('nan')]))
+    assert torch.isnan(img).all()
+
+
 @pytest.mark.parametrize(
     'array_dtype',
     [np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32, np.int64],

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -578,6 +578,17 @@ def test_quantile_normalization(img: Tensor) -> None:
     assert 0 <= img.min() <= img.max() <= 1
 
 
+def test_quantile_normalization_integer() -> None:
+    img = quantile_normalization(torch.arange(6))
+    expected = torch.tensor([0, 0, 0, 0.5, 1, 1])
+    assert torch.allclose(img, expected)
+
+
+def test_quantile_normalization_large() -> None:
+    img = quantile_normalization(torch.ones(2**24 + 1))
+    assert not torch.count_nonzero(img)
+
+
 @pytest.mark.parametrize(
     'array_dtype',
     [np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32, np.int64],

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -884,8 +884,26 @@ def quantile_normalization(
     if (img == nodata).all():
         return img
 
-    lower = torch.quantile(img[img != nodata], lower, dim, interpolation='higher')
-    upper = torch.quantile(img[img != nodata], upper, dim, interpolation='lower')
+    values = img[img != nodata]
+    if not img.is_floating_point() and not img.is_complex():
+        img = img.float()
+        values = values.float()
+    dim = -1 if dim is None else dim
+    has_nan = torch.isnan(values).any()
+
+    def _quantile(q: float | Tensor, higher: bool) -> Tensor:
+        ranks = torch.as_tensor(q).detach().cpu().double() * (values.numel() - 1)
+        ranks = torch.ceil(ranks) if higher else torch.floor(ranks)
+        if has_nan:
+            ranks.fill_(values.numel() - 1)
+        quantiles = [
+            torch.kthvalue(values, int(rank) + 1, dim).values
+            for rank in ranks.flatten()
+        ]
+        return torch.stack(quantiles).reshape(ranks.shape)
+
+    lower = _quantile(lower, higher=True)
+    upper = _quantile(upper, higher=False)
     img = (img - lower) / (upper - lower + 1e-5)
     return torch.clamp(img, 0, 1)
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -888,7 +888,7 @@ def quantile_normalization(
     if not img.is_floating_point() and not img.is_complex():
         img = img.float()
         values = values.float()
-    dim = -1 if dim is None else dim
+    quantile_dim = -1 if dim is None else dim
     has_nan = torch.isnan(values).any()
 
     def _quantile(q: float | Tensor, higher: bool) -> Tensor:
@@ -897,7 +897,7 @@ def quantile_normalization(
         if has_nan:
             ranks.fill_(values.numel() - 1)
         quantiles = [
-            torch.kthvalue(values, int(rank) + 1, dim).values
+            torch.kthvalue(values, int(rank) + 1, quantile_dim).values
             for rank in ranks.flatten()
         ]
         return torch.stack(quantiles).reshape(ranks.shape)


### PR DESCRIPTION
### Summary

Normalize integer inputs as floating-point tensors and compute the existing higher/lower quantiles with exact order statistics, avoiding PyTorch's 2²⁴-element torch.quantile limit.

Fixes #4050.

### Rationale

quantile_normalization currently fails for integer imagery and large scenes used by existing datasets. torch.kthvalue preserves the requested interpolation behavior without copying image data off its device or approximating the quantiles.

The two regression tests cover the reported integer and large-input failures.

Validation:
- pytest -q tests/datasets/test_utils.py — 127 passed
- ruff format --check torchgeo/datasets/utils.py tests/datasets/test_utils.py
- ruff check torchgeo/datasets/utils.py tests/datasets/test_utils.py
- ty check torchgeo/datasets/utils.py tests/datasets/test_utils.py

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
