### PR TITLE
Dependabot: grouped, weekly, indirect, widen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,37 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
 version: 2
 updates:
   - package-ecosystem: 'devcontainers'
     directory: '/.devcontainer'
+    groups:
+      all:
+        patterns:
+          - '*'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'github-actions'
     directory: '/'
+    groups:
+      all:
+        patterns:
+          - '*'
     schedule:
       interval: 'weekly'
-  - package-ecosystem: 'uv'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    groups:
-      pandas:
-        patterns:
-          - 'pandas'
-          - 'pandas[parquet]'
-      # torchvision pins torch, must update in unison
-      torch:
-        patterns:
-          - 'torch'
-          - 'torchvision'
   - package-ecosystem: 'npm'
     directory: '/'
+    groups:
+      all:
+        patterns:
+          - '*'
     schedule:
       interval: 'weekly'
-    versioning-strategy: 'lockfile-only'
+    versioning-strategy: 'widen'
+  - package-ecosystem: 'uv'
+    directory: '/'
+    groups:
+      all:
+        patterns:
+          - '*'
+    schedule:
+      interval: 'weekly'
+    versioning-strategy: 'widen'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
       interval: 'weekly'
     versioning-strategy: 'widen'
   - package-ecosystem: 'uv'
+    all:
+      dependency-type: 'indirect'
     directory: '/'
     groups:
       all:


### PR DESCRIPTION
### Summary

This PR includes the following changes to our dependabot configuration:

- [x] **Grouped**: group all package updates into a single PR ([could go further...](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#multi-ecosystem-groups-))
- [x] **Weekly**: switch uv from a daily to a weekly update cadence
- [x] **Indirect**: update indirect uv dependencies too (might make minimum tests harder?)
- [x] **Widen**: change npm to match the default uv manifest/lockfile update behavior

### Rationale

Here is the motivation behind each change:

* **Grouped**: fewer PRs, reviews, rebases, CI for mostly innocuous changes
* **Weekly**: fewer PRs, uniform cadence, security updates are still immediate
* **Indirect**: test what new users see, get security fixes before CVE is published
* **Widen**: uniform behavior across npm and uv

See https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/ for additional documentation.

Happy to split the above changes into 4 separate PRs if we are worried about having to revert 1 of these changes someday.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
