### PR TITLE
Support integer and large images in quantile normalization

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -594,6 +594,13 @@ def test_quantile_normalization(img: Tensor) -> None:
     assert 0 <= img.min() <= img.max() <= 1
 
 
+def test_quantile_normalization_integer_input() -> None:
+    img = torch.tensor([[1, 2], [3, 4]], dtype=torch.int16)
+    normalized = quantile_normalization(img)
+    assert normalized.dtype == torch.float32
+    assert 0 <= normalized.min() <= normalized.max() <= 1
+
+
 @pytest.mark.parametrize(
     'array_dtype',
     [np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32, np.int64],

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -615,7 +615,7 @@ def test_quantile_normalization_subsamples_large_input(
     normalized = quantile_normalization(img)
 
     assert normalized.shape == img.shape
-    assert seen_sizes == [2**24, 2**24]
+    assert seen_sizes == [2**23 + 1, 2**23 + 1]
 
 
 @pytest.mark.parametrize(

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -601,6 +601,23 @@ def test_quantile_normalization_integer_input() -> None:
     assert 0 <= normalized.min() <= normalized.max() <= 1
 
 
+def test_quantile_normalization_subsamples_large_input(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    seen_sizes: list[int] = []
+
+    def quantile(values: Tensor, *args: Any, **kwargs: Any) -> Tensor:
+        seen_sizes.append(values.numel())
+        return torch.tensor(0.0)
+
+    monkeypatch.setattr(torch, 'quantile', quantile)
+    img = torch.ones(2**24 + 1)
+    normalized = quantile_normalization(img)
+
+    assert normalized.shape == img.shape
+    assert seen_sizes == [2**24, 2**24]
+
+
 @pytest.mark.parametrize(
     'array_dtype',
     [np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32, np.int64],

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -889,8 +889,13 @@ def quantile_normalization(
     if (img == nodata).all():
         return img
 
-    lower = torch.quantile(img[img != nodata], lower, dim, interpolation='higher')
-    upper = torch.quantile(img[img != nodata], upper, dim, interpolation='lower')
+    values = img[img != nodata].float()
+    max_elements = 2**24
+    if values.numel() > max_elements:
+        stride = (values.numel() + max_elements - 1) // max_elements
+        values = values[::stride]
+    lower = torch.quantile(values, lower, dim, interpolation='higher')
+    upper = torch.quantile(values, upper, dim, interpolation='lower')
     img = (img - lower) / (upper - lower + 1e-5)
     return torch.clamp(img, 0, 1)
 


### PR DESCRIPTION
Cast quantile inputs to float and subsample oversized tensors before computing quantiles. This keeps dataset plotting working for integer imagery and large scenes.

Test: python3 -m py_compile torchgeo/datasets/utils.py tests/datasets/test_utils.py

AI assistance was used.