### PR TITLE
UnionDataset: support one or more datasets

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1638,7 +1638,7 @@ class IntersectionDataset(GeoDataset):
 
 
 class UnionDataset(GeoDataset):
-    """Dataset representing the union of two GeoDatasets.
+    """Dataset representing the union of one or more GeoDatasets.
 
     This allows users to do things like:
 
@@ -1659,32 +1659,33 @@ class UnionDataset(GeoDataset):
 
     def __init__(
         self,
-        dataset1: GeoDataset,
-        dataset2: GeoDataset,
+        *datasets: GeoDataset,
         collate_fn: Callable[[Sequence[Sample]], Sample] = merge_samples,
         transforms: Callable[[Sample], Sample] | None = None,
     ) -> None:
         """Initialize a new UnionDataset instance.
 
-        When computing the union between two datasets that both contain model inputs
-        (such as images) or model outputs (such as masks), the default behavior is to
-        merge the data to create a single image/mask. The *collate_fn* parameter can be
-        used to change this behavior.
+        When computing the union between one or more datasets and multiple datasets
+        contain model inputs (such as images) or model outputs (such as masks),
+        the default behavior is to merge the data to create a single image/mask.
+        The *collate_fn* parameter can be used to change this behavior.
 
         Args:
-            dataset1: the first dataset
-            dataset2: the second dataset
+            *datasets: one or more datasets
             collate_fn: function used to collate samples
             transforms: a function/transform that takes input sample and its target as
                 entry and returns a transformed version
 
         Raises:
-            TypeError: if either dataset is not a :class:`GeoDataset`
+            TypeError: if any dataset is not a :class:`GeoDataset`
+
+        .. versionadded:: 0.11
+           The *datasets* parameter.
 
         .. versionadded:: 0.4
-            The *transforms* parameter.
+           The *transforms* parameter.
         """
-        self.datasets = [dataset1, dataset2]
+        self.datasets = datasets
         self.collate_fn = collate_fn
         self.transforms = transforms
 
@@ -1692,10 +1693,10 @@ class UnionDataset(GeoDataset):
             if not isinstance(ds, GeoDataset):
                 raise TypeError('UnionDataset only supports GeoDatasets')
 
-        dataset2.crs = dataset1.crs
-        dataset2.res = dataset1.res
+            ds.crs = datasets[0].crs
+            ds.res = datasets[0].res
 
-        self.index = pd.concat([dataset1.index, dataset2.index])
+        self.index = pd.concat([ds.index for ds in datasets])
 
     def __getitem__(self, index: GeoSlice) -> Sample:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
@@ -1758,8 +1759,8 @@ class UnionDataset(GeoDataset):
             new_crs: New :term:`coordinate reference system (CRS)`.
         """
         self.index.to_crs(new_crs, inplace=True)
-        self.datasets[0].crs = new_crs
-        self.datasets[1].crs = new_crs
+        for ds in self.datasets:
+            ds.crs = new_crs
 
     @property
     def res(self) -> tuple[float, float]:
@@ -1777,5 +1778,5 @@ class UnionDataset(GeoDataset):
         Args:
             new_res: New resolution.
         """
-        self.datasets[0].res = new_res
-        self.datasets[1].res = new_res
+        for ds in self.datasets:
+            ds.res = new_res


### PR DESCRIPTION
### Summary

Previously, UnionDataset only supported exactly 2 datasets. With this PR, UnionDataset now supports 1+ datasets.

### Rationale

1. It's more flexible and powerful with the same # lines of code, so why not?
2. Support for exactly 1 dataset or 3+ datasets would be really nice for #3807 @evgeniialappo 

I'm thinking about doing the same thing for IntersectionDataset, although it's a lot more complicated. I could have sworn I had a good reason I decided to only support exactly 2 datasets, but now I can't remember why?

> [!WARNING]
> This change is technically backwards-incompatible. While most users using `ds1 | ds2 | ds3` won't notice any difference, the following no longer work:
> ```python
> UnionDataset(dataset1=ds1, dataset2=ds2)
> UnionDataset(ds1, ds2, collate_fn, transforms)
> ```
> These uses can be migrated like so:
> ```python
> UnionDataset(ds1, ds2)
> UnionDataset(ds1, ds2, collate_fn=collate_fn, transforms=transforms)
> ```

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [x] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
