### PR TITLE
Fix quantile_normalization on integer and large images

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -588,8 +588,25 @@ def test_percentile_normalization(img: NDArray[np.float64]) -> None:
     assert 0 <= img.min() <= img.max() <= 1
 
 
-@pytest.mark.parametrize('img', [torch.rand(2, 2), torch.zeros(2, 2)])
+@pytest.mark.parametrize(
+    'img',
+    [
+        torch.rand(2, 2),
+        torch.zeros(2, 2),
+        # regression test: integer images used to fail with
+        # "quantile() input tensor must be either float or double dtype"
+        torch.randint(0, 255, (3, 64, 64), dtype=torch.int64),
+    ],
+)
 def test_quantile_normalization(img: Tensor) -> None:
+    img = quantile_normalization(img)
+    assert 0 <= img.min() <= img.max() <= 1
+
+
+def test_quantile_normalization_large_image() -> None:
+    # regression test: images with more than 2**24 elements used to fail
+    # with "quantile() input tensor is too large"
+    img = torch.rand(3, 5000, 5000)
     img = quantile_normalization(img)
     assert 0 <= img.min() <= img.max() <= 1
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -12,6 +12,7 @@ import fnmatch
 import glob
 import hashlib
 import importlib
+import math
 import os
 import pathlib
 import shutil
@@ -889,10 +890,49 @@ def quantile_normalization(
     if (img == nodata).all():
         return img
 
-    lower = torch.quantile(img[img != nodata], lower, dim, interpolation='higher')
-    upper = torch.quantile(img[img != nodata], upper, dim, interpolation='lower')
+    values = img[img != nodata]
+
+    # torch.quantile only supports float/double tensors.
+    if not torch.is_floating_point(values):
+        values = values.float()
+
+    # torch.quantile has a hard limit of 2**24 elements, see
+    # https://github.com/pytorch/pytorch/issues/64947. Fall back to sorting
+    # and indexing manually for inputs larger than that.
+    if values.numel() > 2**24:
+        lower = _quantile_unbounded(values, lower, interpolation='higher')
+        upper = _quantile_unbounded(values, upper, interpolation='lower')
+    else:
+        lower = torch.quantile(values, lower, dim, interpolation='higher')
+        upper = torch.quantile(values, upper, dim, interpolation='lower')
+
     img = (img - lower) / (upper - lower + 1e-5)
     return torch.clamp(img, 0, 1)
+
+
+def _quantile_unbounded(
+    values: Tensor, q: float | Tensor, interpolation: str
+) -> Tensor:
+    """Quantile of a 1D tensor with no limit on the number of elements.
+
+    :func:`torch.quantile` refuses tensors with more than 2**24 elements.
+    This computes the same result (for a single scalar ``q`` and the
+    ``'higher'``/``'lower'`` interpolation modes) by sorting instead.
+
+    Args:
+        values: 1D tensor to compute the quantile of.
+        q: Quantile in range [0, 1].
+        interpolation: Either ``'higher'`` or ``'lower'``.
+
+    Returns:
+        The requested quantile as a 0-dim tensor.
+    """
+    n = values.numel()
+    sorted_values = torch.sort(values).values
+    rank = float(q) * (n - 1)
+    idx = math.ceil(rank) if interpolation == 'higher' else math.floor(rank)
+    idx = min(max(idx, 0), n - 1)
+    return sorted_values[idx]
 
 
 def array_to_tensor(array: np.typing.NDArray[Any]) -> Tensor:


### PR DESCRIPTION
torch.quantile requires a float or double tensor, so any dataset whose plot() passes an integer image raises RuntimeError: quantile() input tensor must be either float or double dtype. It also has a hard limit of 2**24 elements, so any image larger than about 4096x4096 per band raises RuntimeError: quantile() input tensor is too large. Both are regressions against percentile_normalization, which this function replaced and which used np.percentile without either limitation.

Reproduced both cases from the issue directly against quantile_normalization, confirmed they raise on the current code, and confirmed they are fixed here.

Fix:
Cast the masked values to float before calling torch.quantile, since only the quantile computation itself needs a float dtype (the final arithmetic already promotes correctly).
For inputs over the 2**24 element limit, fall back to a small helper that sorts the values and indexes directly, matching the higher and lower interpolation modes torch.quantile uses here.

Checked that the existing small float image code path is bit for bit identical to the previous output, and that the manual quantile implementation matches torch.quantile within a tight tolerance on a tensor just under the size limit, so this should not change behavior for any currently passing dataset or test.

Added two regression tests to test_quantile_normalization, one for an integer image and one for a 5000x5000 image. Ran the full tests/datasets/test_utils.py suite (128 passed) plus ruff check and ruff format on the changed files.

Fixes #4050