### PR TITLE
Prettier 3.3+ now required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "prettier": ">=3"
+        "prettier": ">=3.3"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "torchgeo",
   "private": "true",
   "dependencies": {
-    "prettier": ">=3"
+    "prettier": ">=3.3"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
### Summary

Bump the minimum required prettier version to 3.3.

### Rationale

The recently updated SECURITY.md file formats differently between prettier 3.2 and 3.3. Updating ensures consistent formatting for all contributors.
```diff
diff --git a/.github/SECURITY.md b/.github/SECURITY.md
index fd4b8fd7b..a171f2687 100644
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -27,7 +27,6 @@ The following examples _do_ constitute security vulnerabilities:
 This list is not exhaustive, and we encourage you to report when in doubt.
 
 [^1]: https://github.com/torchgeo/torchgeo/security/advisories/GHSA-ghq9-vc6f-8qjf
-
 [^2]: https://github.com/torchgeo/torchgeo/security/advisories/GHSA-6gm9-8jxc-p862
 
 ## Known Security Considerations
```

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
