### PR TITLE
Dependabot: fix syntax again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
     versioning-strategy: 'widen'
   - package-ecosystem: 'uv'
     allow:
-      dependency-type: 'indirect'
+    - dependency-type: 'all'
     directory: '/'
     groups:
       all:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
     versioning-strategy: 'widen'
   - package-ecosystem: 'uv'
     allow:
-    - dependency-type: 'all'
+      - dependency-type: 'all'
     directory: '/'
     groups:
       all:


### PR DESCRIPTION
### Summary

Really frustrating that dependabot doesn't offer a service to validate configuration files before merge. Here is yet another attempt to fix the syntax. The official docs don't provide any examples to describe what this should look like, but https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#allowing-specific-dependencies-to-be-updated gives a good example.

### Rationale

Currently failing with:
```
The property '#/updates/3/allow' of type object did not match the following type: array
```

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
