### PR TITLE
Use So2Sat statistics for all bands

### DIFF
--- a/tests/datamodules/test_so2sat.py
+++ b/tests/datamodules/test_so2sat.py
@@ -1,0 +1,10 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+from torchgeo.datamodules import So2SatDataModule
+
+
+def test_so2sat_all_uses_all_band_statistics() -> None:
+    datamodule = So2SatDataModule()
+    assert datamodule.mean.shape == (18,)
+    assert datamodule.std.shape == (18,)

--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -198,6 +198,9 @@ class So2SatDataModule(NonGeoDataModule):
         elif band_set == 'rgb':
             self.mean = self.means_per_version[version][[10, 9, 8]]
             self.std = self.stds_per_version[version][[10, 9, 8]]
+        else:
+            self.mean = self.means_per_version[version]
+            self.std = self.stds_per_version[version]
 
         super().__init__(So2Sat, batch_size, num_workers, **kwargs)
 


### PR DESCRIPTION
Apply the existing 18-band statistics when So2SatDataModule uses its default all-band configuration.

Test: python3 -m py_compile torchgeo/datamodules/so2sat.py tests/datamodules/test_so2sat.py

AI assistance was used.