### PR TITLE
fix: scope openstreetmap warning test to expected UserWarning

### DIFF
--- a/tests/datasets/test_openstreetmap.py
+++ b/tests/datasets/test_openstreetmap.py
@@ -794,7 +794,9 @@ class TestOpenStreetMap:
 
         # Subsequent queries should not trigger warning
         with warnings.catch_warnings():
-            warnings.simplefilter('error')  # Turn warnings into errors
+            warnings.filterwarnings(
+                'error', message='Class .* has no geometries', category=UserWarning
+            )
             dataset[dataset.bounds]  # Should not raise (no warning)
 
     def test_len(self, dataset: OpenStreetMap) -> None:


### PR DESCRIPTION
rasterio v1.5.1 throws a `PendingDeprecationWarning` which causes the OSM dataset test to fail its warning catch test

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution