### PR TITLE
Add timeout to dataset downloads

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -5,7 +5,6 @@ import os
 import pickle
 import re
 import shutil
-import socket
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -409,10 +408,10 @@ def test_download_url_timeout(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
 
     def stall(*args: Any, **kwargs: Any) -> None:
         calls.append(kwargs['timeout'])
-        raise socket.timeout('simulated stall')
+        raise TimeoutError('simulated stall')
 
     monkeypatch.setattr('urllib.request.urlopen', stall)
-    with pytest.raises(socket.timeout, match='simulated stall'):
+    with pytest.raises(TimeoutError, match='simulated stall'):
         download_url('https://example.com/file', tmp_path, timeout=5)
     assert calls == [5]
 

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import re
 import shutil
+import socket
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -401,6 +402,19 @@ def test_download_url_interrupted(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
     # Neither a truncated final file nor a leftover temporary file should remain.
     assert not (tmp_path / filename).exists()
     assert list(tmp_path.iterdir()) == []
+
+
+def test_download_url_timeout(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    calls: list[float] = []
+
+    def stall(*args: Any, **kwargs: Any) -> None:
+        calls.append(kwargs['timeout'])
+        raise socket.timeout('simulated stall')
+
+    monkeypatch.setattr('urllib.request.urlopen', stall)
+    with pytest.raises(socket.timeout, match='simulated stall'):
+        download_url('https://example.com/file', tmp_path, timeout=5)
+    assert calls == [5]
 
 
 def test_download_url_truncated(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -394,6 +394,7 @@ def download_url(
     filename: Path | None = None,
     md5: str | None = None,
     max_redirect_hops: int = 3,
+    timeout: float = 60,
     **kwargs: str | None,
 ) -> None:
     """Download a file from a url and place it in root.
@@ -409,6 +410,7 @@ def download_url(
         filename: File path to save to. Defaults to the basename of the URL.
         md5: Expected MD5 checksum.
         max_redirect_hops: Maximum number of allowed redirection attempts.
+        timeout: Socket timeout in seconds for each read operation.
         **kwargs: Expected checksum for any valid :mod:`hashlib` algorithm.
 
     Raises:
@@ -431,7 +433,7 @@ def download_url(
         # interrupted download cannot leave a truncated file behind.
         tmp = f'{fpath}.tmp'
         try:
-            with urllib.request.urlopen(request) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 total = response.headers.get('Content-Length')
                 expected = int(total) if total else None
                 with (

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -465,6 +465,7 @@ def download_and_extract_archive(
     filename: Path | None = None,
     md5: str | None = None,
     remove_finished: bool = False,
+    timeout: float = 60,
     **kwargs: str | None,
 ) -> None:
     """Download and extract a remote archive.
@@ -481,6 +482,7 @@ def download_and_extract_archive(
         filename: File path to save to. Defaults to the basename of the URL.
         md5: Expected MD5 checksum.
         remove_finished: If True, remove *filename* after extraction.
+        timeout: Socket timeout in seconds for each read operation.
         **kwargs: Expected checksum for any valid :module:`hashlib` algorithm.
     """
     download_root = os.path.expanduser(download_root)
@@ -488,7 +490,7 @@ def download_and_extract_archive(
     filename = filename or os.path.basename(url)
     from_path = os.path.join(download_root, filename)
 
-    download_url(url, download_root, filename, md5, 3, **kwargs)
+    download_url(url, download_root, filename, md5, 3, timeout, **kwargs)
     extract_archive(from_path, extract_root, remove_finished)
 
 


### PR DESCRIPTION
Add a per-read timeout to download_url so stalled transfers fail instead of blocking forever.

Test: python3 -m py_compile torchgeo/datasets/utils.py tests/datasets/test_utils.py

AI assistance was used.