### PR TITLE
Fix IDTReeS bounding box shape for empty annotations

### DIFF
--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -64,6 +64,15 @@ class TestIDTReeS:
                 assert x['bbox_xyxy'].shape[-1] == 4
                 assert x['bbox_xyxy'].shape[0] > 0
 
+    def test_getitem_without_annotations(self, dataset: IDTReeS) -> None:
+        if dataset.split != 'train':
+            pytest.skip('Only the training split contains labels')
+
+        dataset.labels = dataset.labels.iloc[:0]
+        sample = dataset[0]
+        assert sample['bbox_xyxy'].shape == (0, 4)
+        assert sample['label'].shape == (0,)
+
     def test_len(self, dataset: IDTReeS) -> None:
         assert len(dataset) == 3
 

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -324,7 +324,7 @@ class IDTReeS(NonGeoDataset):
                 ymax_px = max(row_min, row_max)
                 boxes.append([xmin_px, ymin_px, xmax_px, ymax_px])
 
-        tensor = torch.tensor(boxes)
+        tensor = torch.tensor(boxes).reshape(-1, 4)
         return tensor
 
     def _load_target(self, path: Path) -> Tensor:


### PR DESCRIPTION
### Summary

Fixes #4046. Reshape IDTReeS bounding boxes to `(N, 4)` so indexing an image without annotations returns empty boxes and labels instead of crashing in box filtering.

### Rationale

This keeps the fix to one source line and adds one public-indexing regression using the existing fixture. Existing tests are unchanged. Earlier attempts #4049 and #4093 are closed; this includes the regression requested on #4049.

Validation: the regression failed before the fix; the IDTReeS tests passed (15 passed, 2 skipped), along with Ruff formatting/lint and ty. A later coverage run encountered a local NumPy import error, so coverage is not verified.

### Checklist

- [x] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [x] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)
- [ ] 🟢 **No AI usage**: written by humans, for humans
- [x] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
