### PR TITLE
Datasets: include the native CRS in each sample

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -438,7 +438,7 @@ class TestRasterDataset:
         assert isinstance(x[key], torch.Tensor)
         assert x[key].ndim == expected_ndim
         assert x[key].shape[-3] == len(ds.bands)
-        assert x['crs'] == ds.crs
+        assert ds.crs_registry[int(x['crs'])] == ds.crs
 
     @pytest.mark.parametrize(
         'bands',
@@ -464,7 +464,7 @@ class TestRasterDataset:
         assert isinstance(x[key], torch.Tensor)
         assert x[key].ndim == expected_ndim
         assert x[key].shape[-3] == len(ds.bands)
-        assert x['crs'] == ds.crs
+        assert ds.crs_registry[int(x['crs'])] == ds.crs
 
     def test_reprojection(self) -> None:
         naip1 = NAIP(self.naip_dir, crs=CRS.from_epsg(4087))
@@ -636,7 +636,7 @@ class TestXarrayDataset:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
-        assert x['crs'] == dataset.crs
+        assert dataset.crs_registry[int(x['crs'])] == dataset.crs
 
     def test_and(self, dataset: XarrayDataset) -> None:
         ds = dataset & dataset
@@ -715,7 +715,7 @@ class TestVectorDataset:
         assert isinstance(x, dict)
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(x['mask'].unique(), torch.tensor([0, 1], dtype=torch.uint8))
-        assert x['crs'] == dataset.crs
+        assert dataset.crs_registry[int(x['crs'])] == dataset.crs
 
     def test_getitem_obj_det(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'object_detection'
@@ -958,7 +958,7 @@ class TestIntersectionDataset:
     def test_getitem(self, dataset: IntersectionDataset) -> None:
         sample = dataset[dataset.bounds]
         assert isinstance(sample['image'], torch.Tensor)
-        assert sample['crs'] == dataset.crs
+        assert dataset.crs_registry[int(sample['crs'])] == dataset.crs
 
     def test_len(self, dataset: IntersectionDataset) -> None:
         assert len(dataset) == 1
@@ -1236,7 +1236,7 @@ class TestUnionDataset:
     def test_getitem(self, dataset: UnionDataset) -> None:
         sample = dataset[dataset.bounds]
         assert isinstance(sample['image'], torch.Tensor)
-        assert sample['crs'] == dataset.crs
+        assert dataset.crs_registry[int(sample['crs'])] == dataset.crs
 
     def test_len(self, dataset: UnionDataset) -> None:
         assert len(dataset) == 2

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -438,6 +438,7 @@ class TestRasterDataset:
         assert isinstance(x[key], torch.Tensor)
         assert x[key].ndim == expected_ndim
         assert x[key].shape[-3] == len(ds.bands)
+        assert x['crs'] == ds.crs
 
     @pytest.mark.parametrize(
         'bands',
@@ -463,6 +464,7 @@ class TestRasterDataset:
         assert isinstance(x[key], torch.Tensor)
         assert x[key].ndim == expected_ndim
         assert x[key].shape[-3] == len(ds.bands)
+        assert x['crs'] == ds.crs
 
     def test_reprojection(self) -> None:
         naip1 = NAIP(self.naip_dir, crs=CRS.from_epsg(4087))
@@ -634,6 +636,7 @@ class TestXarrayDataset:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
+        assert x['crs'] == dataset.crs
 
     def test_and(self, dataset: XarrayDataset) -> None:
         ds = dataset & dataset
@@ -712,6 +715,7 @@ class TestVectorDataset:
         assert isinstance(x, dict)
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(x['mask'].unique(), torch.tensor([0, 1], dtype=torch.uint8))
+        assert x['crs'] == dataset.crs
 
     def test_getitem_obj_det(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'object_detection'
@@ -954,6 +958,7 @@ class TestIntersectionDataset:
     def test_getitem(self, dataset: IntersectionDataset) -> None:
         sample = dataset[dataset.bounds]
         assert isinstance(sample['image'], torch.Tensor)
+        assert sample['crs'] == dataset.crs
 
     def test_len(self, dataset: IntersectionDataset) -> None:
         assert len(dataset) == 1
@@ -1231,6 +1236,7 @@ class TestUnionDataset:
     def test_getitem(self, dataset: UnionDataset) -> None:
         sample = dataset[dataset.bounds]
         assert isinstance(sample['image'], torch.Tensor)
+        assert sample['crs'] == dataset.crs
 
     def test_len(self, dataset: UnionDataset) -> None:
         assert len(dataset) == 2

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -438,7 +438,7 @@ class TestRasterDataset:
         assert isinstance(x[key], torch.Tensor)
         assert x[key].ndim == expected_ndim
         assert x[key].shape[-3] == len(ds.bands)
-        assert ds.crs_registry[int(x['crs'])] == ds.crs
+        assert ds.crs_registry[int(x['crs_index'])] == ds.crs
 
     @pytest.mark.parametrize(
         'bands',
@@ -464,7 +464,34 @@ class TestRasterDataset:
         assert isinstance(x[key], torch.Tensor)
         assert x[key].ndim == expected_ndim
         assert x[key].shape[-3] == len(ds.bands)
-        assert ds.crs_registry[int(x['crs'])] == ds.crs
+        assert ds.crs_registry[int(x['crs_index'])] == ds.crs
+
+    def test_crs_registry_deterministic(self) -> None:
+        """``crs_registry`` is a deterministic, per-process function of the files.
+
+        Distributed training builds an independent dataset per rank/worker, so a
+        sample's integer ``crs`` only resolves correctly if every process derives an
+        identical registry with no sharing. Two independent constructions (two ranks)
+        and a pickle round-trip (a spawned worker / broadcast) must all agree.
+        """
+        ds1 = NAIP(self.naip_dir)
+        ds2 = NAIP(self.naip_dir)
+        assert ds1.crs_registry == ds2.crs_registry
+
+        x = ds1[ds1.bounds]
+        assert x['crs_index'].dtype == torch.long
+        assert x['crs_index'].ndim == 0
+        assert ds1.crs_registry[int(x['crs_index'])] == ds1.crs
+
+        # The registry must survive the process boundary exactly as a spawned worker
+        # or a DDP broadcast moves the dataset (via pickle), keeping indices stable.
+        ds3 = pickle.loads(pickle.dumps(ds1))
+        assert ds3.crs_registry == ds1.crs_registry
+        y = ds3[ds3.bounds]
+        assert (
+            ds3.crs_registry[int(y['crs_index'])]
+            == ds1.crs_registry[int(x['crs_index'])]
+        )
 
     def test_reprojection(self) -> None:
         naip1 = NAIP(self.naip_dir, crs=CRS.from_epsg(4087))
@@ -636,7 +663,7 @@ class TestXarrayDataset:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
-        assert dataset.crs_registry[int(x['crs'])] == dataset.crs
+        assert dataset.crs_registry[int(x['crs_index'])] == dataset.crs
 
     def test_and(self, dataset: XarrayDataset) -> None:
         ds = dataset & dataset
@@ -715,7 +742,7 @@ class TestVectorDataset:
         assert isinstance(x, dict)
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(x['mask'].unique(), torch.tensor([0, 1], dtype=torch.uint8))
-        assert dataset.crs_registry[int(x['crs'])] == dataset.crs
+        assert dataset.crs_registry[int(x['crs_index'])] == dataset.crs
 
     def test_getitem_obj_det(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'object_detection'
@@ -958,7 +985,7 @@ class TestIntersectionDataset:
     def test_getitem(self, dataset: IntersectionDataset) -> None:
         sample = dataset[dataset.bounds]
         assert isinstance(sample['image'], torch.Tensor)
-        assert dataset.crs_registry[int(sample['crs'])] == dataset.crs
+        assert dataset.crs_registry[int(sample['crs_index'])] == dataset.crs
 
     def test_len(self, dataset: IntersectionDataset) -> None:
         assert len(dataset) == 1
@@ -1236,7 +1263,7 @@ class TestUnionDataset:
     def test_getitem(self, dataset: UnionDataset) -> None:
         sample = dataset[dataset.bounds]
         assert isinstance(sample['image'], torch.Tensor)
-        assert dataset.crs_registry[int(sample['crs'])] == dataset.crs
+        assert dataset.crs_registry[int(sample['crs_index'])] == dataset.crs
 
     def test_len(self, dataset: UnionDataset) -> None:
         assert len(dataset) == 2

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -466,33 +466,6 @@ class TestRasterDataset:
         assert x[key].shape[-3] == len(ds.bands)
         assert ds.crs_registry[int(x['crs_index'])] == ds.crs
 
-    def test_crs_registry_deterministic(self) -> None:
-        """``crs_registry`` is a deterministic, per-process function of the files.
-
-        Distributed training builds an independent dataset per rank/worker, so a
-        sample's integer ``crs`` only resolves correctly if every process derives an
-        identical registry with no sharing. Two independent constructions (two ranks)
-        and a pickle round-trip (a spawned worker / broadcast) must all agree.
-        """
-        ds1 = NAIP(self.naip_dir)
-        ds2 = NAIP(self.naip_dir)
-        assert ds1.crs_registry == ds2.crs_registry
-
-        x = ds1[ds1.bounds]
-        assert x['crs_index'].dtype == torch.long
-        assert x['crs_index'].ndim == 0
-        assert ds1.crs_registry[int(x['crs_index'])] == ds1.crs
-
-        # The registry must survive the process boundary exactly as a spawned worker
-        # or a DDP broadcast moves the dataset (via pickle), keeping indices stable.
-        ds3 = pickle.loads(pickle.dumps(ds1))
-        assert ds3.crs_registry == ds1.crs_registry
-        y = ds3[ds3.bounds]
-        assert (
-            ds3.crs_registry[int(y['crs_index'])]
-            == ds1.crs_registry[int(x['crs_index'])]
-        )
-
     def test_reprojection(self) -> None:
         naip1 = NAIP(self.naip_dir, crs=CRS.from_epsg(4087))
         naip2 = NAIP(self.naip_dir, crs=CRS.from_epsg(4326))

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -16,6 +16,7 @@ import rasterio
 import torch
 from affine import Affine
 from numpy.typing import NDArray
+from pyproj import CRS
 from pytest import MonkeyPatch
 from rasterio import MemoryFile
 from rasterio.transform import from_origin
@@ -507,7 +508,10 @@ class TestCollateFunctionsMatchingKeys:
     @pytest.fixture(scope='class')
     @classmethod
     def samples(cls) -> list[Sample]:
-        return [{'image': torch.tensor([1, 2, 0])}, {'image': torch.tensor([0, 0, 3])}]
+        return [
+            {'image': torch.tensor([1, 2, 0]), 'crs': CRS.from_epsg(4326)},
+            {'image': torch.tensor([0, 0, 3]), 'crs': CRS.from_epsg(3857)},
+        ]
 
     def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
         sample = stack_samples(samples)
@@ -517,6 +521,7 @@ class TestCollateFunctionsMatchingKeys:
         new_samples = unbind_samples(sample)
         for i in range(2):
             assert torch.allclose(samples[i]['image'], new_samples[i]['image'])
+            assert samples[i]['crs'] == new_samples[i]['crs']
 
     def test_concat_samples(self, samples: list[Sample]) -> None:
         sample = concat_samples(samples)

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -16,7 +16,6 @@ import rasterio
 import torch
 from affine import Affine
 from numpy.typing import NDArray
-from pyproj import CRS
 from pytest import MonkeyPatch
 from rasterio import MemoryFile
 from rasterio.transform import from_origin
@@ -508,10 +507,7 @@ class TestCollateFunctionsMatchingKeys:
     @pytest.fixture(scope='class')
     @classmethod
     def samples(cls) -> list[Sample]:
-        return [
-            {'image': torch.tensor([1, 2, 0]), 'crs': CRS.from_epsg(4326)},
-            {'image': torch.tensor([0, 0, 3]), 'crs': CRS.from_epsg(3857)},
-        ]
+        return [{'image': torch.tensor([1, 2, 0])}, {'image': torch.tensor([0, 0, 3])}]
 
     def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
         sample = stack_samples(samples)
@@ -521,7 +517,6 @@ class TestCollateFunctionsMatchingKeys:
         new_samples = unbind_samples(sample)
         for i in range(2):
             assert torch.allclose(samples[i]['image'], new_samples[i]['image'])
-            assert samples[i]['crs'] == new_samples[i]['crs']
 
     def test_concat_samples(self, samples: list[Sample]) -> None:
         sample = concat_samples(samples)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -281,6 +281,22 @@ class GeoDataset(Dataset[Sample], abc.ABC, PlottingMixin):
         self.index.to_crs(new_crs, inplace=True)
 
     @property
+    def crs_registry(self) -> list[PROJ_CRS]:
+        """Ordered registry of the CRSs a sample's ``crs`` index refers to.
+
+        A sample's ``crs`` key is an integer index into this list, letting the
+        per-sample :term:`coordinate reference system (CRS)` travel as a tensor (see
+        :data:`~torchgeo.datasets.utils.Sample`). A plain dataset reads every query in
+        :attr:`crs`, so the registry holds that single CRS.
+
+        Returns:
+            The CRSs this dataset can emit, in index order.
+
+        .. versionadded:: 0.11
+        """
+        return [self.crs]
+
+    @property
     def res(self) -> tuple[float, float]:
         """Resolution of the dataset in units of CRS.
 
@@ -575,7 +591,7 @@ class RasterDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
-            'crs': out_crs,
+            'crs': torch.tensor(self.crs_registry.index(out_crs)),
             'transform': torch.tensor(transform),
         }
 
@@ -968,7 +984,7 @@ class XarrayDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
-            'crs': out_crs,
+            'crs': torch.tensor(self.crs_registry.index(out_crs)),
             'image': image,
             'transform': torch.tensor(transform),
         }
@@ -1301,7 +1317,7 @@ class VectorDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
-            'crs': out_crs,
+            'crs': torch.tensor(self.crs_registry.index(out_crs)),
             'transform': torch.tensor(transform),
         }
 
@@ -1581,7 +1597,12 @@ class IntersectionDataset(GeoDataset):
         # All datasets are guaranteed to have a valid index
         samples = [ds[index] for ds in self.datasets]
 
+        # The combined sample's CRS is this dataset's own: children are read into a
+        # common grid, so drop their per-child crs indices and re-stamp our own.
+        for s in samples:
+            s.pop('crs', None)
         sample = self.collate_fn(samples)
+        sample['crs'] = torch.tensor(self.crs_registry.index(self.crs))
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -1725,7 +1746,12 @@ class UnionDataset(GeoDataset):
                 f'index: {index} not found in dataset with bounds: {self.bounds}'
             )
 
+        # The combined sample's CRS is this dataset's own: children are read into a
+        # common grid, so drop their per-child crs indices and re-stamp our own.
+        for s in samples:
+            s.pop('crs', None)
         sample = self.collate_fn(samples)
+        sample['crs'] = torch.tensor(self.crs_registry.index(self.crs))
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -575,6 +575,7 @@ class RasterDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
+            'crs': out_crs,
             'transform': torch.tensor(transform),
         }
 
@@ -967,6 +968,7 @@ class XarrayDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
+            'crs': out_crs,
             'image': image,
             'transform': torch.tensor(transform),
         }
@@ -1299,6 +1301,7 @@ class VectorDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
+            'crs': out_crs,
             'transform': torch.tensor(transform),
         }
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -284,7 +284,7 @@ class GeoDataset(Dataset[Sample], abc.ABC, PlottingMixin):
     def crs_registry(self) -> list[PROJ_CRS]:
         """Ordered registry of the CRSs a sample's ``crs`` index refers to.
 
-        A sample's ``crs`` key is an integer index into this list, letting the
+        A sample's ``crs_index`` key is an integer index into this list, letting the
         per-sample :term:`coordinate reference system (CRS)` travel as a tensor (see
         :data:`~torchgeo.datasets.utils.Sample`). A plain dataset reads every query in
         :attr:`crs`, so the registry holds that single CRS.
@@ -591,7 +591,7 @@ class RasterDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
-            'crs': torch.tensor(self.crs_registry.index(out_crs)),
+            'crs_index': torch.tensor(self.crs_registry.index(out_crs)),
             'transform': torch.tensor(transform),
         }
 
@@ -984,7 +984,7 @@ class XarrayDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
-            'crs': torch.tensor(self.crs_registry.index(out_crs)),
+            'crs_index': torch.tensor(self.crs_registry.index(out_crs)),
             'image': image,
             'transform': torch.tensor(transform),
         }
@@ -1317,7 +1317,7 @@ class VectorDataset(GeoDataset):
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample: Sample = {
             'bounds': self._slice_to_tensor(index),
-            'crs': torch.tensor(self.crs_registry.index(out_crs)),
+            'crs_index': torch.tensor(self.crs_registry.index(out_crs)),
             'transform': torch.tensor(transform),
         }
 
@@ -1600,9 +1600,9 @@ class IntersectionDataset(GeoDataset):
         # The combined sample's CRS is this dataset's own: children are read into a
         # common grid, so drop their per-child crs indices and re-stamp our own.
         for s in samples:
-            s.pop('crs', None)
+            s.pop('crs_index', None)
         sample = self.collate_fn(samples)
-        sample['crs'] = torch.tensor(self.crs_registry.index(self.crs))
+        sample['crs_index'] = torch.tensor(self.crs_registry.index(self.crs))
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -1749,9 +1749,9 @@ class UnionDataset(GeoDataset):
         # The combined sample's CRS is this dataset's own: children are read into a
         # common grid, so drop their per-child crs indices and re-stamp our own.
         for s in samples:
-            s.pop('crs', None)
+            s.pop('crs_index', None)
         sample = self.collate_fn(samples)
-        sample['crs'] = torch.tensor(self.crs_registry.index(self.crs))
+        sample['crs_index'] = torch.tensor(self.crs_registry.index(self.crs))
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -282,12 +282,11 @@ class GeoDataset(Dataset[Sample], abc.ABC, PlottingMixin):
 
     @property
     def crs_registry(self) -> list[PROJ_CRS]:
-        """Ordered registry of the CRSs a sample's ``crs`` index refers to.
+        """Ordered registry of the CRSs a sample's ``crs_index`` refers to.
 
-        A sample's ``crs_index`` key is an integer index into this list, letting the
-        per-sample :term:`coordinate reference system (CRS)` travel as a tensor (see
-        :data:`~torchgeo.datasets.utils.Sample`). A plain dataset reads every query in
-        :attr:`crs`, so the registry holds that single CRS.
+        A sample's ``crs_index`` is an integer index into this list, so the per-sample
+        CRS travels as a tensor. A dataset currently reads every query in :attr:`crs`,
+        so the registry holds only that single CRS.
 
         Returns:
             The CRSs this dataset can emit, in index order.
@@ -1597,8 +1596,8 @@ class IntersectionDataset(GeoDataset):
         # All datasets are guaranteed to have a valid index
         samples = [ds[index] for ds in self.datasets]
 
-        # The combined sample's CRS is this dataset's own: children are read into a
-        # common grid, so drop their per-child crs indices and re-stamp our own.
+        # We don't yet resolve the combined CRS from the child samples, so use self.crs.
+        # Each child's crs_index refers to its own registry, so drop it.
         for s in samples:
             s.pop('crs_index', None)
         sample = self.collate_fn(samples)
@@ -1746,8 +1745,8 @@ class UnionDataset(GeoDataset):
                 f'index: {index} not found in dataset with bounds: {self.bounds}'
             )
 
-        # The combined sample's CRS is this dataset's own: children are read into a
-        # common grid, so drop their per-child crs indices and re-stamp our own.
+        # We don't yet resolve the combined CRS from the child samples, so use self.crs.
+        # Each child's crs_index refers to its own registry, so drop it.
         for s in samples:
             s.pop('crs_index', None)
         sample = self.collate_fn(samples)

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -75,11 +75,11 @@ Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
 #: * prediction: predicted output
 #: * bounds: spatiotemporal bounds of the sample
 #: * transform: affine transform of the sample
-#: * crs: :term:`coordinate reference system (CRS)` the sample is in
+#: * crs_index: index into the dataset's ``crs_registry`` giving the sample's CRS
 #:
-#: Values are of type torch.Tensor. The ``crs`` key holds an integer index into the
-#: dataset's :attr:`~torchgeo.datasets.geo.GeoDataset.crs_registry`, so the per-sample
-#: :term:`coordinate reference system (CRS)` travels as a tensor.
+#: Values are of type torch.Tensor. The ``crs_index`` key holds an integer index into
+#: the dataset's :attr:`~torchgeo.datasets.geo.GeoDataset.crs_registry`, so the
+#: per-sample :term:`coordinate reference system (CRS)` travels as a tensor.
 Sample: TypeAlias = dict[str, Tensor]  # noqa: UP040
 
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -73,9 +73,14 @@ Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
 #: * label: expected output classification or regression label
 #: * bbox_xyxy: expected output bounding box in (x1, y1, x2, y2) format
 #: * prediction: predicted output
+#: * bounds: spatiotemporal bounds of the sample
+#: * transform: affine transform of the sample
+#: * crs: :term:`coordinate reference system (CRS)` the sample is in
 #:
-#: Values are of type torch.Tensor.
-Sample: TypeAlias = dict[str, Tensor]  # noqa: UP040
+#: Values are usually of type torch.Tensor. The ``crs`` key is an exception: it holds
+#: a non-tensor :class:`pyproj.CRS`. Collation keeps it as a per-sample list, and
+#: device transfer and augmentation pass it through unchanged.
+Sample: TypeAlias = dict[str, Any]  # noqa: UP040
 
 
 @deprecated('Use torchgeo.datasets.utils.GeoSlice or shapely.Polygon instead')

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -77,10 +77,10 @@ Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
 #: * transform: affine transform of the sample
 #: * crs: :term:`coordinate reference system (CRS)` the sample is in
 #:
-#: Values are usually of type torch.Tensor. The ``crs`` key is an exception: it holds
-#: a non-tensor :class:`pyproj.CRS`. Collation keeps it as a per-sample list, and
-#: device transfer and augmentation pass it through unchanged.
-Sample: TypeAlias = dict[str, Any]  # noqa: UP040
+#: Values are of type torch.Tensor. The ``crs`` key holds an integer index into the
+#: dataset's :attr:`~torchgeo.datasets.geo.GeoDataset.crs_registry`, so the per-sample
+#: :term:`coordinate reference system (CRS)` travels as a tensor.
+Sample: TypeAlias = dict[str, Tensor]  # noqa: UP040
 
 
 @deprecated('Use torchgeo.datasets.utils.GeoSlice or shapely.Polygon instead')

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -77,9 +77,7 @@ Path: TypeAlias = str | os.PathLike[str]  # noqa: UP040
 #: * transform: affine transform of the sample
 #: * crs_index: index into the dataset's ``crs_registry`` giving the sample's CRS
 #:
-#: Values are of type torch.Tensor. The ``crs_index`` key holds an integer index into
-#: the dataset's :attr:`~torchgeo.datasets.geo.GeoDataset.crs_registry`, so the
-#: per-sample :term:`coordinate reference system (CRS)` travels as a tensor.
+#: Values are of type torch.Tensor.
 Sample: TypeAlias = dict[str, Tensor]  # noqa: UP040
 
 


### PR DESCRIPTION
### Summary
(follows torchgeo#3804, same motivation). 
GeoDatasets currently enforce a single CRS across the dataset; reprojection can be expensive, lossy, and conflicts with inference-time use where the native CRS is preferable. This PR makes samples self-describing so downstream code knows the CRS of the data it holds, setting up mixed-CRS batches and stitching of gridded predictions.

The effort to implement this is split into smaller PRs to make it easy to review. Node color shows each step's status relative to this PR: **green = implemented in this PR**, blue = already in place before it, gray = later in the stack (including deferred/blocked work). Data inputs are drawn as cylinders.

```mermaid
flowchart TD
  classDef prior fill:#d6eaf8,stroke:#2e86c1,color:#000
  classDef thisPR fill:#d5f5e3,stroke:#27ae60,color:#000
  classDef future fill:#eceff1,stroke:#b0bec5,color:#000

  FILES[("Raster files — native CRS & res<br/>(a dataset may span multiple zones)")]:::prior

  subgraph INIT["Dataset __init__"]
    IDX["index: geometry → index CRS (lookup only)<br/>+ native_crs, native_res per file"]:::future
    IDXCRS["index CRS = EPSG:6933 (global, equal-area)<br/>when prefer_native_crs"]:::future
    DEFAULT["prefer_native_crs default = False<br/>flip to native-by-default blocked by STITCH"]:::future
    REG["crs_registry: ordered CRSs a sample can emit<br/>(here just [self.crs]; frozen at init)"]:::thisPR
  end

  subgraph SMPL["Sampler (box in index CRS — no redesign)"]
    Q["query box in index CRS"]:::prior
  end

  subgraph GI["Standalone __getitem__"]
    LOOK["lookup df (.cx, index CRS)"]:::prior
    SEL["_select_out_crs — majority native CRS<br/>(warp the minority onto it)"]:::future
    REP["_reproject_slice: reproject CENTER point +<br/>box snapped to out_res grid (pixel-aligned, no resample)"]:::future
    READ["read in out_crs — NO warp when native"]:::future
    SMP["sample: data, bounds, transform,<br/>crs_index = crs_registry.index(out_crs)"]:::thisPR
  end

  subgraph CMB["Intersection / Union — multi-CRS combine"]
    VOTE["_resolve_out_crs: anchor = left-most child<br/>finest-GSD voting = override seam (future)"]:::future
    KEY["grid-tagged key (out_crs, out_res) on the GeoSlice;<br/>_split_grid peels it in each public __getitem__"]:::future
    CA["anchor child → native (no warp)"]:::future
    CB["other children (Raster / Vector / nested combo)<br/>→ warp / rasterize into anchor grid"]:::future
    SMPC["combined sample: combiner drops children's<br/>crs_index, stamps its own registry index"]:::thisPR
  end

  subgraph BATCH["DataLoader → Trainer"]
    COL["stack_samples / default_collate:<br/>crs_index is a tensor, stacks natively (no special-case)"]:::prior
    AUG["Kornia / device transfer: crs_index passes through untouched"]:::prior
  end

  subgraph INF["Inference"]
    PRED["per-chip predictions (crs_index in batch)"]:::prior
    STITCH["stitch gridded predictions via crs_registry[crs_index]<br/>→ reproject / mosaic to target CRS"]:::future
  end

  FILES --> IDX --> Q
  Q --> LOOK --> SEL
  SEL -->|"native != index"| REP --> READ
  SEL -->|"already aligned"| READ
  READ --> SMP
  REG --> SMP
  Q --> VOTE --> KEY
  KEY --> CA --> SMPC
  KEY --> CB --> SMPC
  SMP --> COL
  SMPC --> COL
  COL --> AUG --> PRED --> STITCH
```

### Additions

- Add a `crs_index` key to every GeoDataset sample: a 0-d integer tensor indexing a new dataset-side `crs_registry`, so `dataset.crs_registry[int(sample['crs_index'])]` is the sample's CRS.
- New `crs_registry` property on `GeoDataset`, frozen at `__init__`. Here it is `[self.crs]`; later PRs populate it with the distinct native CRSs.
- `IntersectionDataset`/`UnionDataset` stamp one coherent CRS on the combined sample: drop the children's `crs_index` (each points into its own registry) and re-stamp `self.crs`. This is the hook a later PR will use to resolve the combined CRS *from* the children, instead of defaulting to `self.crs`.

### Motivations

- Make samples self-describing so downstream code knows the CRS of the data it holds — the carrier for mixed-CRS batches and prediction stitching.
- Carry the CRS as an **integer index rather than a `pyproj.CRS` object**, so samples stay `dict[str, Tensor]`: PyTorch `default_collate`, `stack_samples`, and Lightning `transfer_batch_to_device` all work unchanged, no per-sample-list special-casing. The lossless `pyproj.CRS` lives once in `crs_registry`, avoiding WKT/EPSG-encoding loss (`to_epsg()` is `None` for `OGC:CRS84` and a wrong close-match for ESRI Albers).
- The registry is a deterministic, per-process function of the sorted files, so `crs_index` resolves to the same CRS in every independently built process (DataLoader workers, DDP ranks) with zero IPC. This holds trivially here (`[self.crs]`);. It gets a real test once the registry becomes multi-CRS.

### Behaviour / known limitations

- Behaviour is unchanged after this PR: `crs_registry` is `[self.crs]`, so every `crs_index` is `0` and resolves to the index CRS. Because it's sourced from `crs_registry.index(out_crs)`, it will automatically reflect any future per-query CRS selection without further wiring.
- Resolution requires the dataset (`crs_registry[crs_index]`), not the raw value. Named `crs_index` (not `crs`) so anyone calling `sample['crs']` fails loudly rather than returning a misleading int.


@adamjstewart @evgeniialappo @calebrob6 

### Checklist

- [X] I have read the [Contributing docs](https://docs.torchgeo.org/en/stable/user/contributing.html)
- [X] I have read the [AI policy](https://github.com/torchgeo/governance/blob/main/AI-POLICY.md)

<!-- Check one of the following boxes to help us better review your PR -->

- [ ] 🟢 **No AI usage**: written by humans, for humans
- [X] 🟡 **AI-assisted**: AI helped with the coding, but I understand every line
- [ ] 🔴 **AI-generated**: AI did everything, review with caution
