### PR TITLE
Fix DIOR labels and test plotting

### DIFF
--- a/tests/datasets/test_dior.py
+++ b/tests/datasets/test_dior.py
@@ -81,7 +81,6 @@ class TestDIOR:
             DIOR(tmp_path)
 
     def test_plot(self, dataset: DIOR) -> None:
-        if dataset.split != 'test':
-            x = dataset[0].copy()
-            dataset.plot(x, suptitle='Test')
-            plt.close()
+        x = dataset[0].copy()
+        dataset.plot(x, suptitle='Test')
+        plt.close()

--- a/torchgeo/datasets/dior.py
+++ b/torchgeo/datasets/dior.py
@@ -258,7 +258,10 @@ class DIOR(NonGeoDataset):
         parsed = parse_pascal_voc(path)
         boxes = torch.tensor(parsed['bboxes'], dtype=torch.float32)
         labels = torch.tensor(
-            [self.class_to_idx[label] for label in parsed['labels']]
+            [
+                self.class_to_idx[label.lower().replace('-', '')]
+                for label in parsed['labels']
+            ]
         ).long()
         return boxes, labels
 
@@ -348,8 +351,8 @@ class DIOR(NonGeoDataset):
             a matplotlib Figure with the rendered sample
         """
         image = sample['image'].permute((1, 2, 0)).numpy()
-        boxes = sample['bbox_xyxy'].numpy()
-        labels = sample['label'].numpy()
+        boxes = sample.get('bbox_xyxy', torch.empty((0, 4))).numpy()
+        labels = sample.get('label', torch.empty(0, dtype=torch.long)).numpy()
 
         fig, axs = plt.subplots(ncols=1, figsize=(10, 10))
 


### PR DESCRIPTION
Normalize hyphenated DIOR annotation labels and let plot render test samples without annotations.

Test: python3 -m py_compile torchgeo/datasets/dior.py tests/datasets/test_dior.py

AI assistance was used.