### PR TITLE
Cache AirQuality downloads in root

### DIFF
--- a/tests/datasets/test_air_quality.py
+++ b/tests/datasets/test_air_quality.py
@@ -21,7 +21,7 @@ class TestAirQuality:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> AirQuality:
         url = os.path.join('tests', 'data', 'air_quality', 'data.csv')
-        monkeypatch.setattr(AirQuality, 'url', url)
+        monkeypatch.setattr(AirQuality, 'url', Path(url).absolute().as_uri())
         input_features, target_features = request.param
         return AirQuality(
             tmp_path,

--- a/tests/datasets/test_air_quality.py
+++ b/tests/datasets/test_air_quality.py
@@ -21,7 +21,7 @@ class TestAirQuality:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> AirQuality:
         url = os.path.join('tests', 'data', 'air_quality', 'data.csv')
-        monkeypatch.setattr(AirQuality, 'url', Path(url).absolute().as_uri())
+        monkeypatch.setattr(AirQuality, 'url', url)
         input_features, target_features = request.param
         return AirQuality(
             tmp_path,

--- a/torchgeo/datasets/air_quality.py
+++ b/torchgeo/datasets/air_quality.py
@@ -15,7 +15,7 @@ from matplotlib.figure import Figure
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, Sample
+from .utils import Path, Sample, download_url
 
 
 class AirQuality(NonGeoDataset):
@@ -134,7 +134,7 @@ class AirQuality(NonGeoDataset):
         if filepath.is_file():
             pass
         elif self.download:
-            filepath = self.url
+            download_url(self.url, self.root, filename=self.data_file_name)
         else:
             raise DatasetNotFoundError(self)
 


### PR DESCRIPTION
Download AirQuality data into the dataset root and reuse the local file on later loads.

Test: python3 -m py_compile torchgeo/datasets/air_quality.py tests/datasets/test_air_quality.py

AI assistance was used.