### PR TITLE
Add quantile regression with pinball loss

### DIFF
--- a/tests/losses/test_quantile.py
+++ b/tests/losses/test_quantile.py
@@ -1,0 +1,29 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+import torch
+
+from torchgeo.losses import PinballLoss
+
+
+class TestPinballLoss:
+    @pytest.mark.parametrize('shape', [(2, 3), (2, 3, 2, 4)])
+    def test_forward(self, shape: tuple[int, ...]) -> None:
+        predictions = torch.tensor([[0.0, 3.0, 4.0], [2.0, 0.0, -1.0]])
+        gradient = torch.tensor([[-0.2, 0.5, 0.2], [0.8, -0.5, -0.8]])
+        if len(shape) == 4:
+            predictions = predictions[:, :, None, None].expand(shape).clone()
+            gradient = gradient[:, :, None, None].expand(shape)
+        predictions.requires_grad_()
+        target = torch.ones((shape[0], 1, *shape[2:]))
+
+        loss = PinballLoss([0.2, 0.5, 0.8])(predictions, target)
+        torch.testing.assert_close(loss, torch.tensor(4.7 / 6))
+        loss.backward()
+        torch.testing.assert_close(predictions.grad, gradient / predictions.numel())
+
+    @pytest.mark.parametrize('quantiles', [[], [0], [1], [-0.1], [1.1], [float('nan')]])
+    def test_invalid_quantiles(self, quantiles: list[float]) -> None:
+        with pytest.raises(ValueError, match='nonempty and between 0 and 1'):
+            PinballLoss(quantiles)

--- a/tests/tasks/test_regression.py
+++ b/tests/tasks/test_regression.py
@@ -69,8 +69,9 @@ class TestRegression:
             'skippd',
         ],
     )
+    @pytest.mark.parametrize('pinball', [False, True])
     def test_trainer(
-        self, monkeypatch: MonkeyPatch, name: str, fast_dev_run: bool
+        self, monkeypatch: MonkeyPatch, name: str, fast_dev_run: bool, pinball: bool
     ) -> None:
         if name in ['skippd', 'digital_typhoon_id', 'digital_typhoon_time']:
             pytest.importorskip('h5py', minversion='3.10')
@@ -91,6 +92,9 @@ class TestRegression:
             '--trainer.log_every_n_steps',
             '1',
         ]
+
+        if pinball:
+            args.extend(['--model.init_args.loss', 'pinball'])
 
         main(['fit', *args])
         try:
@@ -230,8 +234,9 @@ class TestPixelwiseRegression:
             'copernicus_biomass_s3',
         ],
     )
+    @pytest.mark.parametrize('pinball', [False, True])
     def test_trainer(
-        self, monkeypatch: MonkeyPatch, name: str, fast_dev_run: bool
+        self, monkeypatch: MonkeyPatch, name: str, fast_dev_run: bool, pinball: bool
     ) -> None:
         config = os.path.join('tests', 'conf', name + '.yaml')
 
@@ -253,6 +258,9 @@ class TestPixelwiseRegression:
             '--trainer.log_every_n_steps',
             '1',
         ]
+
+        if pinball:
+            args.extend(['--model.init_args.loss', 'pinball'])
 
         main(['fit', *args])
         try:
@@ -359,3 +367,54 @@ class TestPixelwiseRegression:
 
     def test_vit_backbone(self) -> None:
         PixelwiseRegression(model='dpt', backbone='tu-vit_base_patch16_224')
