### PR TITLE
Fix AirQuality download caching

### DIFF
--- a/tests/datasets/test_air_quality.py
+++ b/tests/datasets/test_air_quality.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import pytest
 from _pytest.fixtures import SubRequest
+from pandas.testing import assert_frame_equal
 from pytest import MonkeyPatch
 from torch import Tensor
 
@@ -51,6 +52,24 @@ class TestAirQuality:
     def test_already_downloaded(self) -> None:
         root = os.path.join('tests', 'data', 'air_quality')
         AirQuality(root)
+
+    def test_download_saves_data_for_offline_reuse(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        source = Path('tests/data/air_quality/data.csv').resolve()
+        monkeypatch.setattr(AirQuality, 'url', str(source))
+        root = tmp_path / 'air_quality'
+
+        downloaded = AirQuality(root, download=True)
+
+        cached_file = root / AirQuality.data_file_name
+        assert cached_file.is_file()
+        assert cached_file.read_bytes() == source.read_bytes()
+
+        monkeypatch.setattr(AirQuality, 'url', str(tmp_path / 'unavailable.csv'))
+        offline = AirQuality(root, download=False)
+        assert_frame_equal(offline.input_data, downloaded.input_data)
+        assert_frame_equal(offline.target_data, downloaded.target_data)
 
     @pytest.mark.parametrize('features', [None, GT])
     def test_plot(self, dataset: AirQuality, features: list[str] | None) -> None:

--- a/torchgeo/datasets/air_quality.py
+++ b/torchgeo/datasets/air_quality.py
@@ -15,7 +15,7 @@ from matplotlib.figure import Figure
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, Sample
+from .utils import Path, Sample, download_url
 
 
 class AirQuality(NonGeoDataset):
@@ -134,7 +134,7 @@ class AirQuality(NonGeoDataset):
         if filepath.is_file():
             pass
         elif self.download:
-            filepath = self.url
+            download_url(self.url, self.root, filename=self.data_file_name)
         else:
             raise DatasetNotFoundError(self)
 


### PR DESCRIPTION
### Summary

Save the AirQuality CSV in the requested root directory using `download_url`, then read the saved file. Add a regression test that checks the saved CSV and verifies that loading it with `download=False` returns the same input and target data.

### Rationale

Previously, `download=True` read directly from the URL without saving the dataset locally, preventing later offline reuse.

Fixes #4047.

### Validation

- All 19 AirQuality dataset tests pass.
- Ruff lint and formatting checks pass for both changed files.
- Type checks pass for both changed files.
- Coverage collection could not complete locally because of a NumPy import error.

### AI disclosure

This fix was created using GPT-6 Astra.

### Checklist

- [ ] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [ ] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- AI classification is left for the contributor to confirm after review. -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [ ] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
