### PR TITLE
Dependabot: fix syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
       interval: 'weekly'
     versioning-strategy: 'widen'
   - package-ecosystem: 'uv'
-    all:
+    allow:
       dependency-type: 'indirect'
     directory: '/'
     groups:
@@ -36,4 +36,3 @@ updates:
           - '*'
     schedule:
       interval: 'weekly'
-    versioning-strategy: 'widen'


### PR DESCRIPTION
### Summary

Fixes uv settings, typo in config flag and unsupported versioning strategy? Wish GitHub would validate the file _before_ merge instead of _after_.

### Rationale

Fixes the following errors on main:
```
The property '#/updates/3/' contains additional properties ["all"] outside of the schema when none are allowed
The property '#/updates/3/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary
```

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