+
+
+class TestQuantileRegression:
+    @pytest.fixture(params=[Regression, PixelwiseRegression])
+    def task_class(
+        self, request: pytest.FixtureRequest, monkeypatch: MonkeyPatch
+    ) -> type[Regression]:
+        monkeypatch.setattr(timm, 'create_model', TestRegression.create_model)
+        monkeypatch.setattr(smp, 'Unet', TestPixelwiseRegression.create_model)
+        return request.param
+
+    def test_steps(self, task_class: type[Regression]) -> None:
+        model = 'resnet18' if task_class is Regression else 'unet'
+        task = task_class(model=model, loss='pinball', quantiles=[0.5, 0.9, 0.1])
+        task.trainer = Trainer(accelerator='cpu', barebones=True)
+        with torch.no_grad():
+            for parameter in task.model.parameters():
+                parameter.zero_()
+            head = task.model.fc if task_class is Regression else task.model.conv1
+            head.bias.copy_(torch.tensor([1.0, 5.0, -1.0]))
+        shape = (2,) if task_class is Regression else (2, 2, 4)
+        batch = {
+            'image': torch.zeros(2, 3, 2, 4),
+            task.target_key: torch.full(shape, 2.0),
+        }
+
+        loss = task.training_step(batch, 0)
+        torch.testing.assert_close(loss, torch.tensor(1.1 / 3))
+        loss.backward()
+        torch.testing.assert_close(head.bias.grad, torch.tensor([-0.5, 0.1, -0.1]) / 3)
+        task.validation_step(batch, 0)
+        task.test_step(batch, 0)
+        for metrics in [task.train_metrics, task.val_metrics, task.test_metrics]:
+            for value in metrics.compute().values():
+                torch.testing.assert_close(value, torch.tensor(1.0))
+
+        predictions = task.predict_step(batch, 0)
+        expected = torch.tensor([1.0, 5.0, -1.0]).view(1, 3, *([1] * (len(shape) - 1)))
+        torch.testing.assert_close(predictions, expected.expand(2, 3, *shape[1:]))
+
+    @pytest.mark.parametrize('num_outputs,quantiles', [(2, [0.5]), (1, [0.1, 0.9])])
+    def test_invalid_config(
+        self, task_class: type[Regression], num_outputs: int, quantiles: list[float]
+    ) -> None:
+        with pytest.raises(ValueError, match='requires num_outputs=1 and quantile 0.5'):
+            task_class(
+                model='unet',
+                loss='pinball',
+                num_outputs=num_outputs,
+                quantiles=quantiles,
+            )

--- a/torchgeo/losses/__init__.py
+++ b/torchgeo/losses/__init__.py
@@ -5,5 +5,6 @@
 
 from .elects import EarlyRewardLoss
 from .qr import QRLoss, RQLoss
+from .quantile import PinballLoss
 
-__all__ = ('EarlyRewardLoss', 'QRLoss', 'RQLoss')
+__all__ = ('EarlyRewardLoss', 'PinballLoss', 'QRLoss', 'RQLoss')

--- a/torchgeo/losses/quantile.py
+++ b/torchgeo/losses/quantile.py
@@ -1,0 +1,49 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""Loss for quantile regression."""
+
+from collections.abc import Sequence
+
+import torch
+from torch import Tensor, nn
+
+
+class PinballLoss(nn.Module):
+    """Pinball loss, averaged over quantiles, samples, and spatial dimensions.
+
+    See equation (14) of `Image-to-Image Regression with Distribution-Free
+    Uncertainty Quantification <https://arxiv.org/abs/2202.05265>`_.
+
+    .. versionadded:: 0.11
+    """
+
+    def __init__(self, quantiles: Sequence[float]) -> None:
+        """Initialize a new PinballLoss instance.
+
+        Args:
+            quantiles: Quantile levels corresponding to prediction channels.
+
+        Raises:
+            ValueError: If quantiles are empty or outside (0, 1).
+        """
+        super().__init__()
+        if not quantiles or any(not 0 < q < 1 for q in quantiles):
+            raise ValueError('Quantiles must be nonempty and between 0 and 1.')
+        self.quantiles = tuple(quantiles)
+
+    def forward(self, predictions: Tensor, target: Tensor) -> Tensor:
+        """Compute the pinball loss.
+
+        Args:
+            predictions: Predictions of shape (B, Q, ...) for Q quantiles.
+            target: Regression targets of shape (B, 1, ...).
+
+        Returns:
+            Mean pinball loss.
+        """
+        quantiles = predictions.new_tensor(self.quantiles).view(
+            1, -1, *([1] * (predictions.ndim - 2))
+        )
+        error = target - predictions
+        return torch.maximum(quantiles * error, (quantiles - 1) * error).mean()

--- a/torchgeo/tasks/regression.py
+++ b/torchgeo/tasks/regression.py
@@ -4,6 +4,7 @@
 """Tasks for regression."""
 
 import os
+from collections.abc import Sequence
 from typing import Literal
 
 import kornia.augmentation as K
@@ -18,6 +19,7 @@ from torchvision.models._api import WeightsEnum
 from ..datamodules import BaseDataModule
 from ..datasets import RGBBandsMissingError, unbind_samples
 from ..datasets.utils import Sample
+from ..losses import PinballLoss
 from ..models import FCN, get_weight
 from . import utils
 from .base import BaseTask
@@ -38,11 +40,12 @@ class Regression(RegressionMixin, BaseTask):
         num_outputs: int = 1,
         labels: list[str] | None = None,
         num_filters: int = 3,
-        loss: Literal['mae', 'mse'] = 'mse',
+        loss: Literal['mae', 'mse', 'pinball'] = 'mse',
         lr: float = 1e-3,
         patience: int = 10,
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
+        quantiles: Sequence[float] = (0.1, 0.5, 0.9),
     ) -> None:
         """Initialize a new Regression instance.
 
