### PR TITLE
Fix the empty bounding-box in the IDTrees dataset

### DIFF
--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -64,6 +64,16 @@ class TestIDTReeS:
                 assert x['bbox_xyxy'].shape[-1] == 4
                 assert x['bbox_xyxy'].shape[0] > 0
 
+    def test_getitem_without_annotations(self, dataset: IDTReeS) -> None:
+        if dataset.split != 'train':
+            pytest.skip('Only the training split contains labels')
+
+        dataset.labels = dataset.labels.iloc[0:0]
+        sample = dataset[0]
+
+        assert sample['bbox_xyxy'].shape == (0, 4)
+        assert sample['label'].shape == (0,)
+
     def test_len(self, dataset: IDTReeS) -> None:
         assert len(dataset) == 3
 

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -324,7 +324,7 @@ class IDTReeS(NonGeoDataset):
                 ymax_px = max(row_min, row_max)
                 boxes.append([xmin_px, ymin_px, xmax_px, ymax_px])
 
-        tensor = torch.tensor(boxes)
+        tensor = torch.tensor(boxes).reshape(-1, 4)
         return tensor
 
     def _load_target(self, path: Path) -> Tensor:


### PR DESCRIPTION
### Summary

Reshaped the empty IDTreeS bounding box tensors to (0,4). Add a regression test for images without tree annotations.

### Rationale

IDTreeS previously returned an empty tensor w/ shape (0,). Detection code expects 4 bounding-box coordinates and could raise an IndexError. This addresses issue #4046.

### Checklist

- [x] I have read the Contributing docs.
- [x] I have read the AI policy.

- [ ] No AI usage: written by humans, for humans.
- [x] AI-assisted: AI helped with the coding, but I understand every line.
- [ ] AI-generated: AI did everything, review with caution.
