### PR TITLE
Use reflectance scale for PASTIS

### DIFF
--- a/tests/datamodules/test_pastis.py
+++ b/tests/datamodules/test_pastis.py
@@ -1,0 +1,12 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import torch
+
+from torchgeo.datamodules import PASTIS100DataModule, PASTISDataModule
+
+
+def test_pastis_normalization_scale() -> None:
+    for datamodule in (PASTISDataModule(), PASTIS100DataModule()):
+        assert datamodule.mean == torch.tensor(0)
+        assert datamodule.std == torch.tensor(10000)

--- a/torchgeo/datamodules/pastis.py
+++ b/torchgeo/datamodules/pastis.py
@@ -21,6 +21,9 @@ class PASTISDataModule(NonGeoDataModule):
     .. versionadded:: 0.8
     """
 
+    mean = torch.tensor(0)
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 32,
@@ -83,6 +86,9 @@ class PASTIS100DataModule(NonGeoDataModule):
 
     .. versionadded:: 0.9
     """
+
+    mean = torch.tensor(0)
+    std = torch.tensor(10000)
 
     def __init__(
         self,


### PR DESCRIPTION
Use the Sentinel-2 reflectance scale for PASTIS and PASTIS100 augmentations instead of the 8-bit image default.

Test: python3 -m py_compile torchgeo/datamodules/pastis.py tests/datamodules/test_pastis.py

AI assistance was used.