### PR TITLE
Fix So2Sat all-band normalization statistics

### DIFF
--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -198,6 +198,9 @@ class So2SatDataModule(NonGeoDataModule):
         elif band_set == 'rgb':
             self.mean = self.means_per_version[version][[10, 9, 8]]
             self.std = self.stds_per_version[version][[10, 9, 8]]
+        else:
+            self.mean = self.means_per_version[version]
+            self.std = self.stds_per_version[version]
 
         super().__init__(So2Sat, batch_size, num_workers, **kwargs)
 


### PR DESCRIPTION
### Summary

Use the existing full per-version mean and standard deviation tensors when So2SatDataModule uses its default band_set='all'.

Fixes #4051.

### Rationale

The default currently inherits scalar 0/255 statistics from BaseDataModule, even though So2Sat already provides the correct 18-band statistics. This restores the intended normalization without changing the other band selections.

Validation:
- pytest -q 'tests/tasks/test_classification.py::TestClassification::test_trainer[True-so2sat_all]'
- ruff format --check torchgeo/datamodules/so2sat.py
- ruff check torchgeo/datamodules/so2sat.py
- ty check torchgeo/datamodules/so2sat.py

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
