### PR TITLE
Use reflectance scale for Substation

### DIFF
--- a/tests/datamodules/test_substation.py
+++ b/tests/datamodules/test_substation.py
@@ -1,0 +1,13 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import torch
+
+from torchgeo.datamodules import SubstationDataModule
+
+
+def test_substation_normalization_scale() -> None:
+    datamodule = SubstationDataModule()
+
+    assert datamodule.mean == torch.tensor(0)
+    assert datamodule.std == torch.tensor(10000)

--- a/torchgeo/datamodules/substation.py
+++ b/torchgeo/datamodules/substation.py
@@ -19,6 +19,9 @@ class SubstationDataModule(NonGeoDataModule):
     .. versionadded:: 0.7
     """
 
+    mean = torch.tensor(0)
+    std = torch.tensor(10000)
+
     def __init__(
         self,
         batch_size: int = 64,


### PR DESCRIPTION
Fixes #4070.

Use the Sentinel-2 reflectance scale for Substation normalization instead of the 8-bit default.

AI assistance was used.