### PR TITLE
Handle IDTReeS images without boxes

### DIFF
--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -19,6 +19,14 @@ pytest.importorskip('laspy', minversion='2.5.3')
 
 
 class TestIDTReeS:
+    def test_filter_empty_boxes(self) -> None:
+        boxes = torch.empty((0, 4))
+        filtered, labels = IDTReeS._filter_boxes(
+            IDTReeS.__new__(IDTReeS), (200, 200), 1, boxes, None
+        )
+        assert filtered.shape == (0, 4)
+        assert labels is None
+
     @pytest.fixture(params=zip(['train', 'test', 'test'], ['task1', 'task1', 'task2']))
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -324,7 +324,7 @@ class IDTReeS(NonGeoDataset):
                 ymax_px = max(row_min, row_max)
                 boxes.append([xmin_px, ymin_px, xmax_px, ymax_px])
 
-        tensor = torch.tensor(boxes)
+        tensor = torch.tensor(boxes).reshape(-1, 4)
         return tensor
 
     def _load_target(self, path: Path) -> Tensor:


### PR DESCRIPTION
Return empty IDTReeS box annotations with shape (0, 4) so samples without trees pass through torchvision box filtering.

Test: python3 -m py_compile torchgeo/datasets/idtrees.py tests/datasets/test_idtrees.py

AI assistance was used.