### PR TITLE
datasets: test empty grid cell branch in random_grid_cell_assignment

### DIFF
--- a/tests/datasets/test_splits.py
+++ b/tests/datasets/test_splits.py
@@ -193,6 +193,29 @@ def test_random_grid_cell_assignment() -> None:
         random_grid_cell_assignment(ds, fractions=[1 / 2, 1 / 4, 1 / 4], grid_size=1)
 
 
+def test_random_grid_cell_assignment_partial_cells() -> None:
+    # A triangle does not fill its bounding box, so some grid cells fall
+    # entirely outside the geometry and are skipped.
+    geometry = [Polygon([(0, 0), (3, 0), (0, 3)])]
+    ds = CustomGeoDataset(geometry=geometry)
+
+    train_ds, val_ds, test_ds = random_grid_cell_assignment(
+        ds, fractions=[1 / 2, 1 / 4, 1 / 4], grid_size=3
+    )
+
+    # At least one grid cell does not intersect the triangle and is dropped
+    total_cells = len(train_ds) + len(val_ds) + len(test_ds)
+    assert 0 < total_cells < 3**2
+
+    # No overlap
+    assert no_overlap(train_ds, val_ds)
+    assert no_overlap(val_ds, test_ds)
+    assert no_overlap(test_ds, train_ds)
+
+    # Union equals original geometry
+    assert isclose(total_area(train_ds | val_ds | test_ds), total_area(ds))
+
+
 def test_roi_split() -> None:
     geometry = [
         shapely.box(0, 0, 1, 1),


### PR DESCRIPTION
### Summary

Adds a test for `random_grid_cell_assignment` that covers the case where a grid cell does not intersect the dataset geometry and is skipped. This closes the one remaining partial branch in `torchgeo/datasets/splits.py` (`227->220`), taking that file to 100% branch coverage.

### Rationale

Progress toward #2501. The existing `test_random_grid_cell_assignment` only uses rectangular `shapely.box` geometries, whose bounding box equals the shape, so every grid cell intersects and the empty-cell branch is never exercised. The new test uses a triangle, which does not fill its bounding box, so the top-right grid cell falls entirely outside it and is skipped.

Verified locally: `torchgeo/datasets/splits.py` goes from 99% (1 partial branch, `227->220`) to 100% with the test, and back to 99% without it. `ruff check` and `ruff format` are clean.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