@@ -61,7 +64,8 @@ class Regression(RegressionMixin, BaseTask):
             num_outputs: Number of prediction outputs.
             labels: List of feature names.
             num_filters: Number of filters. Only applicable when model='fcn'.
-            loss: One of 'mse' or 'mae'.
+            loss: One of 'mse', 'mae', or 'pinball'. Quantile regression with
+                'pinball' requires num_outputs=1.
             lr: Learning rate for optimizer.
             patience: Patience for learning rate scheduler.
             freeze_backbone: Freeze the backbone network to linear probe
@@ -69,6 +73,14 @@ class Regression(RegressionMixin, BaseTask):
             freeze_decoder: Freeze the decoder network to linear probe
                 the regression head. Does not support FCN models.
                 Only applicable to PixelwiseRegression.
+            quantiles: Quantile levels to predict when loss='pinball'. Must include
+                0.5, which is used for metrics and plotting. Predictions contain
+                one channel per quantile, in this order. These estimates are not
+                calibrated prediction intervals.
+
+        Raises:
+            ValueError: If pinball loss is used with multiple targets, invalid
+                quantile levels, or without the median quantile.
 
         .. versionchanged:: 0.4
            Change regression model support from torchvision.models to timm
@@ -82,7 +94,17 @@ class Regression(RegressionMixin, BaseTask):
 
         .. versionadded:: 0.10
            The *labels* parameter.
+
+        .. versionadded:: 0.11
+           The *quantiles* parameter and 'pinball' loss.
         """
+        self.median_index = None
+        if loss == 'pinball':
+            if num_outputs != 1 or 0.5 not in quantiles:
+                raise ValueError(
+                    'Pinball loss requires num_outputs=1 and quantile 0.5.'
+                )
+            self.median_index = quantiles.index(0.5)
         self.weights = weights
         super().__init__()
 
@@ -92,7 +114,11 @@ class Regression(RegressionMixin, BaseTask):
         weights = self.weights
         self.model = timm.create_model(
             self.hparams['model'],
-            num_classes=self.hparams['num_outputs'],
+            num_classes=(
+                len(self.hparams['quantiles'])
+                if self.median_index is not None
+                else self.hparams['num_outputs']
+            ),
             in_chans=self.hparams['in_channels'],
             pretrained=weights is True,
         )
@@ -118,6 +144,13 @@ class Regression(RegressionMixin, BaseTask):
             for param in self.model.get_classifier().parameters():  # ty: ignore[call-non-callable]
                 param.requires_grad = True
 
+    def configure_losses(self) -> None:
+        """Initialize the loss criterion."""
+        if self.hparams['loss'] == 'pinball':
+            self.criterion = PinballLoss(self.hparams['quantiles'])
+        else:
+            super().configure_losses()
+
     def training_step(
         self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
@@ -140,6 +173,8 @@ class Regression(RegressionMixin, BaseTask):
             y = y.unsqueeze(dim=1)
         loss: Tensor = self.criterion(y_hat, y)
         self.log('train_loss', loss, batch_size=batch_size)
+        if self.median_index is not None:
+            y_hat = y_hat[:, self.median_index : self.median_index + 1].contiguous()
         self.train_metrics(y_hat, y)
 
         return loss
@@ -163,6 +198,8 @@ class Regression(RegressionMixin, BaseTask):
             y = y.unsqueeze(dim=1)
         loss = self.criterion(y_hat, y)
         self.log('val_loss', loss, batch_size=batch_size)
+        if self.median_index is not None:
+            y_hat = y_hat[:, self.median_index : self.median_index + 1].contiguous()
         self.val_metrics(y_hat, y)
 
         if (
@@ -218,6 +255,8 @@ class Regression(RegressionMixin, BaseTask):
             y = y.unsqueeze(dim=1)
         loss = self.criterion(y_hat, y)
         self.log('test_loss', loss, batch_size=batch_size)
+        if self.median_index is not None:
+            y_hat = y_hat[:, self.median_index : self.median_index + 1].contiguous()
         self.test_metrics(y_hat, y)
 
     def predict_step(
@@ -231,7 +270,8 @@ class Regression(RegressionMixin, BaseTask):
             dataloader_idx: Index of the current dataloader.
 
         Returns:
-            Output predicted probabilities.
+            Regression predictions. With pinball loss, the shape is (B, Q)
+            or (B, Q, H, W), with channels in the order of *quantiles*.
         """
         x = batch['image']
         y_hat: Tensor = self(x)
