### PR TITLE
Fix quantile normalization for integer and large images

### DIFF
--- a/tests/datasets/test_quantile_normalization.py
+++ b/tests/datasets/test_quantile_normalization.py
@@ -1,0 +1,37 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+import torch
+
+from torchgeo.datasets.utils import quantile_normalization
+
+
+def test_quantile_normalization_integer() -> None:
+    img = torch.arange(1, 101, dtype=torch.int16).reshape(10, 10)
+
+    result = quantile_normalization(img)
+
+    values = img.float().flatten()
+    lower = torch.quantile(values, 0.02, interpolation='higher')
+    upper = torch.quantile(values, 0.98, interpolation='lower')
+    expected = torch.clamp(
+        (values.reshape_as(img) - lower) / (upper - lower + 1e-5), 0, 1
+    )
+
+    assert result.dtype == torch.float32
+    assert torch.allclose(result, expected)
+
+
+def test_quantile_normalization_without_torch_quantile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def size_limit(*args: object, **kwargs: object) -> None:
+        raise RuntimeError('quantile() input tensor is too large')
+
+    monkeypatch.setattr(torch, 'quantile', size_limit)
+    img = torch.arange(1, 101, dtype=torch.float32).reshape(10, 10)
+
+    result = quantile_normalization(img)
+
+    assert 0 <= result.min() <= result.max() <= 1

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -889,9 +889,28 @@ def quantile_normalization(
     if (img == nodata).all():
         return img
 
-    lower = torch.quantile(img[img != nodata], lower, dim, interpolation='higher')
-    upper = torch.quantile(img[img != nodata], upper, dim, interpolation='lower')
-    img = (img - lower) / (upper - lower + 1e-5)
+    if not torch.is_floating_point(img):
+        img = img.float()
+
+    values = img[img != nodata]
+    reduce_dim = 0 if dim is None else dim
+
+    def kth_quantile(q: float | Tensor, higher: bool) -> Tensor:
+        q_tensor = torch.as_tensor(q, dtype=torch.float64, device='cpu')
+        positions = q_tensor * (values.numel() - 1)
+        indices = torch.ceil(positions) if higher else torch.floor(positions)
+        indices = indices.to(torch.int64) + 1
+        quantiles = torch.stack(
+            [
+                torch.kthvalue(values, k, dim=reduce_dim).values
+                for k in indices.reshape(-1).tolist()
+            ]
+        )
+        return quantiles.reshape(indices.shape)
+
+    lower_value = kth_quantile(lower, higher=True)
+    upper_value = kth_quantile(upper, higher=False)
+    img = (img - lower_value) / (upper_value - lower_value + 1e-5)
     return torch.clamp(img, 0, 1)
 
 


### PR DESCRIPTION
Fixes #4050.

Use exact kth-value quantiles so integer and large images can be normalized without `torch.quantile` limitations.

AI assistance was used.