@@ -253,6 +293,9 @@ class PixelwiseRegression(Regression):
         model = self.hparams['model']
         backbone = self.hparams['backbone']
         in_channels = self.hparams['in_channels']
+        num_outputs = (
+            len(self.hparams['quantiles']) if self.median_index is not None else 1
+        )
 
         match model:
             case 'unet':
@@ -260,19 +303,19 @@ class PixelwiseRegression(Regression):
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_outputs,
                 )
             case 'deeplabv3+':
                 self.model = smp.DeepLabV3Plus(
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_outputs,
                 )
             case 'fcn':
                 self.model = FCN(
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_outputs,
                     num_filters=self.hparams['num_filters'],
                 )
             case 'upernet':
@@ -280,21 +323,21 @@ class PixelwiseRegression(Regression):
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_outputs,
                 )
             case 'segformer':
                 self.model = smp.Segformer(
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_outputs,
                 )
             case 'dpt':
                 self.model = smp.DPT(
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_outputs,
                 )
 
         if model != 'fcn' and weights and weights is not True:


### PR DESCRIPTION
### Summary

Add `PinballLoss` and `loss="pinball"` to `Regression` and `PixelwiseRegression`. Models predict one channel per requested quantile for one regression target. The loss trains all quantiles; median predictions feed existing metrics and plots. These estimates are not calibrated prediction intervals.

Quantiles are registered as a buffer so they move with the loss module. The loss rejects mismatched prediction channels or target shapes before broadcasting. Task branches explicitly check `loss == 'pinball'`; pixelwise model channels are named separately from the constructor's target count.

### Rationale

Closes #3456. A possible application is biomass mapping with lower, median, and upper conditional quantiles. This PR does not provide field-study or production performance results.

### Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_socket -p pytest_cov.plugin -q tests/losses/test_quantile.py tests/tasks/test_regression.py --cov=torchgeo/losses --cov=torchgeo/tasks` — 77 passed, 33 slow tests deselected. Both changed production modules have 100% line coverage.
- Numerical loss/gradient tests cover scalar and spatial targets; task tests cover quantile ordering, median metrics, and fit/test/predict. The buffer/dtype assertion fails on its previous implementation. Five invalid-shape cases fail before the shape fix and pass afterward.
- CPU YAML `fast_dev_run` fit/test passed with actual ResNet18 and U-Net/ResNet18 models using `cyclone.yaml` and `copernicus_biomass_s3.yaml`, `loss=pinball`, and repository synthetic fixtures. These are smoke runs, not a trained application study.
- CPU checks confirm ordinary `Regression(num_outputs=2)` works with MAE/MSE. Current upstream pixelwise models hard-code one output channel; that pre-existing limitation remains unchanged.
- Ruff check/format and full ty pass; `git diff --check` passes.

Read the Docs currently encounters the two missing Tokenizers references tracked in #4125, outside this PR.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
